### PR TITLE
PRChecker: Update `commitsAfterReview` to warn only last 3 commits

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -209,7 +209,7 @@ class PRChecker {
             cli.warn(`Commits pushed after the last ${lastCI.typeName} ` +
             'CI run:');
           }
-          cli.warn(`- ${commit.message.split('\n')[0]}`);
+          cli.warn(`- ${commit.messageHeadline}`);
         }
       });
     }
@@ -276,30 +276,41 @@ class PRChecker {
     } = this;
 
     if (reviews.length < 1) {
-      return true;
+      return false;
     }
 
-    const commitIndex = commits.length - 1;
     const reviewIndex = reviews.length - 1;
-    const lastCommit = commits[commitIndex].commit;
-    const lastReview = reviews[reviewIndex];
+    const reviewDate = reviews[reviewIndex].publishedAt;
 
-    const commitDate = lastCommit.committedDate;
-    const reviewDate = lastReview.publishedAt;
+    let afterCommits = [];
+    commits.forEach((commit) => {
+      commit = commit.commit;
+      if (commit.committedDate > reviewDate) {
+        afterCommits.push(commit);
+      }
+    });
 
-    let status = true;
-    if (commitDate > reviewDate) {
-      cli.warn('Changes pushed since the last review:');
-      commits.forEach((commit) => {
-        commit = commit.commit;
-        if (commit.committedDate > reviewDate) {
-          status = false;
-          cli.warn(`- ${commit.message.split('\n')[0]}`);
-        }
-      });
+    let totalCommits = afterCommits.length;
+    if (totalCommits > 0) {
+      let warnMsg =
+        `${totalCommits} commits were pushed since the last review:`;
+
+      warnMsg = warnMsg.replace('1 commits were', 'Single commit was');
+      if (totalCommits > 3) {
+        let msg = `, the last three commits are:`;
+        warnMsg = warnMsg.replace(/:$/, msg);
+      }
+
+      cli.warn(warnMsg);
+      afterCommits.slice(-3)
+        .forEach(commit => {
+          cli.warn(`- ${commit.messageHeadline}`);
+        });
+
+      return false;
     }
 
-    return status;
+    return true;
   }
 
   checkMergeableState() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1347,7 +1347,7 @@
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "http://registry.npm.taobao.org/figures/download/figures-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
         "escape-string-regexp": "1.0.5"

--- a/queries/PRCommits.gql
+++ b/queries/PRCommits.gql
@@ -20,6 +20,7 @@ query Commits($prid: Int!, $owner: String!, $repo: String!, $after: String) {
             }
             oid
             message
+            messageHeadline
             authoredByCommitter
           }
         }

--- a/test/fixtures/code_and_learn_pr.json
+++ b/test/fixtures/code_and_learn_pr.json
@@ -1,0 +1,22 @@
+{
+  "createdAt": "2017-10-24T11:13:43Z",
+  "authorAssociation": "FIRST_TIMER",
+  "author": {
+    "login": "pr_author",
+    "email": "pr_author@example.com"
+  },
+  "url": "https://github.com/nodejs/node/pull/16438",
+  "bodyHTML": "<p>Awesome changes</p>",
+  "bodyText": "Awesome changes",
+  "labels": {
+    "nodes": [
+      {
+        "name": "test",
+        "name": "code-and-learn"
+      }
+    ]
+  },
+  "title": "test: awesome changes",
+  "baseRefName": "master",
+  "headRefName": "awesome-changes"
+}

--- a/test/fixtures/commits_after_ci.json
+++ b/test/fixtures/commits_after_ci.json
@@ -1,44 +1,43 @@
-  {
-    "commits": [{
-      "commit": {
-        "committedDate": "2017-10-25T11:27:02Z",
-        "oid": "6c0945cbeea2cbbc97d13a3d9e3fe68bd145b985",
-        "message": "fixup: adjust spelling",
-        "author": {
-          "login": "bar"
-        }
+{
+  "commits": [{
+    "commit": {
+      "committedDate": "2017-10-25T11:27:02Z",
+      "oid": "6c0945cbeea2cbbc97d13a3d9e3fe68bd145b985",
+      "messageHeadline": "fixup: adjust spelling",
+      "author": {
+        "login": "bar"
       }
-    },{
-      "commit": {
-        "committedDate": "2017-10-26T12:10:20Z",
-        "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
-        "message": "doc: add api description README",
-        "author": {
-          "login": "foo"
-        }
+    }
+  },{
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
       }
-    },{
-      "commit": {
-        "committedDate": "2017-10-28T06:40:50Z",
-        "oid": "7dsjdw8olmxvfdh820jxnska0o28wjnjdsw9jdazxz",
-        "message": "feat: add something",
-        "author": {
-          "login": "bar"
-        }
+    }
+  },{
+    "commit": {
+      "committedDate": "2017-10-28T06:40:50Z",
+      "oid": "7dsjdw8olmxvfdh820jxnska0o28wjnjdsw9jdazxz",
+      "messageHeadline": "feat: add something",
+      "author": {
+        "login": "bar"
       }
-    },{
-      "commit": {
-        "committedDate": "2017-10-23T08:02:30Z",
-        "oid": "3edy729kzmdh74shd937dfnalxmdj38kjdnmaj87l9",
-        "message": "style: format code",
-        "author": {
-          "login": "Quo"
-        }
+    }
+  },{
+    "commit": {
+      "committedDate": "2017-10-23T08:02:30Z",
+      "oid": "3edy729kzmdh74shd937dfnalxmdj38kjdnmaj87l9",
+      "messageHeadline": "style: format code",
+      "author": {
+        "login": "Quo"
       }
-    }],
-    "comment": [{
-      "bodyText": "CI: https://ci.nodejs.org/job/node-test-pull-request/10984/",
-      "publishedAt": "2017-10-24T11:19:25Z"
-    }]
-  }
-  
+    }
+  }],
+  "comment": [{
+    "bodyText": "CI: https://ci.nodejs.org/job/node-test-pull-request/10984/",
+    "publishedAt": "2017-10-24T11:19:25Z"
+  }]
+}

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -39,6 +39,11 @@ const multipleCommitsAfterReview = {
   commits: readJSON('multiple_commits_after_review_commits.json'),
   reviews: readJSON('multiple_commits_after_review_reviews.json')
 };
+const moreThanThreeCommitsAfterReview = {
+  commits: readJSON('more_than_three_commits_after_review_commits.json'),
+  reviews: readJSON('more_than_three_commits_after_review_reviews.json')
+};
+
 const commitsAfterCi = readJSON('commits_after_ci.json');
 
 collabArr.forEach((c) => {
@@ -72,6 +77,7 @@ module.exports = {
   simpleCommits,
   singleCommitAfterReview,
   multipleCommitsAfterReview,
+  moreThanThreeCommitsAfterReview,
   commitsAfterCi,
   collaborators,
   firstTimerPR,

--- a/test/fixtures/more_than_three_commits_after_review_commits.json
+++ b/test/fixtures/more_than_three_commits_after_review_commits.json
@@ -1,0 +1,51 @@
+[{
+  "commit": {
+    "committedDate": "2017-06-25T11:27:02Z",
+    "oid": "f230e691459f8b0f448e1eec1b83fbf7f708eba3",
+    "messageHeadline": "src: add requested feature",
+    "message": "src: add requested feature\nkjlks jskld ksa",
+    "author": {
+      "login": "foo"
+    }
+  }
+},{
+  "commit": {
+    "committedDate": "2017-08-25T12:42:02Z",
+    "oid": "9416475a6dc1b27c3e343dcbc07674a439c88db1",
+    "messageHeadline": "nit: edit mistakes",
+    "message": "nit: fix errors\n fixed requested errors",
+    "author": {
+      "login": "bar"
+    }
+  }
+},{
+  "commit": {
+    "committedDate": "2017-09-25T11:27:02Z",
+    "oid": "f230e691459f8b0f448e1eec1b83fbf7f708eba3",
+    "messageHeadline": "src: add requested feature",
+    "message": "src: new functionality\n works really great",
+    "author": {
+      "login": "baz"
+    }
+  }
+},{
+  "commit": {
+    "committedDate": "2017-10-25T12:42:02Z",
+    "oid": "9416475a6dc1b27c3e343dcbc07674a439c88db1",
+    "messageHeadline": "nit: edit mistakes",
+    "message": "nit: fix mistakes\n fixed requested errors",
+    "author": {
+      "login": "bar"
+    }
+  }
+},{
+  "commit": {
+    "committedDate": "2017-10-25T12:42:02Z",
+    "oid": "9416475a6dc1b27c3e343dcbc07674a439c88db1",
+    "messageHeadline": "final: we should be good to go",
+    "message": "final: we should be good to go\n fixed requested errors",
+    "author": {
+      "login": "bar"
+    }
+  }
+}]

--- a/test/fixtures/more_than_three_commits_after_review_reviews.json
+++ b/test/fixtures/more_than_three_commits_after_review_reviews.json
@@ -1,0 +1,9 @@
+[{
+  "bodyText": "Good idea",
+  "state": "APPROVED",
+  "author": {
+    "login": "foo"
+  },
+  "url": "https://github.com/nodejs/node/pull/16438#pullrequestreview-89923489",
+  "publishedAt": "2017-07-23T11:19:25Z"
+}]

--- a/test/fixtures/multiple_commits_after_review_commits.json
+++ b/test/fixtures/multiple_commits_after_review_commits.json
@@ -2,7 +2,8 @@
   "commit": {
     "committedDate": "2017-10-25T11:27:02Z",
     "oid": "f230e691459f8b0f448e1eec1b83fbf7f708eba3",
-    "bodyText": "src: add requested feature",
+    "messageHeadline": "src: add requested feature",
+    "bodyText": "kjlks jskld ksa",
     "message": "src: add requested feature\nkjlks jskld ksa",
     "author": {
       "login": "bar"
@@ -12,7 +13,8 @@
   "commit": {
     "committedDate": "2017-10-25T12:42:02Z",
     "oid": "9416475a6dc1b27c3e343dcbc07674a439c88db1",
-    "bodyText": "nit: edit mistakes",
+    "messageHeadline": "nit: edit mistakes",
+    "bodyText": "fixed requested errors",
     "message": "nit: fix errors\n fixed requested errors",
     "author": {
       "login": "bar"

--- a/test/fixtures/reviews_approved.json
+++ b/test/fixtures/reviews_approved.json
@@ -1,4 +1,3 @@
-
 [{
   "bodyText": "Good idea",
   "state": "APPROVED",
@@ -60,5 +59,5 @@
     "login": "bot"
   },
   "url": "https://github.com/nodejs/node/pull/16438#pullrequestreview-71839232",
-  "publishedAt": "2017-10-24T19:21:52Z"
+  "publishedAt": "2017-10-28T19:21:52Z"
 }]

--- a/test/fixtures/single_commit_after_review_commits.json
+++ b/test/fixtures/single_commit_after_review_commits.json
@@ -2,8 +2,9 @@
   "commit": {
     "committedDate": "2017-10-25T11:27:02Z",
     "oid": "6c0945cbeea2cbbc97d13a3d9e3fe68bd145b985",
-    "bodyText": "src: fix issue with es-modules",
-    "message": "single commit was pushed after review",
+    "messageHeadline": "src: fix issue with es-modules",
+    "bodyText": "single commit",
+    "message": "single commit was pushed after review\nsingle commit",
     "author": {
       "login": "bar"
     }

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -416,7 +416,7 @@ describe('PRChecker', () => {
 
       let status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
-      assert.deepStrictEqual(cli.logs, expectedLogs);
+      cli.assertCalledWith(expectedLogs);
     });
 
     it('should only warn last three commits if more than 3 commits', () => {
@@ -463,7 +463,7 @@ describe('PRChecker', () => {
 
       let status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
-      assert.deepStrictEqual(cli.logs, expectedLogs);
+      cli.assertCalledWith(expectedLogs);
     });
 
     it('should return true if PR can be landed', () => {

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -16,6 +16,7 @@ const {
   commentsWithLGTM,
   singleCommitAfterReview,
   multipleCommitsAfterReview,
+  moreThanThreeCommitsAfterReview,
   oddCommits,
   simpleCommits,
   commitsAfterCi,
@@ -370,9 +371,11 @@ describe('PRChecker', () => {
 
       const expectedLogs = {
         warn: [
-          [ 'Changes pushed since the last review:' ],
-          [ '- single commit was pushed after review' ]
-        ]
+          [ 'Single commit was pushed since the last review:' ],
+          [ '- src: fix issue with es-modules' ]
+        ],
+        info: [],
+        error: []
       };
 
       const checker = new PRChecker(cli, {
@@ -394,10 +397,40 @@ describe('PRChecker', () => {
 
       const expectedLogs = {
         warn: [
-          [ 'Changes pushed since the last review:' ],
+          [ '2 commits were pushed since the last review:' ],
           [ '- src: add requested feature' ],
-          [ '- nit: fix errors' ]
-        ]
+          [ '- nit: edit mistakes' ]
+        ],
+        info: [],
+        error: []
+      };
+
+      const checker = new PRChecker(cli, {
+        pr: firstTimerPR,
+        reviewers: allGreenReviewers,
+        comments: commentsWithLGTM,
+        collaborators,
+        reviews,
+        commits
+      });
+
+      let status = checker.checkCommitsAfterReview();
+      assert.deepStrictEqual(status, false);
+      assert.deepStrictEqual(cli.logs, expectedLogs);
+    });
+
+    it('should only warn last three commits if more than 3 commits', () => {
+      const { commits, reviews } = moreThanThreeCommitsAfterReview;
+      const expectedLogs = {
+        warn: [
+          [ '4 commits were pushed since the last review, ' +
+            'the last three commits are:' ],
+          [ '- src: add requested feature' ],
+          [ '- nit: edit mistakes' ],
+          [ '- final: we should be good to go' ]
+        ],
+        info: [],
+        error: []
       };
 
       const checker = new PRChecker(cli, {
@@ -429,8 +462,22 @@ describe('PRChecker', () => {
       });
 
       let status = checker.checkCommitsAfterReview();
+      assert.deepStrictEqual(status, false);
+      assert.deepStrictEqual(cli.logs, expectedLogs);
+    });
+
+    it('should return true if PR can be landed', () => {
+      const checker = new PRChecker(cli, {
+        pr: semverMajorPR,
+        reviewers: allGreenReviewers,
+        comments: commentsWithLGTM,
+        reviews: approvingReviews,
+        commits: simpleCommits,
+        collaborators
+      });
+
+      const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, true);
-      cli.assertCalledWith(expectedLogs);
     });
   });
 


### PR DESCRIPTION
To keep noise level to minimum, only warn about last 3 commits since the last review.

Same exact work for `checkCI` is coming in next pr.
idea: we can also have flag for how much commits to log.