### PR TITLE
PRChecker: support new label fast-track

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -53,8 +53,8 @@ class PRChecker {
     const status = [
       this.checkReviews(comments),
       this.checkCommitsAfterReview(),
-      this.checkPRWait(new Date()),
       this.checkCI(),
+      this.checkPRWait(new Date()),
       this.checkMergeableState()
     ];
 
@@ -150,16 +150,29 @@ class PRChecker {
    * @param {Date} now
    */
   checkPRWait(now) {
-    const { pr } = this;
-    const { cli } = this;
+    const {
+      pr, cli, reviewers, CIStatus
+    } = this;
     const labels = pr.labels.nodes;
 
     const fast =
-      labels.some((l) => ['code-and-learn', 'fast-track'].includes(l.name)) ||
-      (labels.length === 1 && labels[0].name === 'doc');
+      labels.some((l) => ['fast-track'].includes(l.name));
     if (fast) {
-      cli.info('This PR is being fast-tracked.');
-      return true;
+      const { approved } = reviewers;
+      if (approved.length > 1 && CIStatus) {
+        cli.info('This PR is being fast-tracked');
+        return true;
+      } else {
+        const msg = ['This PR is being fast-tracked, but awating '];
+        if (approved.length < 2) msg.push('approvals of 2 contributors');
+        if (!CIStatus) msg.push('a CI run');
+
+        let warnMsg = msg.length === 2
+          ? msg.join('') : `${msg[0] + msg[1]} and ${msg[2]}`;
+        cli.warn(warnMsg);
+      }
+
+      return false;
     }
 
     const wait = this.getWait(now);
@@ -188,6 +201,7 @@ class PRChecker {
     let status = true;
     if (!ciMap.size) {
       cli.error('No CI runs detected');
+      this.CIStatus = false;
       return false;
     } else if (!ciMap.get(FULL)) {
       status = false;
@@ -237,6 +251,7 @@ class PRChecker {
       }
     }
 
+    this.CIStatus = status;
     return status;
   }
 

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -153,9 +153,15 @@ class PRChecker {
     const { pr } = this;
     const { cli } = this;
     const labels = pr.labels.nodes;
-    const fast = labels.some((l) => isFast(l.name)) ||
+
+    const fast =
+      labels.some((l) => ['code-and-learn', 'fast-track'].includes(l.name)) ||
       (labels.length === 1 && labels[0].name === 'doc');
-    if (fast) { return true; }
+    if (fast) {
+      cli.info('This PR is being fast-tracked.');
+      return true;
+    }
+
     const wait = this.getWait(now);
     if (wait.timeLeft > 0) {
       const dateStr = new Date(pr.createdAt).toDateString();
@@ -163,10 +169,6 @@ class PRChecker {
       cli.info(`This PR was created on ${dateStr} (${type} in UTC)`);
       cli.warn(`${wait.timeLeft} hours left to land`);
       return false;
-    }
-
-    function isFast(label) {
-      return (label === 'code-and-learn' || label === 'fast-track');
     }
 
     return true;

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -153,7 +153,7 @@ class PRChecker {
     const { pr } = this;
     const { cli } = this;
     const labels = pr.labels.nodes;
-    const fast = labels.some((l) => l.name === 'code-and-learn') ||
+    const fast = labels.some((l) => isFast(l.name)) ||
       (labels.length === 1 && labels[0].name === 'doc');
     if (fast) { return true; }
     const wait = this.getWait(now);
@@ -163,6 +163,10 @@ class PRChecker {
       cli.info(`This PR was created on ${dateStr} (${type} in UTC)`);
       cli.warn(`${wait.timeLeft} hours left to land`);
       return false;
+    }
+
+    function isFast(label) {
+      return (label === 'code-and-learn' || label === 'fast-track');
     }
 
     return true;

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -204,7 +204,9 @@ describe('PRChecker', () => {
     it('should skip wait check for Code & Learn PR', () => {
       const cli = new TestCLI();
 
-      const expectedLogs = {};
+      const expectedLogs = {
+        info: [['This PR is being fast-tracked.']]
+      };
 
       const now = new Date();
       const youngPR = Object.assign({}, firstTimerPR, {
@@ -236,9 +238,10 @@ describe('PRChecker', () => {
     it('should skip wait check for fast-track labelled PR', () => {
       const cli = new TestCLI();
 
-      const expectedLogs = {};
+      const expectedLogs = {
+        info: [['This PR is being fast-tracked.']]
+      };
 
-      const now = new Date();
       const youngPR = Object.assign({}, firstTimerPR, {
         createdAt: '2017-10-27T14:25:41.682Z',
         labels: {
@@ -257,7 +260,7 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      const status = checker.checkPRWait(now);
+      const status = checker.checkPRWait(new Date());
       assert(status);
       cli.assertCalledWith(expectedLogs);
     });

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -232,6 +232,35 @@ describe('PRChecker', () => {
       assert(status);
       cli.assertCalledWith(expectedLogs);
     });
+
+    it('should skip wait check for fast-track labelled PR', () => {
+      const cli = new TestCLI();
+
+      const expectedLogs = {};
+
+      const now = new Date();
+      const youngPR = Object.assign({}, firstTimerPR, {
+        createdAt: '2017-10-27T14:25:41.682Z',
+        labels: {
+          nodes: [
+            { name: 'fast-track' }
+          ]
+        }
+      });
+
+      const checker = new PRChecker(cli, {
+        pr: youngPR,
+        reviewers: allGreenReviewers,
+        comments: commentsWithLGTM,
+        reviews: approvingReviews,
+        commits: simpleCommits,
+        collaborators
+      });
+
+      const status = checker.checkPRWait(now);
+      assert(status);
+      cli.assertCalledWith(expectedLogs);
+    });
   });
 
   describe('checkCI', () => {


### PR DESCRIPTION
Now core has the label `fast-track` and a PR that uses that label so i think it is time to add support for new label that @joyeecheung  opened a issue for. 