### PR TITLE
PRChecker: add flag `--warn-commits`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Options:
   --repo, -r        GitHub repository of the PR                         [string]
   --file, -f        File to write the metadata in                       [string]
   --check-comments  Check for 'LGTM' in comments                       [boolean]
-  --warn-commits    Number of commits to warn              [number] [default: 3]
+  --max-commits     Number of commits to warn              [number] [default: 3]
   --help, -h        Show help                                          [boolean]
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Options:
   --owner, -o       GitHub owner of the PR repository                   [string]
   --repo, -r        GitHub repository of the PR                         [string]
   --file, -f        File to write the metadata in                       [string]
-  --check-comments  Check for 'LGTM' in comments                        [boolean]
+  --check-comments  Check for 'LGTM' in comments                       [boolean]
+  --warn-commits    Number of commits to warn              [number] [default: 3]
   --help, -h        Show help                                          [boolean]
 ```
 

--- a/components/metadata.js
+++ b/components/metadata.js
@@ -35,8 +35,7 @@ module.exports = async function getMetadata(argv, cli) {
   cli.write(metadata);
   cli.separator();
 
-  data.warnCommits = argv.warnCommits;
-  const checker = new PRChecker(cli, data);
+  const checker = new PRChecker(cli, data, argv);
   const status = checker.checkAll(argv.checkComments);
   return {
     status,

--- a/components/metadata.js
+++ b/components/metadata.js
@@ -35,6 +35,7 @@ module.exports = async function getMetadata(argv, cli) {
   cli.write(metadata);
   cli.separator();
 
+  data.warnCommits = argv.warnCommits;
   const checker = new PRChecker(cli, data);
   const status = checker.checkAll(argv.checkComments);
   return {

--- a/lib/args.js
+++ b/lib/args.js
@@ -42,6 +42,12 @@ function buildYargs(args = null) {
       describe: 'Check for \'LGTM\' in comments',
       type: 'boolean'
     })
+    .option('warn-commits', {
+      demandOption: false,
+      describe: 'Number of commits to warn',
+      type: 'number',
+      default: 3
+    })
     .help()
     .alias('help', 'h')
     .argv;
@@ -53,9 +59,10 @@ const PR_RE = new RegExp(
 
 function checkAndParseArgs(args) {
   const {
-    owner = 'nodejs', repo = 'node', identifier, file, checkComments
+    owner = 'nodejs', repo = 'node',
+    identifier, file, checkComments, warnCommits
   } = args;
-  const result = { owner, repo, file, checkComments };
+  const result = { owner, repo, file, checkComments, warnCommits };
   if (!isNaN(identifier)) {
     result.prid = +identifier;
   } else {

--- a/lib/args.js
+++ b/lib/args.js
@@ -42,7 +42,7 @@ function buildYargs(args = null) {
       describe: 'Check for \'LGTM\' in comments',
       type: 'boolean'
     })
-    .option('warn-commits', {
+    .option('max-commits', {
       demandOption: false,
       describe: 'Number of commits to warn',
       type: 'number',
@@ -60,9 +60,9 @@ const PR_RE = new RegExp(
 function checkAndParseArgs(args) {
   const {
     owner = 'nodejs', repo = 'node',
-    identifier, file, checkComments, warnCommits
+    identifier, file, checkComments, maxCommits
   } = args;
-  const result = { owner, repo, file, checkComments, warnCommits };
+  const result = { owner, repo, file, checkComments, maxCommits };
   if (!isNaN(identifier)) {
     result.prid = +identifier;
   } else {
@@ -76,6 +76,12 @@ function checkAndParseArgs(args) {
       prid: +match[3]
     });
   }
+
+  let sliceLength = Math.abs(maxCommits);
+  if (isNaN(sliceLength)) { sliceLength = 3; }
+  Object.assign(result, {
+    maxCommits: sliceLength
+  });
 
   return result;
 }

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -29,10 +29,10 @@ class PRChecker {
    * @param {{}} cli
    * @param {PRData} data
    */
-  constructor(cli, data) {
+  constructor(cli, data, argv) {
     this.cli = cli;
     const {
-      pr, reviewers, comments, reviews, commits, collaborators, warnCommits
+      pr, reviewers, comments, reviews, commits, collaborators
     } = data;
     this.reviewers = reviewers;
     this.pr = pr;
@@ -43,7 +43,7 @@ class PRChecker {
     // the last review.
     this.reviews = reviews;
     this.commits = commits;
-    this.warnCommits = warnCommits;
+    this.argv = argv;
     this.collaboratorEmails = new Set(
       Array.from(collaborators).map((c) => c[1].email)
     );
@@ -171,11 +171,12 @@ class PRChecker {
   // TODO: we might want to check CI status when it's less flaky...
   // TODO: not all PR requires CI...labels?
   checkCI() {
-    const { pr, cli, comments, reviews, commits } = this;
+    const { pr, cli, comments, reviews, commits, argv } = this;
     const prNode = {
       publishedAt: pr.createdAt,
       bodyText: pr.bodyText
     };
+    const { maxCommits } = argv;
     const thread = comments.concat([prNode]).concat(reviews);
     const ciMap = new CIParser(thread).parse();
     let status = true;
@@ -211,19 +212,22 @@ class PRChecker {
 
       let totalCommits = afterCommits.length;
       if (totalCommits > 0) {
-        let warnMsg = `Commits pushed after the last ${lastCI.typeName} ` +
-            'CI run:';
-
-        if (totalCommits > 3) {
-          let msg = '. The last 3 commits are...';
-          warnMsg = warnMsg.replace(/:$/, msg);
-        }
+        let warnMsg = `Commits were pushed after the last ` +
+          `${lastCI.typeName} CI run:`;
 
         cli.warn(warnMsg);
-        afterCommits.slice(-3)
+        let sliceLength = maxCommits === 0 ? totalCommits : -maxCommits;
+        afterCommits.slice(sliceLength)
           .forEach(commit => {
             cli.warn(`- ${commit.messageHeadline}`);
           });
+
+        if (totalCommits > maxCommits) {
+          let infoMsg = '...(use `' +
+            `--max-commits ${totalCommits}` +
+            '` to see the full list of commits)';
+          cli.warn(infoMsg);
+        }
       }
     }
 
@@ -285,8 +289,9 @@ class PRChecker {
 
   checkCommitsAfterReview() {
     const {
-      commits, reviews, cli, warnCommits
+      commits, reviews, cli, argv
     } = this;
+    const { maxCommits } = argv;
 
     if (reviews.length < 1) {
       return false;
@@ -305,20 +310,19 @@ class PRChecker {
 
     let totalCommits = afterCommits.length;
     if (totalCommits > 0) {
-      let warnMsg =
-        `${totalCommits} commits were pushed since the last review:`;
-
-      warnMsg = warnMsg.replace('1 commits were', 'Single commit was');
-      if (totalCommits > 3) {
-        let msg = `, the last three commits are:`;
-        warnMsg = warnMsg.replace(/:$/, msg);
-      }
-
-      cli.warn(warnMsg);
-      afterCommits.slice(-warnCommits || -3)
+      cli.warn(`Commits were pushed since the last review:`);
+      let sliceLength = maxCommits === 0 ? totalCommits : -maxCommits;
+      afterCommits.slice(sliceLength)
         .forEach(commit => {
           cli.warn(`- ${commit.messageHeadline}`);
         });
+
+      if (totalCommits > maxCommits) {
+        let infoMsg = '...(use `' +
+          `--max-commits ${totalCommits}` +
+          '` to see the full list of commits)';
+        cli.warn(infoMsg);
+      }
 
       return false;
     }

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -32,7 +32,7 @@ class PRChecker {
   constructor(cli, data) {
     this.cli = cli;
     const {
-      pr, reviewers, comments, reviews, commits, collaborators
+      pr, reviewers, comments, reviews, commits, collaborators, warnCommits
     } = data;
     this.reviewers = reviewers;
     this.pr = pr;
@@ -43,6 +43,7 @@ class PRChecker {
     // the last review.
     this.reviews = reviews;
     this.commits = commits;
+    this.warnCommits = warnCommits;
     this.collaboratorEmails = new Set(
       Array.from(collaborators).map((c) => c[1].email)
     );
@@ -284,7 +285,7 @@ class PRChecker {
 
   checkCommitsAfterReview() {
     const {
-      commits, reviews, cli
+      commits, reviews, cli, warnCommits
     } = this;
 
     if (reviews.length < 1) {
@@ -314,7 +315,7 @@ class PRChecker {
       }
 
       cli.warn(warnMsg);
-      afterCommits.slice(-3)
+      afterCommits.slice(-warnCommits || -3)
         .forEach(commit => {
           cli.warn(`- ${commit.messageHeadline}`);
         });

--- a/test/unit/args.test.js
+++ b/test/unit/args.test.js
@@ -9,7 +9,7 @@ const expected = {
   repo: `node`,
   prid: 16637,
   file: undefined,
-  warnCommits: 3
+  maxCommits: 3
 };
 
 describe('args', async function() {
@@ -75,5 +75,40 @@ describe('args', async function() {
         const actual = parseArgs('https://github.com/nodejs/node/pull/16637 -o nodejs.org');
         assert.deepStrictEqual(actual, expected);
       });
+  });
+
+  describe('Max Commits Flag', () => {
+    it('should convert -1 to postive', async function() {
+      const actual = parseArgs('16637 --max-commits -1');
+      const expected = {
+        checkComments: false,
+        owner: `nodejs`,
+        repo: `node`,
+        prid: 16637,
+        file: undefined,
+        maxCommits: 1
+      };
+
+      assert.deepStrictEqual(actual, expected);
+    });
+
+    it('should be zero if passed 0', async function() {
+      const actual = parseArgs('16637 --max-commits 0');
+      const expected = {
+        checkComments: false,
+        owner: `nodejs`,
+        repo: `node`,
+        prid: 16637,
+        file: undefined,
+        maxCommits: 0
+      };
+
+      assert.deepStrictEqual(actual, expected);
+    });
+
+    it('should default to three if passed string', async function() {
+      const actual = parseArgs('16637 --max-commits not-a-number');
+      assert.deepStrictEqual(actual, expected);
+    });
   });
 });

--- a/test/unit/args.test.js
+++ b/test/unit/args.test.js
@@ -8,7 +8,8 @@ const expected = {
   owner: `nodejs`,
   repo: `node`,
   prid: 16637,
-  file: undefined
+  file: undefined,
+  warnCommits: 3
 };
 
 describe('args', async function() {


### PR DESCRIPTION
Added flag `warn-commits` that defaults to 3.  Documented the flag in readme. 