### PR TITLE
Show actual value in error message

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -75,7 +75,7 @@ function checkAndParseArgs(args) {
   } else {
     const match = identifier.match(PR_RE);
     if (match === null) {
-      throw new Error(`Could not understand PR id format: ${args}`);
+      throw new Error(`Could not understand PR id format: ${identifier}`);
     }
     Object.assign(result, {
       owner: `${match[1]}`,

--- a/test/unit/args.test.js
+++ b/test/unit/args.test.js
@@ -68,7 +68,7 @@ describe('args', async function() {
         const result = () => {
           return parseArgs('dummy');
         };
-        assert.throws(result);
+        assert.throws(result, /dummy/);
       });
 
     it('should ignore other arguments if called with url',


### PR DESCRIPTION
The old code just displayed `[object Object]` instead of the actual argument.