### PR TITLE
lib: support XDG config spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CLI tools for Node.js Core collaborators.
 npm install -g node-core-utils
 ```
 
-After running any of the tools for the first-time, you will be asked to provide a
+After running any of the tools for the first time, you will be asked to provide a
 GitHub username and password in order to create a personal access token.
 
 If you prefer not to provide your login credentials, [follow these instructions](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
@@ -23,9 +23,9 @@ Note: We need to read the email of the PR author in order to check if it matches
 the email of the commit author. This requires checking the box `user:email` when
 you create the personal access token (you can edit the permission later as well).
 
-Then create a file named `.ncurc` under your `$HOME` directory (`~/.ncurc`);
+Then create an rc file (`~/.ncurc` or `$XDG_CONFIG_HOME/ncurc`):
 
-```
+```json
 {
   "username": "your_github_username",
   "token": "token_that_you_created"
@@ -34,7 +34,7 @@ Then create a file named `.ncurc` under your `$HOME` directory (`~/.ncurc`);
 
 If you would prefer to build from the source, install and link:
 
-```
+```bash
 git clone git@github.com:nodejs/node-core-utils.git
 cd node-core-utils
 npm install

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,6 +9,7 @@ const util = require('util');
 const ghauth = util.promisify(require('ghauth'));
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
+let authFile; // ncurc file in $XDG_CONFIG_HOME or ~.
 module.exports = lazy(auth);
 
 function check(username, token) {
@@ -18,16 +19,18 @@ function check(username, token) {
 
 async function auth(getCredentials = ghauth) {
   let username, token;
-  // Try reading from ~/.ncurc
+  // Try reading from $XDG_CONFIG_HOME/ncurc, fall back to ~/.ncurc.
   try {
-    ({ username, token } = JSON.parse(await readFile(path.join(process.env.XDG_CONFIG_HOME, 'ncurc'), 'utf8')));
+    authFile = path.join(process.env.XDG_CONFIG_HOME, 'ncurc');
+    ({ username, token } = JSON.parse(await readFile(authFile, 'utf8')));
   } catch (e) {
     try {
-      ({ username, token } = JSON.parse(await readFile(path.join(homedir(), '.ncurc'), 'utf8')));
+      authFile = path.join(homedir(), '.ncurc');
+      ({ username, token } = JSON.parse(await readFile(authFile, 'utf8')));
     } catch (e) {
       process.stdout.write('If this is your first time running this command, ' +
-                           'follow the instructions to create an access token. ' +
-                           'If you prefer to create it yourself on Github, ' +
+                           'follow the instructions to create an access token' +
+                           '. If you prefer to create it yourself on Github, ' +
                            'see https://github.com/nodejs/node-core-utils/blob/master/README.md.' +
                            EOL);
     }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,7 +9,6 @@ const util = require('util');
 const ghauth = util.promisify(require('ghauth'));
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
-const authFile = path.join(homedir(), '.ncurc');
 module.exports = lazy(auth);
 
 function check(username, token) {
@@ -21,13 +20,17 @@ async function auth(getCredentials = ghauth) {
   let username, token;
   // Try reading from ~/.ncurc
   try {
-    ({ username, token } = JSON.parse(await readFile(authFile, 'utf8')));
+    ({ username, token } = JSON.parse(await readFile(path.join(process.env.XDG_CONFIG_HOME, 'ncurc'), 'utf8')));
   } catch (e) {
-    process.stdout.write('If this is your first time running this command, ' +
-                         'follow the instructions to create an access token. ' +
-                         'If you prefer to create it yourself on Github, ' +
-                         'see https://github.com/nodejs/node-core-utils/blob/master/README.md.' +
-                         EOL);
+    try {
+      ({ username, token } = JSON.parse(await readFile(path.join(homedir(), '.ncurc'), 'utf8')));
+    } catch (e) {
+      process.stdout.write('If this is your first time running this command, ' +
+                           'follow the instructions to create an access token. ' +
+                           'If you prefer to create it yourself on Github, ' +
+                           'see https://github.com/nodejs/node-core-utils/blob/master/README.md.' +
+                           EOL);
+    }
   }
 
   // If that worked, yay


### PR DESCRIPTION
Check $XDG_CONFIG_HOME/ncurc first, and fall back to `~/.ncurc`. This is similar to what other tools like git do.

~If this is acceptable then I'll fix up the auth test.~ Fixed
  