### PR TITLE
pr-summary: move the PR summary into a new file

### DIFF
--- a/components/metadata.js
+++ b/components/metadata.js
@@ -3,6 +3,7 @@
 const Request = require('../lib/request');
 const auth = require('../lib/auth');
 const PRData = require('../lib/pr_data');
+const PRSummary = require('../lib/pr_summary');
 const PRChecker = require('../lib/pr_checker');
 const MetadataGenerator = require('../lib/metadata_gen');
 
@@ -15,8 +16,9 @@ module.exports = async function getMetadata(argv, cli) {
   const data = new PRData(argv, cli, request);
   await data.getAll();
 
+  const summary = new PRSummary(argv, cli, data);
   cli.separator('PR info');
-  data.logIntro();
+  summary.display();
 
   const metadata = new MetadataGenerator(data).getMetadata();
   if (!process.stdout.isTTY) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,7 +15,7 @@ const SPINNER_STATUS = {
 };
 const { SUCCESS, FAILED, WARN, INFO } = SPINNER_STATUS;
 
-function head(text, length = 8) {
+function head(text, length = 11) {
   return chalk.bold(text.padEnd(length));
 }
 

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -14,9 +14,6 @@ const {
   REVIEW_SOURCES: { FROM_COMMENT, FROM_REVIEW_COMMENT }
 } = require('./reviews');
 const {
-  FIRST_TIME_CONTRIBUTOR, FIRST_TIMER
-} = require('./user_status');
-const {
   CONFLICTING
 } = require('./mergeable_state');
 
@@ -31,6 +28,7 @@ class PRChecker {
    */
   constructor(cli, data, argv) {
     this.cli = cli;
+    this.data = data;
     const {
       pr, reviewers, comments, reviews, commits, collaborators
     } = data;
@@ -59,7 +57,7 @@ class PRChecker {
       this.checkPRState()
     ];
 
-    if (this.authorIsNew()) {
+    if (this.data.authorIsNew()) {
       status.push(this.checkAuthor());
     }
 
@@ -254,11 +252,6 @@ class PRChecker {
 
     this.CIStatus = status;
     return status;
-  }
-
-  authorIsNew() {
-    const assoc = this.pr.authorAssociation;
-    return assoc === FIRST_TIME_CONTRIBUTOR || assoc === FIRST_TIMER;
   }
 
   checkAuthor() {

--- a/lib/pr_data.js
+++ b/lib/pr_data.js
@@ -4,6 +4,10 @@ const { getCollaborators } = require('./collaborators');
 const { ReviewAnalyzer } = require('./reviews');
 const fs = require('fs');
 
+const {
+  FIRST_TIME_CONTRIBUTOR, FIRST_TIMER
+} = require('./user_status');
+
 // lib/queries/*.gql file names
 const PR_QUERY = 'PR';
 const REVIEWS_QUERY = 'Reviews';
@@ -13,9 +17,7 @@ const USER_QUERY = 'User';
 
 class PRData {
   /**
-   * @param {number} prid
-   * @param {string} owner
-   * @param {string} repo
+   * @param {Object} argv
    * @param {Object} cli
    * @param {Object} request
    */
@@ -111,28 +113,9 @@ class PRData {
     ]);
   }
 
-  logIntro() {
-    const {
-      commits,
-      cli,
-      owner,
-      prid,
-      pr: {
-        author: { login: author },
-        baseRefName,
-        headRefName,
-        labels,
-        title
-      }
-    } = this;
-
-    const branch = `${author}:${headRefName} -> ${owner}:${baseRefName}`;
-    const labelStr = labels.nodes.map(label => label.name).join(', ');
-    cli.table('Title', `${title} #${prid}`);
-    cli.table('Author', `${author}`);
-    cli.table('Commits', `${commits.length}`);
-    cli.table('Branch', `${branch}`);
-    cli.table('Labels', `${labelStr}`);
+  authorIsNew() {
+    const assoc = this.pr.authorAssociation;
+    return assoc === FIRST_TIME_CONTRIBUTOR || assoc === FIRST_TIMER;
   }
 };
 

--- a/lib/pr_summary.js
+++ b/lib/pr_summary.js
@@ -1,0 +1,58 @@
+'use strict';
+
+class PRSummary {
+  /**
+   * @param {Object} prid
+   * @param {Object} cli
+   * @param {PRData} data
+   */
+  constructor(argv, cli, data) {
+    this.argv = argv;
+    this.cli = cli;
+    this.data = data;
+  }
+
+  display() {
+    const {
+      commits,
+      pr: {
+        author,
+        baseRefName,
+        headRefName,
+        labels,
+        title
+      }
+    } = this.data;
+    const {
+      owner,
+      prid
+    } = this.argv;
+    const cli = this.cli;
+
+    const branch = `${author.login}:${headRefName} -> ${owner}:${baseRefName}`;
+    const labelStr = labels.nodes.map(label => label.name).join(', ');
+    cli.table('Title', `${title} (#${prid})`);
+    const authorHint =
+      this.data.authorIsNew() ? ', first-time contributor' : '';
+    cli.table('Author',
+      `${author.name} <${author.email}> (@${author.login}${authorHint})`);
+    cli.table('Branch', `${branch}`);
+    cli.table('Labels', `${labelStr}`);
+
+    cli.table('Commits', `${commits.length}`);
+    const committers = new Map();
+    for (const commit of commits) {
+      const data = commit.commit;
+      const committer = data.committer;
+      committers.set(committer.email, committer);
+      cli.log(` - ${data.messageHeadline}`);
+    }
+
+    cli.table('Committers', `${committers.size}`);
+    for (const { name, email } of committers.values()) {
+      cli.log(` - ${name} <${email}>`);
+    }
+  };
+}
+
+module.exports = PRSummary;

--- a/lib/queries/User.gql
+++ b/lib/queries/User.gql
@@ -1,6 +1,7 @@
 query User($login: String!){
   user(login: $login) {
     login,
-    email
+    email,
+    name
   }
 }

--- a/test/fixtures/closed_pr.json
+++ b/test/fixtures/closed_pr.json
@@ -3,7 +3,8 @@
   "authorAssociation": "COLLABORATOR",
   "author": {
     "login": "pr_author",
-    "email": "pr_author@example.com"
+    "email": "pr_author@example.com",
+    "name": "Their Github Account email"
   },
   "url": "https://github.com/nodejs/node/pull/16438",
   "bodyHTML": "<p>Awesome changes</p>",

--- a/test/fixtures/code_and_learn_pr.json
+++ b/test/fixtures/code_and_learn_pr.json
@@ -3,7 +3,8 @@
   "authorAssociation": "FIRST_TIMER",
   "author": {
     "login": "pr_author",
-    "email": "pr_author@example.com"
+    "email": "pr_author@example.com",
+    "name": "Their Github Account email"
   },
   "url": "https://github.com/nodejs/node/pull/16438",
   "bodyHTML": "<p>Awesome changes</p>",

--- a/test/fixtures/first_timer_pr.json
+++ b/test/fixtures/first_timer_pr.json
@@ -3,7 +3,8 @@
   "authorAssociation": "FIRST_TIMER",
   "author": {
     "login": "pr_author",
-    "email": "pr_author@example.com"
+    "email": "pr_author@example.com",
+    "name": "Their Github Account email"
   },
   "url": "https://github.com/nodejs/node/pull/16438",
   "bodyHTML": "<p>Awesome changes</p>",

--- a/test/fixtures/first_timer_pr_with_private_email.json
+++ b/test/fixtures/first_timer_pr_with_private_email.json
@@ -3,7 +3,8 @@
   "authorAssociation": "FIRST_TIMER",
   "author": {
     "login": "pr_author",
-    "email": ""
+    "email": "",
+    "name": "Their Github Account"
   },
   "url": "https://github.com/nodejs/node/pull/16438",
   "bodyHTML": "<p>Awesome changes</p>",

--- a/test/fixtures/merged_pr.json
+++ b/test/fixtures/merged_pr.json
@@ -3,7 +3,8 @@
   "authorAssociation": "COLLABORATOR",
   "author": {
     "login": "pr_author",
-    "email": "pr_author@example.com"
+    "email": "pr_author@example.com",
+    "name": "Their Github Account email"
   },
   "url": "https://github.com/nodejs/node/pull/16438",
   "bodyHTML": "<p>Awesome changes</p>",

--- a/test/fixtures/odd_commits.json
+++ b/test/fixtures/odd_commits.json
@@ -11,6 +11,7 @@
         "name": "Their Github Account email"
       },
       "oid": "ffdef335209c77f66d933bd873950747bfe42264",
+      "messageHeadline": "doc: some changes",
       "message": "Normal commit, same email for everything",
       "authoredByCommitter": true
     }
@@ -27,6 +28,7 @@
         "name": "Their Github Account email"
       },
       "oid": "e3ad7c72e88c83b7184563e8fdb63df02e2fbacb",
+      "messageHeadline": "doc: some changes 2",
       "message": "Either they have not configured git user.email, or have not add the email to their account",
       "authoredByCommitter": false
     }
@@ -43,6 +45,7 @@
         "name": "Their Github Account email"
       },
       "oid": "ff30f335209c77f66d933bd873950747bfe42264",
+      "messageHeadline": "test: some changes",
       "message": "They have added the config email to their Github Account, so Github will set authoredByCommitter to true",
       "authoredByCommitter": true
     }
@@ -59,6 +62,7 @@
         "name": "GitHub"
       },
       "oid": "ff88f335209c77f66d933bd873950747bfe42264",
+      "messageHeadline": "test: some changes 2",
       "message": "They probably used the Github interface to update PR, the author email should their account email because...it's done on Github",
       "authoredByCommitter": false
     }
@@ -75,6 +79,7 @@
         "name": "Baz User"
       },
       "oid": "da28173e5e6b4b0d3255bfef95601890afd80709",
+      "messageHeadline": "[squash] fix typo",
       "message": "Edited by a collaborator",
       "authoredByCommitter": false
     }
@@ -91,6 +96,7 @@
         "name": "Baz User"
       },
       "oid": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+      "messageHeadline": "fixup! fix something",
       "message": "Edited by a collaborator, but the author is not their Github Account",
       "authoredByCommitter": false
     }

--- a/test/fixtures/semver_major_pr.json
+++ b/test/fixtures/semver_major_pr.json
@@ -3,7 +3,8 @@
   "authorAssociation": "COLLABORATOR",
   "author": {
     "login": "pr_author",
-    "email": "pr_author@example.com"
+    "email": "pr_author@example.com",
+    "name": "Their Github Account email"
   },
   "url": "https://github.com/nodejs/node/pull/16438",
   "bodyHTML": "<p>Awesome changes</p>",

--- a/test/fixtures/simple_commits.json
+++ b/test/fixtures/simple_commits.json
@@ -12,6 +12,7 @@
       },
       "oid": "ffdef335209c77f66d933bd873950747bfe42264",
       "message": "Normal commit, same email for everything",
+      "messageHeadline": "doc: some changes",
       "authoredByCommitter": true
     }
   }

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -85,7 +85,7 @@ describe('cli', () => {
       it('should print the first element with bold style and padding', () => {
         cli.table('Title', 'description');
         assert.strictEqual(logResult(),
-          `${chalk.bold('Title   ')}description${EOL}`);
+          `${chalk.bold('Title      ')}description${EOL}`);
       });
     });
 

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -35,19 +35,20 @@ const argv = { maxCommits: 3 };
 describe('PRChecker', () => {
   describe('checkAll', () => {
     const cli = new TestCLI();
-    const checker = new PRChecker(cli, {
+    const data = {
       pr: firstTimerPR,
       reviewers: allGreenReviewers,
       comments: commentsWithLGTM,
       reviews: approvingReviews,
       commits: simpleCommits,
-      collaborators
-    });
+      collaborators,
+      authorIsNew: () => true
+    };
+    const checker = new PRChecker(cli, data, argv);
 
     let checkReviewsStub;
     let checkPRWaitStub;
     let checkCIStub;
-    let authorIsNewStub;
     let checkAuthorStub;
     let checkCommitsAfterReviewStub;
     let checkMergeableStateStub;
@@ -57,7 +58,6 @@ describe('PRChecker', () => {
       checkReviewsStub = sinon.stub(checker, 'checkReviews');
       checkPRWaitStub = sinon.stub(checker, 'checkPRWait');
       checkCIStub = sinon.stub(checker, 'checkCI');
-      authorIsNewStub = sinon.stub(checker, 'authorIsNew').returns(true);
       checkAuthorStub = sinon.stub(checker, 'checkAuthor');
       checkCommitsAfterReviewStub =
         sinon.stub(checker, 'checkCommitsAfterReview');
@@ -69,7 +69,6 @@ describe('PRChecker', () => {
       checkReviewsStub.restore();
       checkPRWaitStub.restore();
       checkCIStub.restore();
-      authorIsNewStub.restore();
       checkAuthorStub.restore();
       checkCommitsAfterReviewStub.restore();
       checkMergeableStateStub.restore();
@@ -82,7 +81,6 @@ describe('PRChecker', () => {
       assert.strictEqual(checkReviewsStub.calledOnce, true);
       assert.strictEqual(checkPRWaitStub.calledOnce, true);
       assert.strictEqual(checkCIStub.calledOnce, true);
-      assert.strictEqual(authorIsNewStub.calledOnce, true);
       assert.strictEqual(checkAuthorStub.calledOnce, true);
       assert.strictEqual(checkCommitsAfterReviewStub.calledOnce, true);
       assert.strictEqual(checkMergeableStateStub.calledOnce, true);
@@ -108,15 +106,16 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: semverMajorPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: approvingReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => false
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       const status = checker.checkReviews(true);
       assert(!status);
@@ -135,15 +134,16 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: requestedChangesReviewers,
         comments: [],
         reviews: requestingChangesReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       const status = checker.checkReviews();
       assert(!status);
@@ -165,15 +165,16 @@ describe('PRChecker', () => {
         createdAt: '2017-10-27T14:25:41.682Z'
       });
 
-      const options = {
+      const data = {
         pr: youngPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: approvingReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       const status = checker.checkPRWait(now);
       assert(!status);
@@ -193,15 +194,16 @@ describe('PRChecker', () => {
         createdAt: '2017-10-31T13:00:41.682Z'
       });
 
-      const options = {
+      const data = {
         pr: youngPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: approvingReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       const status = checker.checkPRWait(now);
       assert(!status);
@@ -227,15 +229,16 @@ describe('PRChecker', () => {
         }
       });
 
-      const options = {
+      const data = {
         pr: PR,
         reviewers: allGreenReviewers,
         comments: commentsWithCI,
         reviews: approvingReviews,
         commits: [],
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       checker.checkCI();
       cli.clearCalls();
@@ -264,15 +267,16 @@ describe('PRChecker', () => {
         }
       });
 
-      const options = {
+      const data = {
         pr: PR,
         reviewers: requestedChangesReviewers,
         comments: [],
         reviews: requestingChangesReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       checker.checkCI();
       cli.clearCalls();
@@ -301,15 +305,16 @@ describe('PRChecker', () => {
         }
       });
 
-      const options = {
+      const data = {
         pr: PR,
         reviewers: requestedChangesReviewers,
         comments: commentsWithCI,
         reviews: approvingReviews,
         commits: [],
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       checker.checkCI();
       cli.clearCalls();
@@ -337,15 +342,16 @@ describe('PRChecker', () => {
         }
       });
 
-      const options = {
+      const data = {
         pr: PR,
         reviewers: allGreenReviewers,
         comments: [],
         reviews: approvingReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       checker.checkCI();
       cli.clearCalls();
@@ -365,15 +371,16 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: approvingReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       const status = checker.checkCI();
       assert(!status);
@@ -416,15 +423,16 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithCI,
         reviews: approvingReviews,
         commits: [],
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       const status = checker.checkCI();
       assert(status);
@@ -447,15 +455,16 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: comment,
         reviews: approvingReviews,
         commits: commits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       const status = checker.checkCI();
       assert(!status);
@@ -489,7 +498,8 @@ describe('PRChecker', () => {
         comments: comment,
         reviews: approvingReviews,
         commits: commits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       }, argv);
 
       const status = checker.checkCI();
@@ -521,7 +531,8 @@ describe('PRChecker', () => {
         comments: comment,
         reviews: approvingReviews,
         commits: commits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       }, { maxCommits: 0 });
 
       const status = checker.checkCI();
@@ -530,7 +541,7 @@ describe('PRChecker', () => {
     });
   });
 
-  describe('authorIsNew/checkAuthor', () => {
+  describe('checkAuthor', () => {
     it('should check odd commits for first timers', () => {
       const cli = new TestCLI();
 
@@ -542,17 +553,16 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: approvingReviews,
         commits: oddCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
-
-      assert(checker.authorIsNew());
+      const checker = new PRChecker(cli, data, argv);
       const status = checker.checkAuthor();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
@@ -564,17 +574,16 @@ describe('PRChecker', () => {
 
       const expectedLogs = {};
 
-      const options = {
+      const data = {
         pr: firstTimerPrivatePR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: approvingReviews,
         commits: oddCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
-
-      assert(checker.authorIsNew());
+      const checker = new PRChecker(cli, data, argv);
       const status = checker.checkAuthor();
       assert(status);
       cli.assertCalledWith(expectedLogs);
@@ -600,16 +609,17 @@ describe('PRChecker', () => {
         error: []
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         collaborators,
         reviews,
-        commits
+        commits,
+        authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       let status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -629,15 +639,16 @@ describe('PRChecker', () => {
         error: []
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         collaborators,
         reviews,
-        commits
+        commits,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       let status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -658,15 +669,16 @@ describe('PRChecker', () => {
         error: []
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         collaborators,
         reviews,
-        commits
+        commits,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       let status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -677,15 +689,16 @@ describe('PRChecker', () => {
       const { commits } = multipleCommitsAfterReview;
       const expectedLogs = {};
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: [],
         collaborators,
-        commits
+        commits,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       let status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -699,7 +712,8 @@ describe('PRChecker', () => {
         comments: commentsWithLGTM,
         reviews: approvingReviews,
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       }, argv);
 
       const status = checker.checkCommitsAfterReview();
@@ -718,16 +732,17 @@ describe('PRChecker', () => {
         error: []
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         collaborators,
         reviews,
-        commits
+        commits,
+        authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, options, { maxCommits: 1 });
+      const checker = new PRChecker(cli, data, { maxCommits: 1 });
       const status = checker.checkCommitsAfterReview();
       cli.assertCalledWith(expectedLogs);
       assert(!status);
@@ -744,16 +759,17 @@ describe('PRChecker', () => {
         error: []
       };
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         collaborators,
         reviews,
-        commits
+        commits,
+        authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, options, { maxCommits: 0 });
+      const checker = new PRChecker(cli, data, { maxCommits: 0 });
       const status = checker.checkCommitsAfterReview();
       cli.assertCalledWith(expectedLogs);
       assert(!status);
@@ -772,15 +788,16 @@ describe('PRChecker', () => {
         warn: [['This PR has conflicts that must be resolved']]
       };
 
-      const options = {
+      const data = {
         pr: conflictingPR,
         reviewers: allGreenReviewers,
         comments: [],
         reviews: [],
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       let status = checker.checkMergeableState();
       assert.deepStrictEqual(status, false);
@@ -791,15 +808,16 @@ describe('PRChecker', () => {
       const { commits } = multipleCommitsAfterReview;
       const expectedLogs = {};
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: commentsWithLGTM,
         reviews: [],
         collaborators,
-        commits
+        commits,
+        authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
 
       let status = checker.checkMergeableState();
       assert.deepStrictEqual(status, true);
@@ -821,16 +839,17 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: closedPR,
         reviewers: allGreenReviewers,
         comments: [],
         reviews: [],
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
       const status = checker.checkPRState();
       assert.strictEqual(status, false);
       cli.assertCalledWith(expectedLogs);
@@ -843,16 +862,17 @@ describe('PRChecker', () => {
         ]
       };
 
-      const options = {
+      const data = {
         pr: mergedPR,
         reviewers: allGreenReviewers,
         comments: [],
         reviews: [],
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
       const status = checker.checkPRState();
       assert.strictEqual(status, false);
       cli.assertCalledWith(expectedLogs);
@@ -861,16 +881,17 @@ describe('PRChecker', () => {
     it('should return true if pr is not closed or merged', () => {
       const expectedLogs = {};
 
-      const options = {
+      const data = {
         pr: firstTimerPR,
         reviewers: allGreenReviewers,
         comments: [],
         reviews: [],
         commits: simpleCommits,
-        collaborators
+        collaborators,
+        authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, options, argv);
+      const checker = new PRChecker(cli, data, argv);
       const status = checker.checkPRState();
       assert.strictEqual(status, true);
       cli.assertCalledWith(expectedLogs);

--- a/test/unit/pr_data.test.js
+++ b/test/unit/pr_data.test.js
@@ -25,7 +25,8 @@ const rawPR = toRaw({
 const rawUser = {
   user: {
     login: 'pr_author',
-    email: 'pr_author@example.com'
+    email: 'pr_author@example.com',
+    name: 'Their Github Account email'
   }
 };
 
@@ -55,32 +56,12 @@ describe('PRData', function() {
     const cli = new TestCLI();
     const data = new PRData(argv, cli, request);
     await data.getAll();
-    assert.deepStrictEqual(data.collaborators, collaborators);
-    assert.deepStrictEqual(data.pr, firstTimerPR);
-    assert.deepStrictEqual(data.reviews, approvingReviews);
-    assert.deepStrictEqual(data.comments, commentsWithLGTM);
-    assert.deepStrictEqual(data.commits, oddCommits);
-    assert.deepStrictEqual(data.reviewers, allGreenReviewers);
-  });
-
-  it('logIntro', async() => {
-    const cli = new TestCLI();
-    const data = new PRData(argv, cli, request);
-    await data.getAll();
-    cli.clearCalls();
-
-    const expectedLogs = {
-      table: [
-        ['Title', 'test: awesome changes #16348'],
-        ['Author', 'pr_author'],
-        ['Commits', '6'],
-        ['Branch', 'pr_author:awesome-changes -> nodejs:master'],
-        ['Labels', 'test, doc']
-      ]
-    };
-
-    data.logIntro();
-    cli.assertCalledWith(expectedLogs);
+    assert.deepStrictEqual(data.collaborators, collaborators, 'collaborators');
+    assert.deepStrictEqual(data.pr, firstTimerPR, 'pr');
+    assert.deepStrictEqual(data.reviews, approvingReviews, 'reviews');
+    assert.deepStrictEqual(data.comments, commentsWithLGTM, 'comments');
+    assert.deepStrictEqual(data.commits, oddCommits, 'commits');
+    assert.deepStrictEqual(data.reviewers, allGreenReviewers, 'reviewers');
   });
 });
 
@@ -110,11 +91,11 @@ describe('PRData', function() {
     const argv2 = Object.assign({ readme: readmePath });
     const data = new PRData(argv2, cli, request);
     await data.getAll();
-    assert.deepStrictEqual(data.collaborators, collaborators);
-    assert.deepStrictEqual(data.pr, firstTimerPR);
-    assert.deepStrictEqual(data.reviews, approvingReviews);
-    assert.deepStrictEqual(data.comments, commentsWithLGTM);
-    assert.deepStrictEqual(data.commits, oddCommits);
-    assert.deepStrictEqual(data.reviewers, allGreenReviewers);
+    assert.deepStrictEqual(data.collaborators, collaborators, 'collaborators');
+    assert.deepStrictEqual(data.pr, firstTimerPR, 'pr');
+    assert.deepStrictEqual(data.reviews, approvingReviews, 'reviews');
+    assert.deepStrictEqual(data.comments, commentsWithLGTM, 'comments');
+    assert.deepStrictEqual(data.commits, oddCommits, 'commits');
+    assert.deepStrictEqual(data.reviewers, allGreenReviewers, 'reviewers');
   });
 });

--- a/test/unit/pr_summary.test.js
+++ b/test/unit/pr_summary.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const {
+  oddCommits,
+  simpleCommits,
+  firstTimerPR,
+  semverMajorPR
+} = require('../fixtures/data');
+const TestCLI = require('../fixtures/test_cli');
+const PRSummary = require('../../lib/pr_summary');
+
+describe('PRSummary', () => {
+  const argv = { prid: 16348, owner: 'nodejs', repo: 'node' };
+
+  it('#display() first timer with odd commits', () => {
+    const cli = new TestCLI();
+    const prData = {
+      pr: firstTimerPR,
+      commits: oddCommits,
+      authorIsNew() {
+        return true;
+      }
+    };
+    const summary = new PRSummary(argv, cli, prData);
+
+    const expectedLogs = {
+      log: [
+        // commits
+        [' - doc: some changes'],
+        [' - doc: some changes 2'],
+        [' - test: some changes'],
+        [' - test: some changes 2'],
+        [' - [squash] fix typo'],
+        [' - fixup! fix something'],
+        // committers
+        [' - Their Github Account email <pr_author@example.com>'],
+        [' - GitHub <noreply@github.com>'],
+        [' - Baz User <baz@example.com>']
+      ],
+      table: [
+        ['Title', 'test: awesome changes (#16348)'],
+        ['Author',
+          'Their Github Account email <pr_author@example.com>' +
+          ' (@pr_author, first-time contributor)'],
+        ['Branch', 'pr_author:awesome-changes -> nodejs:master'],
+        ['Labels', 'test, doc'],
+        ['Commits', '6'],
+        ['Committers', '3']
+      ]
+    };
+
+    summary.display();
+    cli.assertCalledWith(expectedLogs);
+  });
+
+  it('#display() old timer with simple commits', () => {
+    const cli = new TestCLI();
+    const prData = {
+      pr: semverMajorPR,
+      commits: simpleCommits,
+      authorIsNew() {
+        return false;
+      }
+    };
+    const summary = new PRSummary(argv, cli, prData);
+
+    const expectedLogs = {
+      log: [
+        // commits
+        [' - doc: some changes'],
+        // committers
+        [' - Their Github Account email <pr_author@example.com>']
+      ],
+      table: [
+        ['Title', 'lib: awesome changes (#16348)'],
+        ['Author',
+          'Their Github Account email <pr_author@example.com>' +
+          ' (@pr_author)'],
+        ['Branch', 'pr_author:awesome-changes -> nodejs:master'],
+        ['Labels', 'semver-major'],
+        ['Commits', '1'],
+        ['Committers', '1']
+      ]
+    };
+
+    summary.display();
+    cli.assertCalledWith(expectedLogs);
+  });
+});


### PR DESCRIPTION
Also logs out the commits and the committers, and the first-timer status.

Fixes: https://github.com/nodejs/node-core-utils/issues/132

<img width="790" alt="screen shot 2018-01-18 at 11 39 50 pm" src="https://user-images.githubusercontent.com/4299420/35106387-0de83fe0-fca9-11e7-8b1b-09f1e38c64df.png">
