### PR TITLE
Handle git-am failure, improve prompt

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,19 +29,26 @@ class CLI {
   prompt(question, defaultAnswer = true) {
     const option =
       `[${(defaultAnswer ? 'Y' : 'y')}/${(defaultAnswer ? 'n' : 'N')}]`;
+    this.separator();
+    const promptText = `${chalk.bold.cyan('?')} ${question} ${option} `;
     return new Promise((resolve, reject) => {
-      read({prompt: `${question} ${option} `}, (err, answer) => {
+      read({prompt: promptText}, (err, answer) => {
         if (err) {
-          reject(err);
+          this.log(`\nCanceled: ${err.message}`);
+          reject(new Error('__ignore__'));
+          return;
         }
         if (answer === undefined || answer === null) {
           reject(new Error('__ignore__'));
+          return;
         }
         const trimmed = answer.toLowerCase().trim();
         if (!trimmed) {
           resolve(defaultAnswer);
+          return;
         } else if (trimmed === 'y') {
           resolve(true);
+          return;
         }
         resolve(false);
       });

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  runAsync, runSync, forceRunAsync
+  runAsync, runSync, forceRunAsync, exit
 } = require('./run');
 const Session = require('./session');
 
@@ -31,7 +31,7 @@ class LandingSession extends Session {
     const { cli } = this;
     this.cleanFiles();
     await this.tryResetBranch();
-    cli.log(`Aborted \`git node land\` session in ${this.ncuDir}`);
+    cli.ok(`Aborted \`git node land\` session in ${this.ncuDir}`);
   }
 
   async apply() {
@@ -51,9 +51,28 @@ class LandingSession extends Session {
     });
     this.savePatch(patch);
     cli.stopSpinner(`Downloaded patch to ${this.patchPath}`);
-
+    cli.separator();
     // TODO: check that patches downloaded match metadata.commits
-    await runAsync('git', ['am', '--whitespace=fix', this.patchPath]);
+    try {
+      await forceRunAsync('git', ['am', '--whitespace=fix', this.patchPath], {
+        ignoreFailure: false
+      });
+    } catch (ex) {
+      const should3Way = await cli.prompt(
+        'The normal `git am` failed. Do you want to retry with 3-way merge?');
+      if (should3Way) {
+        await forceRunAsync('git', ['am', '--abort']);
+        await runAsync('git', [
+          'am',
+          '-3',
+          '--whitespace=fix',
+          this.patchPath
+        ]);
+      } else {
+        cli.error('Failed to apply patches');
+        exit();
+      }
+    }
     cli.ok('Patches applied');
 
     this.startAmending();
@@ -117,7 +136,6 @@ class LandingSession extends Session {
     const messageFile = this.saveMessage(rev, message);
     cli.separator('New Message');
     cli.log(message.trim());
-    cli.separator();
     const takeMessage = await cli.prompt('Use this message?');
     if (takeMessage) {
       await runAsync('git', ['commit', '--amend', '-F', messageFile]);
@@ -142,12 +160,22 @@ class LandingSession extends Session {
     const notYetPushed = this.getNotYetPushedCommits();
     const notYetPushedVerbose = this.getNotYetPushedCommits(true);
     await runAsync('core-validate-commit', notYetPushed);
+
     cli.separator();
     cli.log('The following commits are ready to be pushed to ' +
       `${upstream}/${branch}`);
     cli.log(`- ${notYetPushedVerbose.join('\n- ')}`);
     cli.separator();
-    cli.log(`run \`git push ${upstream} ${branch}\` to finish landing`);
+
+    let willBeLanded = notYetPushed[notYetPushed.length - 1].slice(0, 7);
+    if (notYetPushed.length > 1) {
+      const head = this.getUpstreamHead().slice(0, 7);
+      willBeLanded = `${head}...${willBeLanded}`;
+    }
+    cli.log('To finish landing:');
+    cli.log(`1. Run \`git push ${upstream} ${branch}\``);
+    cli.log(`2. Post in the PR: \`Landed in ${willBeLanded}\``);
+
     const shouldClean = await cli.prompt('Clean up generated temporary files?');
     if (shouldClean) {
       this.cleanFiles();
@@ -183,9 +211,15 @@ class LandingSession extends Session {
   getNotYetPushedCommits(verbose) {
     const { upstream, branch } = this;
     const ref = `${upstream}/${branch}...HEAD`;
-    const gitCmd = verbose ? ['log', '--oneline', ref] : ['rev-list', ref];
+    const gitCmd = verbose
+      ? ['log', '--oneline', '--reverse', ref] : ['rev-list', '--reverse', ref];
     const revs = runSync('git', gitCmd).trim();
     return revs ? revs.split('\n') : [];
+  }
+
+  getUpstreamHead(verbose) {
+    const { upstream, branch } = this;
+    return runSync('git', ['rev-parse', `${upstream}/${branch}^1`]).trim();
   }
 
   async tryAbortAm() {

--- a/lib/run.js
+++ b/lib/run.js
@@ -4,15 +4,22 @@ const { spawn, spawnSync } = require('child_process');
 
 const IGNORE = '__ignore__';
 
-function runAsyncBase(cmd, args, options) {
+function runAsyncBase(cmd, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, Object.assign({
       cwd: process.cwd(),
       stdio: 'inherit'
-    }, options));
+    }, options.spawnArgs));
     child.on('close', (code) => {
       if (code !== 0) {
-        return reject(new Error(IGNORE));
+        const { ignoreFailure = true } = options;
+        if (ignoreFailure) {
+          return reject(new Error(IGNORE));
+        }
+        const err = new Error(`${cmd} failed: ${code}`);
+        err.code = code;
+        err.messageOnly = true;
+        return reject(err);
       }
       return resolve();
     });
@@ -22,7 +29,9 @@ function runAsyncBase(cmd, args, options) {
 exports.forceRunAsync = function(cmd, args, options) {
   return runAsyncBase(cmd, args, options).catch((error) => {
     if (error.message !== IGNORE) {
-      console.error(error);
+      if (!error.messageOnly) {
+        console.error(error);
+      }
       throw error;
     }
   });
@@ -33,7 +42,7 @@ exports.runPromise = function runAsync(promise) {
     if (error.message !== IGNORE) {
       console.error(error);
     }
-    process.exit(1);
+    exports.exit();
   });
 };
 
@@ -52,4 +61,8 @@ exports.runSync = function(cmd, args, options) {
   } else {
     return child.stdout.toString();
   }
+};
+
+exports.exit = function() {
+  process.exit(1);
 };


### PR DESCRIPTION
1. Fixes: https://github.com/nodejs/node-core-utils/issues/142 by prompting for `git am -3` when the normal `git am` fails
2. Improve the prompt: handle cancellation, put a `? ` in the beginning with a separator above the prompt.
3. Display the commits in reverse order (i.e. oldest first) and display the `Landed in xxx...yyy` for copy-pasting.

<img width="686" alt="screen shot 2018-01-21 at 6 26 02 pm" src="https://user-images.githubusercontent.com/4299420/35193064-90da6776-fed8-11e7-8473-0ffa9b94a051.png">
