### PR TITLE
query: directly query user data in PR.gql

### DIFF
--- a/lib/pr_data.js
+++ b/lib/pr_data.js
@@ -13,7 +13,6 @@ const PR_QUERY = 'PR';
 const REVIEWS_QUERY = 'Reviews';
 const COMMENTS_QUERY = 'PRComments';
 const COMMITS_QUERY = 'PRCommits';
-const USER_QUERY = 'User';
 
 class PRData {
   /**
@@ -78,12 +77,7 @@ class PRData {
     const { prid, owner, repo, cli, request, prStr } = this;
     cli.updateSpinner(`Getting PR from ${prStr}`);
     const prData = await request.gql(PR_QUERY, { prid, owner, repo });
-    const pr = this.pr = prData.repository.pullRequest;
-    // Get the mail
-    cli.updateSpinner(`Getting User information for ${pr.author.login}`);
-    const userData = await request.gql(USER_QUERY, { login: pr.author.login });
-    const user = userData.user;
-    Object.assign(this.pr.author, user);
+    this.pr = prData.repository.pullRequest;
   }
 
   async getReviews() {

--- a/lib/queries/PR.gql
+++ b/lib/queries/PR.gql
@@ -4,7 +4,11 @@ query PR($prid: Int!, $owner: String!, $repo: String!) {
       createdAt,
       authorAssociation,
       author {
-        login
+        ... on User {
+          login,
+          email,
+          name
+        }
       },
       url,
       bodyHTML,

--- a/lib/queries/User.gql
+++ b/lib/queries/User.gql
@@ -1,7 +1,0 @@
-query User($login: String!){
-  user(login: $login) {
-    login,
-    email,
-    name
-  }
-}

--- a/test/unit/pr_data.test.js
+++ b/test/unit/pr_data.test.js
@@ -22,13 +22,6 @@ function toRaw(obj) {
 const rawPR = toRaw({
   repository: { pullRequest: firstTimerPR }
 });
-const rawUser = {
-  user: {
-    login: 'pr_author',
-    email: 'pr_author@example.com',
-    name: 'Their Github Account email'
-  }
-};
 
 describe('PRData', function() {
   const request = {
@@ -41,7 +34,6 @@ describe('PRData', function() {
   }).returns(Promise.resolve(readme));
   request.promise.returns(new Error('unknown query'));
   request.gql.withArgs('PR').returns(Promise.resolve(rawPR));
-  request.gql.withArgs('User').returns(Promise.resolve(rawUser));
   request.gql.withArgs('Reviews').returns(
     Promise.resolve(toRaw(approvingReviews)));
   request.gql.withArgs('PRComments').returns(
@@ -75,7 +67,6 @@ describe('PRData', function() {
   }).returns(new Error('Should not call'));
   request.promise.returns(new Error('unknown query'));
   request.gql.withArgs('PR').returns(Promise.resolve(rawPR));
-  request.gql.withArgs('User').returns(Promise.resolve(rawUser));
   request.gql.withArgs('Reviews').returns(
     Promise.resolve(toRaw(approvingReviews)));
   request.gql.withArgs('PRComments').returns(


### PR DESCRIPTION
This eliminates the need of query the user data in a separate request <del>and the user would not have to grant user:email permission to the token anymore.</del> EDIT: nope, still need the permission.
Refs: https://github.com/nodejs/node-core-utils/issues/150#issuecomment-358972583

cc @cPhost 