### PR TITLE
test: fix cli test on windows

### DIFF
--- a/test/fixtures/log_stream.js
+++ b/test/fixtures/log_stream.js
@@ -6,6 +6,7 @@ const writtenSym = Symbol('written');
 class LogStream extends Writable {
   constructor(options) {
     super(options);
+    this.isTTY = false;
     this[writtenSym] = '';
   }
 
@@ -16,6 +17,10 @@ class LogStream extends Writable {
   toString() {
     return this[writtenSym];
   }
+
+  clearLine() {}
+
+  cursorTo() {}
 }
 
 module.exports = LogStream;


### PR DESCRIPTION
https://github.com/nodejs/node-core-utils/commit/9961256d9a89cf09b184686f563b9fa2aa7e2fff fixed a bug where the stream passed to `cli` will not actually get assigned to ora, which revealed another bug in the cli tests (not mocking all the methods called by ora). This patch fixes that.

(TBQH I think the cli tests are rather superfluous and are just testing what the dependencies already test..)