### PR TITLE
bin: deprecate get-metadata and add git-node-metadata

### DIFF
--- a/bin/get-metadata
+++ b/bin/get-metadata
@@ -1,17 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-const argv = require('../lib/args')();
-const getMetadata = require('../components/metadata');
-const CLI = require('../lib/cli');
+const path = require('path');
+const { runAsync } = require('../lib/run');
 
-const logStream = process.stdout.isTTY ? process.stdout : process.stderr;
-const cli = new CLI(logStream);
-
-getMetadata(argv, cli).catch((err) => {
-  if (cli.spinner.enabled) {
-    cli.spinner.fail();
-  }
-  cli.error(err);
-  process.exit(-1);
-});
+const script = path.join(
+  __dirname, '..', 'components', 'git', 'git-node-metadata');
+runAsync(script, process.argv.slice(2));

--- a/components/git/git-node-help
+++ b/components/git/git-node-help
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
 console.log(`
+Steps to get metadata for a pull request:
+==============================================================================
+$ cd path/to/node/project
+$ git node metadata $PRID        # Retrieves metadata for a PR and validates
+                                 # them against nodejs/node PR rules
+==============================================================================
+
 Steps to land a pull request:
 ==============================================================================
 $ cd path/to/node/project

--- a/components/git/git-node-metadata
+++ b/components/git/git-node-metadata
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+'use strict';
+
+const argv = require('../../lib/args')();
+const getMetadata = require('../metadata');
+const CLI = require('../../lib/cli');
+const config = require('../../lib/config').getMergedConfig();
+
+const logStream = process.stdout.isTTY ? process.stdout : process.stderr;
+const cli = new CLI(logStream);
+
+getMetadata(Object.assign({}, config, argv), cli).catch((err) => {
+  if (cli.spinner.enabled) {
+    cli.spinner.fail();
+  }
+  cli.error(err);
+  process.exit(-1);
+});

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -1,6 +1,6 @@
 # git-node
 
-A custom Git command for landing pull requests. You can run it as
+A custom Git command for managing pull requests. You can run it as
 `git-node` or `git node`. To see the help text, run `git node help`.
 
 ### Prerequistes
@@ -19,7 +19,7 @@ A custom Git command for landing pull requests. You can run it as
     ```
     $ cd path/to/node/project
     $ ncu-config set upstream your-remote-name
-    $ ncu-config set branch your-branch-name 
+    $ ncu-config set branch your-branch-name
     ```
 
 ### Demo & Usage


### PR DESCRIPTION
get-metadata felt sort of left out of the organization of the other tools since it existed before and imo it seemed better as part of git-node.