### PR TITLE
lib: accept extra spaces in the collaborators list

### DIFF
--- a/lib/collaborators.js
+++ b/lib/collaborators.js
@@ -4,7 +4,7 @@ const TSC_TITLE = '### TSC (Technical Steering Committee)';
 const TSCE_TITLE = '### TSC Emeriti';
 const CL_TITLE = '### Collaborators';
 const CLE_TITLE = '### Collaborator Emeriti';
-const CONTACT_RE = /\* \[(.+?)\]\(.+?\) -\s\*\*(.+?)\*\* &lt;(.+?)&gt;/mg;
+const CONTACT_RE = /\* +\[(.+?)\]\(.+?\) +-\s\*\*(.+?)\*\* +&lt;(.+?)&gt;/mg;
 
 const TSC = 'TSC';
 const COLLABORATOR = 'COLLABORATOR';


### PR DESCRIPTION
`get-metadata` will skip collaborators from the list without warning if there are extra spaces. For example: 

```
* [mmarchini](https://github.com/mmarchini) -
**Matheus Marchini**  &lt;matheus@sthima.com&gt;
                     ^
                     Extra space
```

Ref: https://github.com/nodejs/node/pull/18822