### PR TITLE
WIP: ncu-contrib: initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp
 coverage.lcov
 tmp-*
 .eslintcache
+.ncu

--- a/bin/ncu-contrib
+++ b/bin/ncu-contrib
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const Request = require('../lib/request');
+const auth = require('../lib/auth');
+const { writeFile } = require('../lib/file');
+const { runPromise } = require('../lib/run');
+const CLI = require('../lib/cli');
+const ContributionAnalyzer = require('../lib/contribution-analyzer');
+
+const yargs = require('yargs');
+// eslint-disable-next-line no-unused-vars
+const argv = yargs
+  .command({
+    command: 'collaborators',
+    desc: 'Getting contributions from collaborators',
+    handler: handler
+  })
+  .command({
+    command: 'tsc',
+    desc: 'Getting contributions from TSC members',
+    handler: handler
+  })
+  .command({
+    command: 'for <ids..>',
+    desc: 'Getting contributions from GitHub handles',
+    builder: (yargs) => {
+      yargs
+        .positional('ids', {
+          describe: 'GitHub handles',
+          type: 'array'
+        });
+    },
+    handler: handler
+  })
+  .string('repo')
+  .string('owner')
+  .string('type')
+  .string('branch')
+  .string('readme')
+  .string('output')
+  .default({
+    repo: 'node',
+    owner: 'nodejs',
+    type: 'participation',
+    branch: 'master'
+  })
+  .demandCommand(1, 'must provide a valid command')
+  .help()
+  .argv;
+
+async function main(argv) {
+  const cli = new CLI();
+  const credentials = await auth();
+  const request = new Request(credentials);
+  const config = require('../lib/config').getMergedConfig();
+  argv = Object.assign(argv, config);
+  const analyzer = new ContributionAnalyzer(request, cli, argv);
+
+  const [ command ] = argv._;
+  let result;
+  switch (command) {
+    case 'collaborators':
+      result = await analyzer.getLatestContributionForCollaborators();
+      break;
+    case 'tsc':
+      result = await analyzer.getLatestContributionForTSC();
+      break;
+    case 'for':
+      result = await analyzer.getLatestContributionForIds(argv.ids);
+      break;
+    default:
+      throw new Error(`Unknown command ${command}`);
+  }
+  if (argv.output) {
+    const txt = analyzer.formatContributionList(result);
+    writeFile(argv.output, txt);
+  }
+}
+
+function handler(argv) {
+  runPromise(main(argv));
+}

--- a/bin/ncu-contrib
+++ b/bin/ncu-contrib
@@ -74,7 +74,7 @@ async function main(argv) {
       throw new Error(`Unknown command ${command}`);
   }
   if (argv.output) {
-    const txt = analyzer.formatContributionList(result);
+    const txt = analyzer.formatContributionList(result, 'csv');
     writeFile(argv.output, txt);
   }
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { writeJson, readJson, writeFile, readFile } = require('./file');
+
+function isAsync(fn) {
+  return fn[Symbol.toStringTag] === 'AsyncFunction';
+}
+
+class Cache {
+  constructor(dir) {
+    this.dir = dir || path.join(__dirname, '..', '.ncu', 'cache');
+    this.originals = {};
+    this.disabled = process.argv.includes('--enable-cache');
+  }
+
+  disable() {
+    this.disabled = true;
+  }
+
+  enable() {
+    this.disabled = false;
+  }
+
+  getFilename(key, ext) {
+    return path.join(this.dir, key) + ext;
+  }
+
+  has(key, ext) {
+    if (this.disabled) {
+      return false;
+    }
+
+    return fs.existsSync(this.getFilename(key, ext));
+  }
+
+  get(key, ext) {
+    if (!this.has(key, ext)) {
+      return undefined;
+    }
+    if (ext === '.json') {
+      return readJson(this.getFilename(key, ext));
+    } else {
+      return readFile(this.getFilename(key, ext));
+    }
+  }
+
+  write(key, ext, content) {
+    if (this.disabled) {
+      return;
+    }
+    const filename = this.getFilename(key, ext);
+    if (ext === '.json') {
+      return writeJson(filename, content);
+    } else {
+      return writeFile(filename, content);
+    }
+  }
+
+  wrapAsync(original, identity) {
+    const cache = this;
+    return async function(...args) {
+      const { key, ext } = identity.call(this, ...args);
+      const cached = cache.get(key, ext);
+      if (cached) {
+        return cached;
+      }
+      const result = await original.call(this, ...args);
+      cache.write(key, ext, result);
+      return result;
+    };
+  }
+
+  wrapNormal(original, identity) {
+    const cache = this;
+    return function(...args) {
+      const { key, ext } = identity.call(this, ...args);
+      const cached = cache.get(key, ext);
+      if (cached) {
+        return cached;
+      }
+      const result = original.call(this, ...args);
+      cache.write(key, ext, result);
+      return result;
+    };
+  }
+
+  wrap(Class, identities) {
+    for (let method of Object.keys(identities)) {
+      const original = Class.prototype[method];
+      const identity = identities[method];
+      this.originals[method] = original;
+      if (isAsync(original)) {
+        Class.prototype[method] = this.wrapAsync(original, identity);
+      } else {
+        Class.prototype[method] = this.wrapNormal(original, identity);
+      }
+    }
+  }
+}
+
+module.exports = Cache;

--- a/lib/contribution-analyzer.js
+++ b/lib/contribution-analyzer.js
@@ -122,17 +122,28 @@ class ContributionAnalyzer {
     };
   }
 
-  formatContribution(data) {
-    if (this.argv.type === 'participation') {
-      const type =
-        data.type.padEnd(8).toUpperCase();
-      const date = data.date.slice(0, 10);
-      return `${date} ${type} @${data.user.padEnd(22)} ${data.url}`;
-    } else if (this.argv.type === 'commit') {
-      const hash = data.oid.slice(0, 7);
-      const date = data.authoredDate.slice(0, 10);
-      const message = data.messageHeadline;
-      return `${date} ${hash} @${data.user.padEnd(22)} ${message}`;
+  formatContribution(data, format = 'text') {
+    if (format === 'text') {
+      if (this.argv.type === 'participation') {
+        const type = data.type.padEnd(8).toUpperCase();
+        const date = data.date.slice(0, 10);
+        return `${date} ${type} @${data.user.padEnd(22)} ${data.url}`;
+      } else if (this.argv.type === 'commit') {
+        const hash = data.oid.slice(0, 7);
+        const date = data.authoredDate.slice(0, 10);
+        const message = data.messageHeadline;
+        return `${date} ${hash} @${data.user.padEnd(22)} ${message}`;
+      }
+    } else if (format === 'csv') {
+      if (this.argv.type === 'participation') {
+        const date = data.date.slice(0, 10);
+        return `${date},${data.type},@${data.user},${data.url}`;
+      } else if (this.argv.type === 'commit') {
+        const hash = data.oid.slice(0, 7);
+        const date = data.authoredDate.slice(0, 10);
+        const message = data.messageHeadline;
+        return `${date},${hash},@${data.user},${message}`;
+      }
     }
   }
 
@@ -182,13 +193,14 @@ class ContributionAnalyzer {
       const data = latestContrib[user];
       return this.getResult(user, data);
     });
+
     return sorted;
   }
 
-  formatContributionList(list) {
+  formatContributionList(list, format = 'text') {
     let txt = '';
     for (const item of list) {
-      txt += this.formatContribution(item) + '\n';
+      txt += this.formatContribution(item, format) + '\n';
     }
     return txt;
   }

--- a/lib/contribution-analyzer.js
+++ b/lib/contribution-analyzer.js
@@ -1,0 +1,223 @@
+'use strict';
+
+const SEARCH_ISSUE = 'SearchIssue';
+const SEARCH_COMMIT = 'SearchCommit';
+const USER = 'User';
+
+const { getCollaborators } = require('./collaborators');
+const Cache = require('./cache');
+const { ascending } = require('./comp');
+const { isTheSamePerson } = require('./user');
+
+class ContributionAnalyzer {
+  constructor(request, cli, argv) {
+    this.request = request;
+    this.cli = cli;
+    this.argv = argv;
+  }
+
+  async getCommits(user) {
+    const { request, argv } = this;
+    const { owner, repo, branch } = argv;
+
+    const userData = await request.gql(USER, { login: user });
+    const authorId = userData.user.id;
+    const results = await request.gql(SEARCH_COMMIT, {
+      owner, repo, branch, authorId
+    }, [ 'repository', 'ref', 'target', 'history' ]);
+    return results
+      .sort((a, b) => {
+        return a.authoredDate > b.authoredDate ? -1 : 1;
+      });
+  }
+
+  async getParticipation(user) {
+    const { request } = this;
+    const results = await request.gql(SEARCH_ISSUE, {
+      queryString: `involves:${user} repo:nodejs/node`,
+      mustBeAuthor: false
+    });
+    if (results.search.nodes.length === 0) {
+      return [{
+        url: 'N/A',
+        date: 'N/A',
+        isRelavent: false,
+        type: 'N/A'
+      }];
+    }
+
+    const res = results.search.nodes
+      .map(issue => this.participationByUser(issue, user))
+      // .filter((res) => res.isRelavent)
+      .sort((a, b) => {
+        return a.date > b.date ? -1 : 1;
+      });
+    return res;
+  }
+
+  participationByUser(issue, user) {
+    const result = {
+      url: issue.url,
+      date: new Date(issue.publishedAt).toISOString(),
+      isRelavent: false,
+      type: ''
+    };
+
+    // Author
+    if (isTheSamePerson(issue.author, user)) {
+      result.date = issue.publishedAt;
+      result.isRelavent = true;
+      result.type = /pull/.test(issue.url) ? 'pull' : 'issue';
+    }
+
+    if (issue.reviews) {
+      issue.reviews.nodes.forEach((review) => {
+        if (!isTheSamePerson(review.author, user)) {
+          return;
+        }
+
+        result.isRelavent = true;
+        if (review.publishedAt > result.date) {
+          result.date = review.publishedAt;
+          result.type = 'review';
+        }
+      });
+    }
+
+    issue.comments.nodes.forEach((comment) => {
+      if (!isTheSamePerson(comment.author, user)) {
+        return;
+      }
+
+      result.isRelavent = true;
+      if (comment.publishedAt > result.date) {
+        result.date = comment.publishedAt;
+        result.type = 'comment';
+      }
+    });
+
+    return result;
+  }
+
+  async getContributionsForId(user) {
+    const { argv } = this;
+    if (argv.type === 'participation') {
+      return this.getParticipation(user);
+    } else if (argv.type === 'commit') {
+      return this.getCommits(user);
+    }
+  }
+
+  async getLatestContributionForId(user) {
+    const contributions = await this.getContributionsForId(user);
+    if (contributions.length) {
+      return Object.assign({ user }, contributions[0]);
+    }
+    return {
+      user: user,
+      url: 'N/A',
+      date: 'N/A',
+      isRelavent: false,
+      type: 'N/A'
+    };
+  }
+
+  formatContribution(data) {
+    if (this.argv.type === 'participation') {
+      const type =
+        data.type.padEnd(8).toUpperCase();
+      const date = data.date.slice(0, 10);
+      return `${date} ${type} @${data.user.padEnd(22)} ${data.url}`;
+    } else if (this.argv.type === 'commit') {
+      const hash = data.oid.slice(0, 7);
+      const date = data.authoredDate.slice(0, 10);
+      const message = data.messageHeadline;
+      return `${date} ${hash} @${data.user.padEnd(22)} ${message}`;
+    }
+  }
+
+  getResult(user, data) {
+    if (this.argv.type === 'participation') {
+      return {
+        user,
+        date: data.date,
+        url: data.url,
+        type: data.type
+      };
+    } else if (this.argv.type === 'commit') {
+      return {
+        user,
+        authoredDate: data.authoredDate,
+        messageHeadline: data.messageHeadline,
+        oid: data.oid
+      };
+    }
+  }
+
+  getDate(item) {
+    if (this.argv.type === 'participation') {
+      return item.date;
+    } else if (this.argv.type === 'commit') {
+      return item.authoredDate;
+    }
+  }
+
+  async getLatestContributionForIds(ids) {
+    const { cli } = this;
+    const total = ids.length;
+    let counter = 1;
+    const latestContrib = {};
+    for (const user of ids) {
+      cli.startSpinner(`Grabbing data for @${user}, ${counter++}/${total}..`);
+      const data = await this.getLatestContributionForId(user);
+      latestContrib[user] = data;
+      cli.stopSpinner(this.formatContribution(data));
+    }
+
+    const sorted = ids.sort((a, b) => {
+      const aa = latestContrib[a];
+      const bb = latestContrib[b];
+      return ascending(this.getDate(aa), this.getDate(bb));
+    }).map((user) => {
+      const data = latestContrib[user];
+      return this.getResult(user, data);
+    });
+    return sorted;
+  }
+
+  formatContributionList(list) {
+    let txt = '';
+    for (const item of list) {
+      txt += this.formatContribution(item) + '\n';
+    }
+    return txt;
+  }
+
+  async getLatestContributionForCollaborators() {
+    const { cli, argv, request } = this;
+    const collaborators = await getCollaborators(cli, request, argv);
+    const ids = [...collaborators.keys()];
+    return this.getLatestContributionForIds(ids);
+  }
+
+  async getLatestContributionForTSC() {
+    const { cli, argv, request } = this;
+    const collaborators = await getCollaborators(cli, request, argv);
+    const tsc = [...collaborators.values()].filter((user) => user.isTSC());
+    const ids = tsc.map(user => user.login);
+    return this.getLatestContributionForIds(ids);
+  }
+}
+
+const contribCache = new Cache();
+contribCache.wrap(ContributionAnalyzer, {
+  getCommits(user) {
+    return { key: `commits-${user}`, ext: '.json' };
+  },
+  getParticipation(user) {
+    return { key: `participation-${user}`, ext: '.json' };
+  }
+});
+contribCache.enable();
+
+module.exports = ContributionAnalyzer;

--- a/lib/queries/SearchCommit.gql
+++ b/lib/queries/SearchCommit.gql
@@ -1,0 +1,26 @@
+query SearchCommitByAuthor($repo: String!, $owner: String!, $branch: String!, $authorId: ID!, $after: String) {
+  repository(name: $repo, owner: $owner) {
+    ref(qualifiedName: $branch) {
+      target {
+        ... on Commit {
+          history(first: 100, after: $after, author: { id: $authorId } ) {
+           totalCount
+           pageInfo { hasNextPage, endCursor }
+            nodes {
+              oid
+              authoredDate
+              messageHeadline
+              author {
+                email
+                name
+                user {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/queries/SearchIssue.gql
+++ b/lib/queries/SearchIssue.gql
@@ -1,5 +1,10 @@
-query SearchIssueByUser($queryString: String!, $isCommenter: Boolean!, $after: String) {
+query SearchIssueByUser($queryString: String!, $mustBeAuthor: Boolean!, $after: String) {
   search(query: $queryString, type: ISSUE, first: 100, after: $after) {
+    issueCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
     nodes {
       ... on PullRequest {
         url
@@ -8,7 +13,7 @@ query SearchIssueByUser($queryString: String!, $isCommenter: Boolean!, $after: S
           login
         }
         title
-        reviews(last: 100) @include(if: $isCommenter) {
+        reviews(last: 100) @skip(if: $mustBeAuthor) {
           nodes {
             publishedAt
             author {
@@ -21,7 +26,7 @@ query SearchIssueByUser($queryString: String!, $isCommenter: Boolean!, $after: S
             name
           }
         }
-        comments(last: 100) @include(if: $isCommenter) {
+        comments(last: 100) @skip(if: $mustBeAuthor) {
           nodes {
             publishedAt
             author {
@@ -37,7 +42,7 @@ query SearchIssueByUser($queryString: String!, $isCommenter: Boolean!, $after: S
           login
         }
         title
-        comments(last: 100) @include(if: $isCommenter) {
+        comments(last: 100) @skip(if: $mustBeAuthor) {
           nodes {
             publishedAt
             author {

--- a/lib/queries/User.gql
+++ b/lib/queries/User.gql
@@ -1,0 +1,7 @@
+query User($login: String!) {
+  user(login: $login) {
+    login,
+    email,
+    id
+  }
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,6 +9,7 @@ class Request {
     this.credentials = credentials;
   }
 
+  // TODO: cache this
   loadQuery(file) {
     const filePath = path.resolve(__dirname, 'queries', `${file}.gql`);
     return fs.readFileSync(filePath, 'utf8');

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "get-metadata": "./bin/get-metadata",
     "git-node": "./bin/git-node",
     "ncu-config": "./bin/ncu-config",
+    "ncu-contrib": "./bin/ncu-contrib",
     "ncu-team": "./bin/ncu-team"
   },
   "scripts": {


### PR DESCRIPTION
Currently two types of contribution profiles are available:

1. Participations (comments, reviews, PRs, opened issues, across the whole nodejs organization). The displayed result are the latest participations of the selected group.

<img width="801" alt="screen shot 2018-02-21 at 7 44 02 am" src="https://user-images.githubusercontent.com/4299420/36455472-20de468e-16db-11e8-8531-175fab95639b.png">

2. Commits (by default, commits on the master branch of nodejs/node). The displayed result are the latest commits of the selected group.
<img width="833" alt="screen shot 2018-02-21 at 7 44 22 am" src="https://user-images.githubusercontent.com/4299420/36455467-1e3fd0c8-16db-11e8-9d35-37f8c58f88c5.png">

The group can be:

1. `collaborators`
2. `tsc`
3.  Array of GitHub handles

```
ncu-contrib <command>

Commands:
  ncu-contrib collaborators  Getting contributions from collaborators
  ncu-contrib tsc            Getting contributions from TSC members
  ncu-contrib for <ids..>    Getting contributions from GitHub handles

Options:
  --version  Show version number                                       [boolean]
  --help     Show help                                                 [boolean]
  --repo                                              [string] [default: "node"]
  --owner                                           [string] [default: "nodejs"]
  --type                                     [string] [default: "participation"]
  --branch                                          [string] [default: "master"]

```
