### PR TITLE
Detect if PR author has incorrect git config.

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -54,7 +54,8 @@ class PRChecker {
       this.checkCI(),
       this.checkPRWait(new Date()),
       this.checkMergeableState(),
-      this.checkPRState()
+      this.checkPRState(),
+      this.checkGitConfig()
     ];
 
     if (this.data.authorIsNew()) {
@@ -277,7 +278,7 @@ class PRChecker {
   }
 
   isOddAuthor(commit) {
-    const { pr, collaboratorEmails } = this;
+    const { pr } = this;
 
     // They have turned on the private email feature, can't really check
     // anything, GitHub should know how to link that, see nodejs/node#15489
@@ -291,12 +292,6 @@ class PRChecker {
       return false;
     }
 
-    // The commit author is one of the collaborators, they should know
-    // what they are doing anyway
-    if (collaboratorEmails.has(commit.author.email)) {
-      return false;
-    }
-
     if (commit.author.email === pr.author.email) {
       return false;
     }
@@ -304,8 +299,20 @@ class PRChecker {
     // At this point, the commit:
     // 1. is not authored by the commiter i.e. author email is not in the
     //    committer's Github account
-    // 2. is not authored by a collaborator
     // 3. is not authored by the people opening the PR
+    return true;
+  }
+
+  checkGitConfig() {
+    const { cli, commits } = this;
+    for (let { commit } of commits) {
+      if (commit.author.user === null) {
+        const msg = 'Author does not have correct git config!';
+        cli.error(msg);
+        return false;
+      }
+    }
+
     return true;
   }
 

--- a/lib/queries/PRCommits.gql
+++ b/lib/queries/PRCommits.gql
@@ -11,6 +11,9 @@ query Commits($prid: Int!, $owner: String!, $repo: String!, $after: String) {
           commit {
             committedDate
             author {
+              user {
+                login
+              }
               email
               name
             }

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -27,6 +27,7 @@ const commentsWithCI = readJSON('comments_with_ci.json');
 const commentsWithLGTM = readJSON('comments_with_lgtm.json');
 
 const oddCommits = readJSON('odd_commits.json');
+const incorrectGitConfigCommits = readJSON('incorrect_git_config_commits.json');
 const simpleCommits = readJSON('simple_commits.json');
 
 const collabArr = readJSON('collaborators.json');
@@ -79,6 +80,7 @@ module.exports = {
   commentsWithCI,
   commentsWithLGTM,
   oddCommits,
+  incorrectGitConfigCommits,
   simpleCommits,
   singleCommitAfterReview,
   multipleCommitsAfterReview,

--- a/test/fixtures/incorrect_git_config_commits.json
+++ b/test/fixtures/incorrect_git_config_commits.json
@@ -1,0 +1,38 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:35:26Z",
+      "author": {
+        "user": null,
+        "email": "pr_author@example.com",
+        "name": "Their Github Account email"
+      },
+      "committer": {
+        "email": "pr_author@example.com",
+        "name": "Their Github Account email"
+      },
+      "oid": "ffdef335209c77f66d933bd873950747bfe42264",
+      "messageHeadline": "doc: some changes",
+      "message": "Normal commit, same email for everything",
+      "authoredByCommitter": true
+    }
+  },
+  {
+    "commit": {
+      "committedDate": "2017-09-26T12:35:14Z",
+      "author": {
+        "email": "test@example.com",
+        "name": "Their git config user.email"
+      },
+      "committer": {
+        "email": "pr_author@example.com",
+        "name": "Their Github Account email"
+      },
+      "oid": "e3ad7c72e88c83b7184563e8fdb63df02e2fbacb",
+      "messageHeadline": "doc: some changes 2",
+      "message": "Either they have not configured git user.email, or have not add the email to their account",
+      "authoredByCommitter": false
+    }
+  }
+]
+


### PR DESCRIPTION
Finally fixed this 😅!

This is what the documentation say about the use field in  author (`GitActor`):
> The GitHub user corresponding to the email field. Null if no such user exists.

@joyeecheung i added new method called `checkGitConfig` since we want the non author committed PR to be checked and logged out. I removed a step where we check if the `oddAuthor` is a collaborator because this method is only called is the author is a first timer. And i request login for `user` since it needs to request something.
 