### PR TITLE
git-node: warn on unexpected remote repository url

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const { URL } = require('url');
 
 const {
   runAsync, runSync, forceRunAsync, exit
@@ -14,6 +15,33 @@ class LandingSession extends Session {
     super(dir, prid, config);
     this.cli = cli;
     this.req = req;
+    const { upstream } = this;
+    const upstreamHref = runSync('git', ['config', '--get',
+      `remote.${upstream}.url`]);
+    let warned = false;
+    try {
+      const { hostname, pathname } = new URL(upstreamHref);
+      if (hostname !== 'github.com') {
+        warned = true;
+        cli.warn('Remote repository URL does not point to the expected ' +
+          'host "github.com"');
+      }
+      if (/^\/nodejs\/node(?:\.git)?$/.test(pathname) !== true) {
+        warned = true;
+        cli.warn('Remote repository URL does not point to the expected ' +
+          'repository "/nodejs/node"');
+      }
+    } catch (e) {
+      warned = true;
+      cli.warn('Could not parse remote repository URL %j, this might be ' +
+        'because it is not a HTTPS URL', upstreamHref);
+    }
+    if (warned) {
+      cli.warn('You might want to change the remote repository URL with ' +
+        `\`git remote set-url ${
+          upstream
+        } "https://github.com/nodejs/node.git"\``);
+    }
   }
 
   async start(metadata) {

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -15,7 +15,7 @@ class LandingSession extends Session {
     super(dir, prid, config);
     this.cli = cli;
     this.req = req;
-    const { upstream } = this;
+    const { upstream, owner, repo } = this;
     const upstreamHref = runSync('git', ['config', '--get',
       `remote.${upstream}.url`]);
     let warned = false;
@@ -26,10 +26,10 @@ class LandingSession extends Session {
         cli.warn('Remote repository URL does not point to the expected ' +
           'host "github.com"');
       }
-      if (/^\/nodejs\/node(?:\.git)?$/.test(pathname) !== true) {
+      if (new RegExp(`^/${owner}/${repo}(?:.git)?$`).test(pathname) !== true) {
         warned = true;
         cli.warn('Remote repository URL does not point to the expected ' +
-          'repository "/nodejs/node"');
+          `repository /${owner}/${repo}`);
       }
     } catch (e) {
       warned = true;
@@ -40,7 +40,7 @@ class LandingSession extends Session {
       cli.warn('You might want to change the remote repository URL with ' +
         `\`git remote set-url ${
           upstream
-        } "https://github.com/nodejs/node.git"\``);
+        } "https://github.com/${owner}/${repo}"\``);
     }
   }
 


### PR DESCRIPTION
This is just a double check so it emits warnings rather than doing anything. It doesn't parse `git+ssh` URLs since they are not valid URLs according to http://url.spec.whatwg.org/ .