### PR TITLE
git-node: do not require https:// urls or github.com urls

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const { URL } = require('url');
 
 const {
   runAsync, runSync, forceRunAsync, exit
@@ -16,31 +15,12 @@ class LandingSession extends Session {
     this.cli = cli;
     this.req = req;
     const { upstream, owner, repo } = this;
-    const upstreamHref = runSync('git', ['config', '--get',
-      `remote.${upstream}.url`]);
-    let warned = false;
-    try {
-      const { hostname, pathname } = new URL(upstreamHref);
-      if (hostname !== 'github.com') {
-        warned = true;
-        cli.warn('Remote repository URL does not point to the expected ' +
-          'host "github.com"');
-      }
-      if (new RegExp(`^/${owner}/${repo}(?:.git)?$`).test(pathname) !== true) {
-        warned = true;
-        cli.warn('Remote repository URL does not point to the expected ' +
-          `repository /${owner}/${repo}`);
-      }
-    } catch (e) {
-      warned = true;
-      cli.warn('Could not parse remote repository URL %j, this might be ' +
-        'because it is not a HTTPS URL', upstreamHref);
-    }
-    if (warned) {
-      cli.warn('You might want to change the remote repository URL with ' +
-        `\`git remote set-url ${
-          upstream
-        } "https://github.com/${owner}/${repo}"\``);
+    const upstreamHref = runSync('git', [
+      'config', '--get',
+      `remote.${upstream}.url`]).trim();
+    if (!upstreamHref.endsWith(`${owner}/${repo}.git`)) {
+      cli.warn('Remote repository URL does not point to the expected ' +
+        `repository ${owner}/${repo}`);
     }
   }
 

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -18,7 +18,7 @@ class LandingSession extends Session {
     const upstreamHref = runSync('git', [
       'config', '--get',
       `remote.${upstream}.url`]).trim();
-    if (!upstreamHref.endsWith(`${owner}/${repo}.git`)) {
+    if (!new RegExp(`${owner}/${repo}(?:.git)?$`).test(upstreamHref)) {
       cli.warn('Remote repository URL does not point to the expected ' +
         `repository ${owner}/${repo}`);
     }


### PR DESCRIPTION
It currently outputs a warning for SSH urls because WHATWG URL does not support that. Also does not trim the output from `git config` so there might be false warnings. This might create confusion to users who have SSH urls since we do not disencourage that in core.

Update to only check the owner and repo instead.