### PR TITLE
git-node: don't check for wrong branch in --amend or --continue

### DIFF
--- a/components/git/land.js
+++ b/components/git/land.js
@@ -103,7 +103,10 @@ module.exports = {
 
 async function main(state, argv, cli, req, dir) {
   let session = new LandingSession(cli, req, dir);
-  if (session.warnForMissing() || session.warnForWrongBranch()) {
+  if (session.warnForMissing()) {
+    return;
+  }
+  if (state !== AMEND && state !== CONTINUE && session.warnForWrongBranch()) {
     return;
   }
 


### PR DESCRIPTION
When running `git node land --amend` from the command line, the HEAD is usually detached anyway (in the middle of a rebase), so there is no need to check the current branch.