### PR TITLE
metadata: remove file hashes from passed url

### DIFF
--- a/components/git/metadata.js
+++ b/components/git/metadata.js
@@ -63,6 +63,9 @@ const PR_RE = new RegExp(
   '([0-9]+)(?:/(?:files)?)?$');
 
 function handler(argv) {
+  // remove hashes from PR link
+  argv.identifier = argv.identifier.replace(/#.*$/, '');
+
   const parsed = {};
   const prid = Number.parseInt(argv.identifier);
   if (!Number.isNaN(prid)) {


### PR DESCRIPTION
The `/files` at the end of URL is handled by `PR_RE` already, so this pr just removes hashes is passed as url.