### PR TITLE
lib,src: fixes for Windows and error output

### DIFF
--- a/bin/get-metadata
+++ b/bin/get-metadata
@@ -5,4 +5,4 @@ const path = require('path');
 const { runAsync } = require('../lib/run');
 
 const script = path.join(__dirname, 'git-node');
-runAsync(script, ['metadata'].concat(process.argv.slice(2)));
+runAsync(process.execPath, [script, 'metadata', ...process.argv.slice(2)]);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -127,7 +127,9 @@ class CLI {
     if (obj instanceof Error) {
       this.log(`${prefix}${error}  ${obj.message}`);
       this.log(`${obj.stack}`);
-      this.log(`${JSON.stringify(obj.data, null, 2).replace(/\n/g, EOL)}`);
+      if (obj.data) {
+        this.log(`${JSON.stringify(obj.data, null, 2).replace(/\n/g, EOL)}`);
+      }
     } else {
       this.log(`${prefix}${error}  ${obj}`);
     }


### PR DESCRIPTION
* On Windows the node executable needs to be explicitly invoked.
* Make sure the data property exists before trying to use it when
  printing error output.