### PR TITLE
fix landed in message for multiple commits

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -244,7 +244,7 @@ class LandingSession extends Session {
 
   getUpstreamHead(verbose) {
     const { upstream, branch } = this;
-    return runSync('git', ['rev-parse', `${upstream}/${branch}^1`]).trim();
+    return runSync('git', ['rev-parse', `${upstream}/${branch}`]).trim();
   }
 
   async tryAbortAm() {


### PR DESCRIPTION
`getUpstreamHead` should return the last remote commit, no the one before it.

Fixes: https://github.com/nodejs/node-core-utils/issues/216