### PR TITLE
lib: fix XDG_CONFIG_HOME not being set

### DIFF
--- a/lib/ncurc_path.js
+++ b/lib/ncurc_path.js
@@ -2,7 +2,8 @@ const path = require('path');
 const os = require('os');
 
 function getNcurcPath() {
-  if (process.env.XDG_CONFIG_HOME !== 'undefined') {
+  if (process.env.XDG_CONFIG_HOME !== 'undefined' &&
+      process.env.XDG_CONFIG_HOME !== undefined) {
     return path.join(process.env.XDG_CONFIG_HOME, 'ncurc');
   } else {
     return path.join(os.homedir(), '.ncurc');


### PR DESCRIPTION
`git-node` is currently broken if `XDG_CONFIG_HOME` is not set becauseit's a real `undefined` if it's not set in the environment (whereas in tests, where it's explicitly set undefined, it will be coerced to `'undefined'`).