### PR TITLE
pr_checker: consider LITE CI as a ci requirement

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -19,7 +19,7 @@ const {
 
 const CIParser = require('./ci');
 const CI_TYPES = CIParser.TYPES;
-const { FULL } = CIParser.constants;
+const { FULL, LITE } = CIParser.constants;
 
 class PRChecker {
   /**
@@ -203,9 +203,9 @@ class PRChecker {
       cli.error('No CI runs detected');
       this.CIStatus = false;
       return false;
-    } else if (!ciMap.get(FULL)) {
+    } else if (!ciMap.get(FULL) && !ciMap.get(LITE)) {
       status = false;
-      cli.error('No full CI runs detected');
+      cli.error('No full CI runs or lite CI runs detected');
     }
 
     let lastCI;

--- a/test/fixtures/comments_with_lite_ci.json
+++ b/test/fixtures/comments_with_lite_ci.json
@@ -1,0 +1,6 @@
+[
+  {
+    "publishedAt": "2018-02-09T21:38:30Z",
+    "bodyText": "CI: https://ci.nodejs.org/job/node-test-commit-lite/246/"
+  }
+]

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -23,6 +23,7 @@ const requestedChangesReviewers = {
 const approvingReviews = readJSON('reviews_approved.json');
 const requestingChangesReviews = readJSON('reviews_requesting_changes.json');
 
+const commentsWithLiteCI = readJSON('comments_with_lite_ci.json');
 const commentsWithCI = readJSON('comments_with_ci.json');
 const commentsWithLGTM = readJSON('comments_with_lgtm.json');
 
@@ -79,6 +80,7 @@ module.exports = {
   approvingReviews,
   requestingChangesReviews,
   commentsWithCI,
+  commentsWithLiteCI,
   commentsWithLGTM,
   oddCommits,
   incorrectGitConfigCommits,

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -13,6 +13,7 @@ const {
   approvingReviews,
   requestingChangesReviews,
   commentsWithCI,
+  commentsWithLiteCI,
   commentsWithLGTM,
   singleCommitAfterReview,
   multipleCommitsAfterReview,
@@ -546,6 +547,33 @@ describe('PRChecker', () => {
 
       const status = checker.checkCI();
       assert(!status);
+      cli.assertCalledWith(expectedLogs);
+    });
+
+    it('should count LITE CI as valid ci requirement', () => {
+      const cli = new TestCLI();
+
+      const expectedLogs = {
+        info: [
+          [
+            'Last Lite CI on 2018-02-09T21:38:30Z: ' +
+            'https://ci.nodejs.org/job/node-test-commit-lite/246/'
+          ]
+        ]
+      };
+
+      const checker = new PRChecker(cli, {
+        pr: firstTimerPR,
+        reviewers: allGreenReviewers,
+        comments: commentsWithLiteCI,
+        reviews: approvingReviews,
+        commits: [],
+        collaborators,
+        authorIsNew: () => true
+      }, { maxCommits: 0 });
+
+      const status = checker.checkCI();
+      assert(status);
       cli.assertCalledWith(expectedLogs);
     });
   });


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-core-utils/issues/225