### PR TITLE
lib: don't print dash for users without names

### DIFF
--- a/lib/team_info.js
+++ b/lib/team_info.js
@@ -9,6 +9,7 @@ function byLogin(a, b) {
 }
 
 function getContact({login, url, name, email}) {
+  if (!name) return `- [@${login}](${url})`;
   return `- [@${login}](${url}) - ${name}`;
 }
 


### PR DESCRIPTION
when logging team data we currently include a dash between
the profile name / link and the account name. If the account
name is blank, we still include the dash. This patch changes
the behavior to remove the dash in cases that the name
is blank.