### PR TITLE
git-node v8: add --v8-dir option

### DIFF
--- a/components/git/v8.js
+++ b/components/git/v8.js
@@ -50,6 +50,9 @@ module.exports = {
         describe: 'Directory where V8 should be cloned',
         default: constants.defaultBaseDir
       })
+      .option('v8-dir', {
+        describe: 'Directory of an existing V8 clone'
+      })
       .option('verbose', {
         describe: 'Enable verbose output',
         boolean: true,
@@ -63,19 +66,24 @@ function main(argv) {
   const options = Object.assign({}, argv);
   options.nodeDir = path.resolve(options.nodeDir);
   options.baseDir = path.resolve(options.baseDir);
-  options.v8CloneDir = path.join(options.baseDir, 'v8');
+  if (!options.v8Dir) {
+    options.v8Dir = path.join(options.baseDir, 'v8');
+  } else {
+    options.v8Dir = path.resolve(options.v8Dir);
+  }
 
   options.execGitNode = function execGitNode(...args) {
     return execa('git', args, { cwd: options.nodeDir });
   };
   options.execGitV8 = function execGitV8(...args) {
-    return execa('git', args, { cwd: options.v8CloneDir });
+    return execa('git', args, { cwd: options.v8Dir });
   };
 
   Promise.resolve()
     .then(async() => {
       await common.checkCwd(options);
-      const kind = argv._[0];
+      // First element of argv is 'v8'
+      const kind = argv._[1];
       options[kind] = true;
       switch (kind) {
         case 'minor':

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -197,6 +197,11 @@ Defaults to current working directory.
 Specify the path where V8 the clone will be maintained.  
 Defaults to `~/.update-v8`.
 
+##### `--v8-dir=/path/to/v8/`
+
+Specify the path of an existing V8 clone. This will be used instead of cloning
+V8 to `baseDir`.
+
 ##### `--verbose`
 
 Enable verbose output.

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -85,7 +85,7 @@ function cloneLocalV8() {
   return {
     title: 'Clone branch to deps/v8',
     task: (ctx) =>
-      execa('git', ['clone', '-b', ctx.branch, ctx.v8CloneDir, 'deps/v8'], {
+      execa('git', ['clone', '-b', ctx.branch, ctx.v8Dir, 'deps/v8'], {
         cwd: ctx.nodeDir
       })
   };

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -27,7 +27,7 @@ function getLatestV8Version() {
     task: async(ctx) => {
       const currentV8Tag = ctx.currentVersion.slice(0, 3).join('.');
       let tags = await execa.stdout('git', ['tag', '-l', `${currentV8Tag}.*`], {
-        cwd: ctx.v8CloneDir
+        cwd: ctx.v8Dir
       });
       tags = toSortedArray(tags);
       ctx.latestVersion = tags[0];
@@ -61,7 +61,7 @@ async function doMinorUpdate(ctx, latestStr) {
   const diff = await execa.stdout(
     'git',
     ['format-patch', '--stdout', `${currentStr}...${latestStr}`],
-    { cwd: ctx.v8CloneDir }
+    { cwd: ctx.v8Dir }
   );
   try {
     await execa('git', ['apply', '--directory', 'deps/v8'], {

--- a/lib/update-v8/updateV8Clone.js
+++ b/lib/update-v8/updateV8Clone.js
@@ -20,7 +20,7 @@ function fetchOrigin() {
     title: 'Fetch V8',
     task: async(ctx, task) => {
       try {
-        await execa('git', ['fetch', 'origin'], { cwd: ctx.v8CloneDir });
+        await execa('git', ['fetch', 'origin'], { cwd: ctx.v8Dir });
       } catch (e) {
         if (e.code === 'ENOENT') {
           ctx.shouldClone = true;


### PR DESCRIPTION
Allows to specify the location of an existing V8 clone. This avoids
having to create a separate clone just for this tool.

Also fixes the git-node v8 command. `argv` was not read correctly.

Fixes: https://github.com/nodejs/node-core-utils/issues/238