### PR TITLE
ci: parse CI links after sorting the comments by publishedDate

### DIFF
--- a/lib/ci/ci_type_parser.js
+++ b/lib/ci/ci_type_parser.js
@@ -2,6 +2,7 @@
 
 const { parsePRFromURL } = require('../links');
 const PRData = require('../pr_data');
+const { ascending } = require('../comp');
 
 const CI_URL_RE = /\/\/ci\.nodejs\.org(\S+)/mg;
 const CI_DOMAIN = 'ci.nodejs.org';
@@ -141,7 +142,9 @@ class JobParser {
    * @param {{bodyText: string, publishedAt: string}[]} thread
    */
   constructor(thread) {
-    this.thread = thread;
+    this.thread = thread.sort(
+      (a, b) => ascending(a.publishedAt, b.publishedAt)
+    );
   }
 
   /**
@@ -155,14 +158,13 @@ class JobParser {
       if (!text.includes(CI_DOMAIN)) continue;
       const jobs = this.parseText(text);
       for (const job of jobs) {
-        const entry = result.get(job.type);
-        if (!entry || entry.date < c.publishedAt) {
-          result.set(job.type, {
-            link: job.link,
-            date: c.publishedAt,
-            jobid: job.jobid
-          });
-        }
+        // Always take the last one
+        // TODO(joyeecheung): exlcude links wrapped in `<del>`
+        result.set(job.type, {
+          link: job.link,
+          date: c.publishedAt,
+          jobid: job.jobid
+        });
       }
     }
     return result;

--- a/test/fixtures/comments_with_ci.json
+++ b/test/fixtures/comments_with_ci.json
@@ -1,32 +1,34 @@
 [
   {
-    "publishedAt": "2017-10-27T04:16:36.458Z",
+    "publishedAt": "2017-10-22T04:16:36.458Z",
     "bodyText": "CI: https://ci.nodejs.org/job/node-test-pull-request/10984/\ncitgm: https://ci.nodejs.org/job/citgm-smoker/1030/"
   },
   {
-    "publishedAt": "2017-10-24T04:16:36.458Z",
+    "publishedAt": "2017-10-23T04:16:36.458Z",
     "bodyText": "https://ci.nodejs.org/job/libuv-test-commit/537/"
   },
   {
-    "publishedAt": "2017-10-23T04:16:36.458Z",
+    "publishedAt": "2017-10-24T04:16:36.458Z",
     "bodyText": "https://ci.nodejs.org/job/node-test-commit-nointl/7/"
   },
   {
-    "publishedAt": "2017-10-22T04:16:36.458Z",
-    "bodyText": "CI: https://ci.nodejs.org/job/node-test-pull-request/10992/\nV8 CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/1018/"
+    "publishedAt": "2017-10-25T04:16:36.458Z",
+    "bodyText": "<del>CI: https://ci.nodejs.org/job/node-test-pull-request/10991/\n</del>\nCI: https://ci.nodejs.org/job/node-test-pull-request/10992/\nV8 CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/1018/"
   },
   {
-    "publishedAt": "2017-10-21T04:16:36.458Z",
+    "publishedAt": "2017-10-26T04:16:36.458Z",
     "bodyText": "Oh nice, it's back now. Benchmark CI: https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/20/"
   },
   {
-    "publishedAt": "2017-10-22T04:16:36.458Z",
+    "publishedAt": "2017-10-27T04:16:36.458Z",
     "bodyText": "Linter CI: https://ci.nodejs.org/job/node-test-linter/13127/"
-  },{
-    "publishedAt": "2018-02-09T21:38:30Z",
+  },
+  {
+    "publishedAt": "2017-10-28T04:16:36.458Z",
     "bodyText": "CI https://ci.nodejs.org/job/node-test-commit-lite/246/"
-  },{
-    "publishedAt": "2017-10-21T04:16:36.458Z",
+  },
+  {
+    "publishedAt": "2017-10-29T04:16:36.458Z",
     "bodyText": "@contributer build started: https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/7213/pipeline/"
   }
 ]

--- a/test/unit/ci_type_parser.test.js
+++ b/test/unit/ci_type_parser.test.js
@@ -11,48 +11,48 @@ const {
 
 const expected = new Map([
   ['PR', {
-    link: 'https://ci.nodejs.org/job/node-test-pull-request/10984/',
-    date: '2017-10-27T04:16:36.458Z',
-    jobid: 10984
+    link: 'https://ci.nodejs.org/job/node-test-pull-request/10992/',
+    date: '2017-10-25T04:16:36.458Z',
+    jobid: 10992
   }],
   ['CITGM', {
     link: 'https://ci.nodejs.org/job/citgm-smoker/1030/',
-    date: '2017-10-27T04:16:36.458Z',
+    date: '2017-10-22T04:16:36.458Z',
     jobid: 1030
   }],
   ['LIBUV', {
     link: 'https://ci.nodejs.org/job/libuv-test-commit/537/',
-    date: '2017-10-24T04:16:36.458Z',
+    date: '2017-10-23T04:16:36.458Z',
     jobid: 537
   }],
   ['NOINTL', {
     link: 'https://ci.nodejs.org/job/node-test-commit-nointl/7/',
-    date: '2017-10-23T04:16:36.458Z',
+    date: '2017-10-24T04:16:36.458Z',
     jobid: 7
   }],
   ['V8', {
     link: 'https://ci.nodejs.org/job/node-test-commit-v8-linux/1018/',
-    date: '2017-10-22T04:16:36.458Z',
+    date: '2017-10-25T04:16:36.458Z',
     jobid: 1018
   }],
   ['BENCHMARK', {
     link: 'https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/20/',
-    date: '2017-10-21T04:16:36.458Z',
+    date: '2017-10-26T04:16:36.458Z',
     jobid: 20
   }],
   ['LINTER', {
     link: 'https://ci.nodejs.org/job/node-test-linter/13127/',
-    date: '2017-10-22T04:16:36.458Z',
+    date: '2017-10-27T04:16:36.458Z',
     jobid: 13127
   }],
   ['LITE_COMMIT', {
     link: 'https://ci.nodejs.org/job/node-test-commit-lite/246/',
-    date: '2018-02-09T21:38:30Z',
+    date: '2017-10-28T04:16:36.458Z',
     jobid: 246
   }],
   ['LITE_PR_PIPELINE', {
     link: 'https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/7213/pipeline/',
-    date: '2017-10-21T04:16:36.458Z',
+    date: '2017-10-29T04:16:36.458Z',
     jobid: 7213
   }]
 ]);

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -427,39 +427,39 @@ describe('PRChecker', () => {
       const expectedLogs = {
         info: [
           [
-            'Last Full PR CI on 2017-10-27T04:16:36.458Z: ' +
-            'https://ci.nodejs.org/job/node-test-pull-request/10984/'
+            'Last Full PR CI on 2017-10-25T04:16:36.458Z: ' +
+            'https://ci.nodejs.org/job/node-test-pull-request/10992/'
           ],
           [
-            'Last CITGM CI on 2017-10-27T04:16:36.458Z: ' +
+            'Last CITGM CI on 2017-10-22T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/citgm-smoker/1030/'
           ],
           [
-            'Last libuv CI on 2017-10-24T04:16:36.458Z: ' +
+            'Last libuv CI on 2017-10-23T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/libuv-test-commit/537/'
           ],
           [
-            'Last No Intl CI on 2017-10-23T04:16:36.458Z: ' +
+            'Last No Intl CI on 2017-10-24T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/node-test-commit-nointl/7/'
           ],
           [
-            'Last V8 CI on 2017-10-22T04:16:36.458Z: ' +
+            'Last V8 CI on 2017-10-25T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/node-test-commit-v8-linux/1018/'
           ],
           [
-            'Last Benchmark CI on 2017-10-21T04:16:36.458Z: ' +
+            'Last Benchmark CI on 2017-10-26T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/benchmark-node-micro-benchmarks/20/'
           ],
           [
-            'Last Linter CI on 2017-10-22T04:16:36.458Z: ' +
+            'Last Linter CI on 2017-10-27T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/node-test-linter/13127/'
           ],
           [
-            'Last Lite Commit CI on 2018-02-09T21:38:30Z: ' +
+            'Last Lite Commit CI on 2017-10-28T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/node-test-commit-lite/246/'
           ],
           [
-            'Last Lite PR Pipeline CI on 2017-10-21T04:16:36.458Z: ' +
+            'Last Lite PR Pipeline CI on 2017-10-29T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/7213/pipeline/'
           ]
         ]


### PR DESCRIPTION
This helps newer CI runs take precedence over old ones if they
are posted in the same comment (usually done when someone
use `<del>` to delete a bad build in the comment
to avoid multiple notifications)