### PR TITLE
git-node: message to do rebase/am before final

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -202,6 +202,8 @@ class LandingSession extends Session {
 
     if (!this.readyToFinal()) {  // check git rebase/am has been done
       cli.warn('Not yet ready to final');
+      cli.log('A git rebase/am is in progress.' +
+        ' Please complete it before running final');
       return;
     };
 

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -203,7 +203,7 @@ class LandingSession extends Session {
     if (!this.readyToFinal()) {  // check git rebase/am has been done
       cli.warn('Not yet ready to final');
       cli.log('A git rebase/am is in progress.' +
-        ' Please complete it before running final');
+        ' Please complete it before running git node land --final');
       return;
     };
 


### PR DESCRIPTION
The command final fails if am/rebase is in progress:

https://github.com/nodejs/node-core-utils/blob/c848152f6d19135e032fbf77b468780f64404f0e/lib/session.js#L184-L189

This PR adds a message to inform the user to complete exiting am/rebase before running final