### PR TITLE
package: fix lint script for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "coverage": "nyc --reporter=html --reporter=text --reporter=text-summary npm test",
     "coverage-all": "nyc --reporter=lcov --reporter=text --reporter=text-summary npm run test-all",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
-    "lint": "eslint . 'bin/*' --cache",
-    "lint-fix": "eslint . 'bin/*' --fix"
+    "lint": "eslint . \"bin/*\" --cache",
+    "lint-fix": "eslint . \"bin/*\" --fix"
   },
   "author": "Joyee Cheung <joyeec9h3@gmail.com>",
   "repository": {


### PR DESCRIPTION
Fixes this error:

```
PS D:\Documents\GitHub\nodejs\node-core-utils> npm run lint

> node-core-utils@1.16.0 lint D:\Documents\GitHub\nodejs\node-core-utils
> eslint . 'bin/*' --cache


Oops! Something went wrong! :(

ESLint: 5.9.0.
No files matching the pattern "'bin/*'" were found.
Please check for typing mistakes in the pattern.
```