### PR TITLE
pr_checker: report minutes left if less than an hour

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -141,9 +141,9 @@ class PRChecker {
     }
 
     const createTime = new Date(this.pr.createdAt);
-    const hoursFromCreateTime = Math.ceil(
-      (now.getTime() - createTime.getTime()) / HOUR
-    );
+    const msFromCreateTime = now.getTime() - createTime.getTime();
+    const minutesFromCreateTime = Math.ceil(msFromCreateTime / MINUTE);
+    const hoursFromCreateTime = Math.ceil(msFromCreateTime / HOUR);
     let timeLeftMulti = WAIT_TIME_MULTI_APPROVAL - hoursFromCreateTime;
     const timeLeftSingle = WAIT_TIME_SINGLE_APPROVAL - hoursFromCreateTime;
 
@@ -153,6 +153,12 @@ class PRChecker {
       }
       if (timeLeftMulti < 0) {
         return true;
+      }
+      if (timeLeftMulti === 0) {
+        const timeLeftMins =
+          WAIT_TIME_MULTI_APPROVAL * 60 - minutesFromCreateTime;
+        cli.error(`This PR needs to wait ${timeLeftMins} more minutes to land`);
+        return false;
       }
       cli.error(`This PR needs to wait ${timeLeftMulti} more hours to land`);
       return false;


### PR DESCRIPTION
Provides a bit more granularity than:
`This PR needs to wait 0 more hours to land`
if trying to land around the 48 hour mark with enough approvals.