### PR TITLE
session: don't call new upstream commits "stray"

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -299,7 +299,8 @@ class Session {
     if (!stray.length) {
       return;
     }
-    cli.log(`Found new commits in ${branchName}:\n` +
+    cli.log(`${branch} is out of sync with ${branchName}. ` +
+            'Mismatched commits:\n' +
       ` - ${stray.join('\n - ')}`);
     const shouldReset = await cli.prompt(`Reset to ${branchName}?`);
     if (shouldReset) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -299,7 +299,7 @@ class Session {
     if (!stray.length) {
       return;
     }
-    cli.log(`Found stray commits in ${branchName}:\n` +
+    cli.log(`Found new commits in ${branchName}:\n` +
       ` - ${stray.join('\n - ')}`);
     const shouldReset = await cli.prompt(`Reset to ${branchName}?`);
     if (shouldReset) {


### PR DESCRIPTION
Stray means to wander away from the right place or group, but upstream
commits are exactly where they should be, ready to be pulled. Use "new"
instead of "stray" to describe them.