### PR TITLE
chore: fix invalid inline .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ recommended to leave your tokens in your command line history.
 Put the following entries into `~/.gitignore_global`
 
 ```
-.ncurc  # node-core-utils configuration file
-.ncu    # node-core-utils working directory
+# node-core-utils configuration file
+.ncurc
+# node-core-utils working directory
+.ncu
 ```
 
 Mind that`.ncu/land` could contain your access token since it contains the


### PR DESCRIPTION
When I copied these line into `.gitignore_global`, I found it didn't work well.

https://github.com/nodejs/node-core-utils#make-sure-your-credentials-wont-be-committed
```
.ncurc  # node-core-utils configuration file
.ncu    # node-core-utils working directory
```

Then I found these from stackoverflow.com:
https://stackoverflow.com/a/46477624/8102333


![screen shot 2019-03-08 at 10 16 15 pm](https://user-images.githubusercontent.com/23313266/54034007-cdaaf380-41f0-11e9-9f46-590c669a81a8.png)
![screen shot 2019-03-08 at 10 16 24 pm](https://user-images.githubusercontent.com/23313266/54034009-cdaaf380-41f0-11e9-9410-d34124ebc3aa.png)


It seems that `.gitignore` wouldn't work if having inline comments, so I move comments to separate lines.

