### PR TITLE
package: update nyc to 14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "intelli-espower-loader": "^1.0.1",
     "mocha": "^6.0.2",
-    "nyc": "^13.3.0",
+    "nyc": "^14.0.0",
     "power-assert": "^1.6.1",
     "sinon": "^7.3.1"
   }


### PR DESCRIPTION
It's not a big deal, because these "vulnerabilities" are only in dev deps, but might as well update.

There is another "vulnerability" in js-yaml is via mocha, https://github.com/nodejs/security-wg/issues/520, but it has to be fixed there because mocha is pinning its dependency's versions.