### PR TITLE
test: create Mocha config file; remove unneeded "exit" option

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "require": "intelli-espower-loader"
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "test": "npm run test-unit && npm run lint",
-    "test-unit": "mocha --require intelli-espower-loader test/unit/*.test.js --exit",
-    "test-all": "mocha --require intelli-espower-loader test/**/*.test.js --exit",
+    "test-unit": "mocha test/unit/*.test.js",
+    "test-all": "mocha test/**/*.test.js",
     "coverage": "nyc --reporter=html --reporter=text --reporter=text-summary npm test",
     "coverage-all": "nyc --reporter=lcov --reporter=text --reporter=text-summary npm run test-all",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",


### PR DESCRIPTION
- Created `.mocharc.json` where current & future flags/options can be placed
- Removed the `exit` option.  Recommended practice is to only use `--exit` if a) your test process won't quit without it, and b) it's too difficult or time-consuming to fix your tests to cleanup properly.  Since the test process exits cleanly, I removed it.