### PR TITLE
lib: change order of "Post in" message

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -213,7 +213,7 @@ class LandingSession extends Session {
     cli.log('To finish landing:');
     cli.log(`1. Run \`git push ${upstream} ${branch}\``);
     const url = `https://github.com/${owner}/${repo}/pull/${prid}`;
-    cli.log(`2. Post \`Landed in ${willBeLanded}\` in ${url}`);
+    cli.log(`2. Post "Landed in ${willBeLanded}" in ${url}`);
 
     const shouldClean = await cli.prompt('Clean up generated temporary files?');
     if (shouldClean) {

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -213,7 +213,7 @@ class LandingSession extends Session {
     cli.log('To finish landing:');
     cli.log(`1. Run \`git push ${upstream} ${branch}\``);
     const url = `https://github.com/${owner}/${repo}/pull/${prid}`;
-    cli.log(`2. Post in ${url}: \`Landed in ${willBeLanded}\``);
+    cli.log(`2. Post \`Landed in ${willBeLanded}\` in ${url}`);
 
     const shouldClean = await cli.prompt('Clean up generated temporary files?');
     if (shouldClean) {


### PR DESCRIPTION
Change order to be slightly more consistent with previous message,
and so that the URL of the PR does not have to be followed directly
by a `:`. Some terminals consider the `:` to be part of the URL,
so clicking on it ends up on an invalid github page. Rearranging the
message so the URL is bounded by whitespace should work with all
terminals, and is no less readable.