### PR TITLE
v8: fix NODE_MODULE_VERSION bump

### DIFF
--- a/components/git/v8.js
+++ b/components/git/v8.js
@@ -24,7 +24,7 @@ module.exports = {
             default: 'lkgr'
           });
           yargs.option('version-bump', {
-            describe: 'Bump the NODE_MODULE_VERSION constant by one',
+            describe: 'Bump the NODE_MODULE_VERSION constant',
             default: true
           });
         }

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -256,7 +256,7 @@ modifying yoru `PATH` environment variable).
 
 - Replaces `deps/v8` with a newer major version.
 - Resets the embedder version number to `-node.0`.
-- Updates `NODE_MODULE_VERSION` according to the V8 version.
+- Bumps `NODE_MODULE_VERSION` according to the [Node.js ABI version registry][].
 
 Options:
 
@@ -314,3 +314,5 @@ to the assets, this also updates:
 $ cd /path/to/node/project
 $ git node wpt url  # Will update test/fixtures/wpt/url and related files
 ```
+
+[node.js abi version registry]: https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -21,10 +21,17 @@ function bumpNodeModule() {
     title: 'Bump NODE_MODULE_VERSION',
     task: async(ctx) => {
       const v8Version = util.getNodeV8Version(ctx.nodeDir);
-      const currentModuleVersion = getModuleVersion(ctx.nodeDir);
-      const newModuleVersion = currentModuleVersion + 1;
-      updateModuleVersion(ctx.nodeDir, newModuleVersion, v8Version);
-      await ctx.execGitNode('add', 'src/node_version.h');
+      const newModuleVersion = await updateModuleVersionRegistry(
+        ctx.nodeDir,
+        v8Version,
+        ctx.nodeMajorVersion
+      );
+      await updateModuleVersion(ctx.nodeDir, newModuleVersion, v8Version);
+      await ctx.execGitNode(
+        'add',
+        'doc/abi_version_registry.json',
+        'src/node_version.h'
+      );
       await ctx.execGitNode(
         'commit',
         '-m',
@@ -37,25 +44,35 @@ function bumpNodeModule() {
   };
 }
 
-function getModuleVersion(nodeDir) {
-  const nodeVersionH = fs.readFileSync(`${nodeDir}/src/node_version.h`, 'utf8');
-  const version = /NODE_MODULE_VERSION (\d+)/.exec(nodeVersionH)[1];
-  return parseInt(version, 10);
+async function updateModuleVersionRegistry(
+  nodeDir,
+  v8Version,
+  nodeMajorVersion
+) {
+  const registryFile = `${nodeDir}/doc/abi_version_registry.json`;
+  const registryStr = await fs.readFile(registryFile, 'utf8');
+  const registry = JSON.parse(registryStr);
+  const newVersion = registry.NODE_MODULE_VERSION[0].modules + 1;
+  const newLine =
+    `{ "modules": ${newVersion}, "runtime": "node", ` +
+    `"variant": "v8_${v8Version[0]}.${v8Version[1]}", ` +
+    `"versions": "${nodeMajorVersion}.0.0-pre" },\n    `;
+  const firstLineIndex = registryStr.indexOf('{ "modules"');
+  const newRegistry =
+    registryStr.substring(0, firstLineIndex) +
+    newLine +
+    registryStr.substring(firstLineIndex);
+  await fs.writeFile(registryFile, newRegistry);
+  return newVersion;
 }
 
-const v8VerReg = / * V8 \d+\.\d+: \d+/g;
-function updateModuleVersion(nodeDir, newVersion, v8Version) {
+async function updateModuleVersion(nodeDir, newVersion) {
   const path = `${nodeDir}/src/node_version.h`;
   let nodeVersionH = fs.readFileSync(path, 'utf8');
   nodeVersionH = nodeVersionH.replace(
     /NODE_MODULE_VERSION \d+/,
     `NODE_MODULE_VERSION ${newVersion}`
   );
-  let index = -1;
-  while (v8VerReg.exec(nodeVersionH)) index = v8VerReg.lastIndex;
-  nodeVersionH = `${nodeVersionH.substring(0, index)}\n * V8 ${v8Version[0]}.${
-    v8Version[1]
-  }: ${newVersion}${nodeVersionH.substring(index)}`;
   fs.writeFileSync(path, nodeVersionH);
 }
 


### PR DESCRIPTION
Use abi_version_registry.json as a reference and update it.

/cc @refack @ryzokuken 