### PR TITLE
git-node: add a prompt for force landing commits with invalid message

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -196,7 +196,23 @@ class LandingSession extends Session {
       __dirname,
       '../node_modules/.bin/core-validate-commit' + (isWindows ? '.cmd' : '')
     );
-    await runAsync(validateCommand, stray);
+
+    try {
+      await forceRunAsync(validateCommand, stray, { ignoreFailure: false });
+    } catch (e) {
+      let forceLand = false;
+      if (e.code === 1) {
+        forceLand = await cli.prompt(
+          'The commit did not pass the validation. ' +
+          'Do you still want to land it?',
+          false);
+      }
+
+      if (!forceLand) {
+        cli.info('Please fix the commit message and try again.');
+        process.exit(1);
+      }
+    }
 
     cli.separator();
     cli.log('The following commits are ready to be pushed to ' +


### PR DESCRIPTION
Makes it possible to land a commit that does not pass
the core-validate-commit checks in case there is a bug
in the validator.