### PR TITLE
ncu-ci: parse console text of the first failed phase

### DIFF
--- a/lib/ci/ci_result_parser.js
+++ b/lib/ci/ci_result_parser.js
@@ -37,7 +37,6 @@ const FAILURE = 'FAILURE';
 const ABORTED = 'ABORTED';
 const UNSTABLE = 'UNSTABLE';
 
-const TEST_PHASE = 'Binary Tests';
 // com.tikal.jenkins.plugins.multijob.MultiJobBuild
 const BUILD_FIELDS = 'builtOn,buildNumber,jobName,result,url';
 const ACTION_TREE = 'actions[parameters[name,value]]';
@@ -733,18 +732,6 @@ class FannedBuild extends Job {
 
     if (!failedPhase) {
       return this.parseConsoleText();
-    }
-
-    if (failedPhase.phaseName !== TEST_PHASE &&
-        !failedPhase.phaseName.toLowerCase().includes('compilation')) {
-      this.failures = [
-        new BuildFailure(
-          { url: failedPhase.url },
-          `Failed in ${failedPhase.phaseName} phase (${failedPhase.jobName})`
-          // TODO: parse console text for the failed phase
-        )
-      ];
-      return this.failures;
     }
 
     const { jobName, buildNumber } = failedPhase;


### PR DESCRIPTION
Previously we try to detect the type of the failed phase
and return a generic build failure when the job failed in a
non-test phase. This is not really necessary - the console
text parser is capable of detecting the actual build failure
from even the console text of the build phase. Also hard-coding
the test phase name makes the detection fragile when there
are configuration changes in the Jenkins. So we should just
skip the detection.

Fixes: https://github.com/nodejs/node-core-utils/issues/344