### PR TITLE
ncu-team: make sync report missing or empty files

### DIFF
--- a/lib/team_info.js
+++ b/lib/team_info.js
@@ -53,6 +53,10 @@ class TeamInfo {
 TeamInfo.syncFile = async function(cli, request, input, output) {
   output = output || input;
   const content = readFile(input);
+  if (content === '') {
+    cli.error('input file `' + input + '` is empty or missing');
+    process.exit(1);
+  }
   const newContent = await TeamInfo.update(cli, request, content);
   writeFile(output, newContent);
   cli.log(`Updated ${output}`);


### PR DESCRIPTION
It can't distinguish between the two, but I get sent on a roundabout
error hunt when ncu-team reported that it couldn't find the correct
line in my file, when actually the file name was misspelled and it
was trying to match against an empty string.