### PR TITLE
pr_checker: report when the PR was closed

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -368,17 +368,19 @@ class PRChecker {
 
   checkPRState() {
     const {
-      pr: { closed, merged },
+      pr: { closed, closedAt, merged, mergedAt },
       cli
     } = this;
 
     if (merged) {
-      cli.warn('This PR is merged');
+      const dateStr = new Date(mergedAt).toUTCString();
+      cli.warn(`This PR was merged on ${dateStr}`);
       return false;
     }
 
     if (closed) {
-      cli.warn('This PR is closed');
+      const dateStr = new Date(closedAt).toUTCString();
+      cli.warn(`This PR was closed on ${dateStr}`);
       return false;
     }
 

--- a/lib/queries/PR.gql
+++ b/lib/queries/PR.gql
@@ -24,7 +24,9 @@ query PR($prid: Int!, $owner: String!, $repo: String!) {
       changedFiles,
       mergeable,
       closed,
-      merged
+      closedAt,
+      merged,
+      mergedAt
     }
   }
 }

--- a/test/fixtures/closed_pr.json
+++ b/test/fixtures/closed_pr.json
@@ -20,5 +20,7 @@
   "baseRefName": "master",
   "headRefName": "awesome-changes",
   "closed": true,
-  "merged": false
+  "closedAt": "2017-10-28T11:13:43Z",
+  "merged": false,
+  "mergedAt": null
 }

--- a/test/fixtures/merged_pr.json
+++ b/test/fixtures/merged_pr.json
@@ -20,5 +20,7 @@
   "baseRefName": "master",
   "headRefName": "awesome-changes",
   "closed": true,
-  "merged": true
+  "closedAt": "2017-10-28T11:13:43Z",
+  "merged": true,
+  "mergedAt": "2017-10-28T11:13:43Z"
 }

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -1110,7 +1110,7 @@ describe('PRChecker', () => {
     it('should warn if PR is closed', () => {
       const expectedLogs = {
         warn: [
-          [ 'This PR is closed' ]
+          [ 'This PR was closed on Sat, 28 Oct 2017 11:13:43 GMT' ]
         ]
       };
 
@@ -1133,7 +1133,7 @@ describe('PRChecker', () => {
     it('should warn if PR is merged', () => {
       const expectedLogs = {
         warn: [
-          [ 'This PR is merged' ]
+          [ 'This PR was merged on Sat, 28 Oct 2017 11:13:43 GMT' ]
         ]
       };
 


### PR DESCRIPTION
To be consistent with PR `createAt` field, also reporting when the PR was closed or merged.