### PR TITLE
ncu-config: introduce project config file

### DIFF
--- a/bin/ncu-config
+++ b/bin/ncu-config
@@ -3,7 +3,7 @@
 'use strict';
 
 const {
-  getConfig, updateConfig
+  getConfig, updateConfig, GLOBAL_CONFIG, PROJECT_CONFIG, LOCAL_CONFIG
 } = require('../lib/config');
 
 const yargs = require('yargs');
@@ -41,26 +41,51 @@ const argv = yargs
     handler: listHandler
   })
   .demandCommand(1, 'must provide a valid command')
-  .boolean('global')
-  .default({ global: false })
+  // Can't set default of boolean variables if using conflict
+  // https://github.com/yargs/yargs/issues/929
+  // default: false
+  .option('global', {
+    alias: 'g',
+    type: 'boolean',
+    describe: 'Use global config (~/.ncurc)'
+  })
+  .option('project', {
+    alias: 'p',
+    type: 'boolean',
+    describe: 'Use project config (./.ncurc)'
+  })
+  .conflicts('global', 'project')
   .help()
   .argv;
 
+function getConfigType(argv) {
+  if (argv.global) {
+    return { configName: 'global', configType: GLOBAL_CONFIG };
+  }
+  if (argv.project) {
+    return { configName: 'project', configType: PROJECT_CONFIG };
+  }
+  return { configName: 'local', configType: LOCAL_CONFIG };
+}
+
 function setHandler(argv) {
-  const config = getConfig(argv.global);
+  const { configName, configType } = getConfigType(argv);
+  const config = getConfig(configType);
   console.log(
-    `Updating ${argv.global ? 'global' : 'local'} configuration ` +
+    `Updating ${configName} configuration ` +
     `[${argv.key}]: ${config[argv.key]} -> ${argv.value}`);
-  updateConfig(argv.global, { [argv.key]: argv.value });
+  updateConfig(configType, { [argv.key]: argv.value });
 }
 
 function getHandler(argv) {
-  const config = getConfig(argv.global);
+  const { configType } = getConfigType(argv);
+  const config = getConfig(configType);
   console.log(config[argv.key]);
 }
 
 function listHandler(argv) {
-  const config = getConfig(argv.global);
+  const { configType } = getConfigType(argv);
+  const config = getConfig(configType);
   for (const key of Object.keys(config)) {
     console.log(`${key}: ${config[key]}`);
   }

--- a/docs/ncu-config.md
+++ b/docs/ncu-config.md
@@ -1,7 +1,9 @@
 # ncu-config
 
 Configure variables for node-core-utils to use. Global variables are stored
-in `~/.ncurc` while local variables are stored in `$PWD/.ncu/config`.
+in `~/.ncurc`, project variables (committed to the repository) are stored in
+`$PWD/.ncurc` and local variables (shouldn't be committed) are stored in
+`$PWD/.ncu/config`.
 
 ```
 ncu-config <command>
@@ -12,7 +14,8 @@ Commands:
   ncu-config list               List the configurations
 
 Options:
-  --version  Show version number                                       [boolean]
-  --help     Show help                                                 [boolean]
-  --global                                            [boolean] [default: false]
+  --version      Show version number                                   [boolean]
+  --global, -g   Use global config (~/.ncurc)                          [boolean]
+  --project, -p  Use project config (./.ncurc)                         [boolean]
+  --help         Show help                                             [boolean]
 ```

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,14 @@ const path = require('path');
 const os = require('os');
 const { readJson, writeJson } = require('./file');
 
+const GLOBAL_CONFIG = Symbol('globalConfig');
+const PROJECT_CONFIG = Symbol('projectConfig');
+const LOCAL_CONFIG = Symbol('localConfig');
+
+exports.GLOBAL_CONFIG = GLOBAL_CONFIG;
+exports.PROJECT_CONFIG = PROJECT_CONFIG;
+exports.LOCAL_CONFIG = LOCAL_CONFIG;
+
 function getNcurcPath() {
   if (process.env.XDG_CONFIG_HOME !== 'undefined' &&
       process.env.XDG_CONFIG_HOME !== undefined) {
@@ -15,33 +23,40 @@ function getNcurcPath() {
 exports.getNcurcPath = getNcurcPath;
 
 exports.getMergedConfig = function(dir, home) {
-  const globalConfig = exports.getConfig(true, home);
-  const localConfig = exports.getConfig(false, dir);
-  return Object.assign(globalConfig, localConfig);
+  const globalConfig = exports.getConfig(GLOBAL_CONFIG, home);
+  const projectConfig = exports.getConfig(PROJECT_CONFIG, dir);
+  const localConfig = exports.getConfig(LOCAL_CONFIG, dir);
+  return Object.assign(globalConfig, projectConfig, localConfig);
 };
 
-exports.getConfig = function(isGlobal, dir) {
-  const configPath = exports.getConfigPath(isGlobal, dir);
+exports.getConfig = function(configType, dir) {
+  const configPath = exports.getConfigPath(configType, dir);
   return readJson(configPath);
 };
 
-exports.getConfigPath = function(isGlobal, dir) {
-  if (!isGlobal) {
-    const ncuDir = exports.getNcuDir(dir);
-    const configPath = path.join(ncuDir, 'config');
-    return configPath;
+exports.getConfigPath = function(configType, dir) {
+  switch (configType) {
+    case GLOBAL_CONFIG:
+      return getNcurcPath();
+    case PROJECT_CONFIG:
+      const projectRcPath = path.join(dir || process.cwd(), '.ncurc');
+      return projectRcPath;
+    case LOCAL_CONFIG:
+      const ncuDir = exports.getNcuDir(dir);
+      const configPath = path.join(ncuDir, 'config');
+      return configPath;
+    default:
+      throw Error('Invalid configType');
   }
-
-  return getNcurcPath();
 };
 
-exports.writeConfig = function(isGlobal, obj, dir) {
-  writeJson(exports.getConfigPath(isGlobal, dir), obj);
+exports.writeConfig = function(configType, obj, dir) {
+  writeJson(exports.getConfigPath(configType, dir), obj);
 };
 
-exports.updateConfig = function(isGlobal, obj, dir) {
-  const config = exports.getConfig(isGlobal, dir);
-  const configPath = exports.getConfigPath(isGlobal, dir);
+exports.updateConfig = function(configType, obj, dir) {
+  const config = exports.getConfig(configType, dir);
+  const configPath = exports.getConfigPath(configType, dir);
   writeJson(configPath, Object.assign(config, obj));
 };
 


### PR DESCRIPTION
Project config file is intended to be committed to a project. This will
allow other projects in the org to use NCU without users having to set
`owner` and `repo` by themselves. In the future we can also use this add
other project-specific configurations (number of hours to wait, minimum
approvals and main CI, for example).