### PR TITLE
git-node: add config option to set wait times

### DIFF
--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -7,10 +7,12 @@ A custom Git command for managing pull requests. You can run it as
   - [Prerequisites](#git-node-land-prerequisites)
   - [Git bash for Windows](#git-bash-for-windows)
   - [Demo & Usage](#demo--usage)
+  - [Optional Settings](#git-node-land-optional-settings)
 - [`git node backport`](#git-node-backport)
   - [Example](#example)
 - [`git node sync`](#git-node-sync)
 - [`git node metadata`](#git-node-metadata)
+  - [Optional Settings](#git-node-metadata-optional-settings)
 - [`git node v8`](#git-node-v8)
   - [Prerequisites](#git-node-v8-prerequisites)
   - [`git node v8 major`](#git-node-v8-major)
@@ -134,6 +136,14 @@ Options:
   --help     Show help                                                 [boolean]
 ```
 
+<a id="git-node-land-optional-settings"></a>
+
+### Optional Settings
+
+The same Settings used by 
+[`git node metadata`](#git-node-metadata-optional-settings) are also used by 
+`git node land`.
+
 ## `git node backport`
 
 Demo: https://asciinema.org/a/221244
@@ -228,6 +238,24 @@ $ git commit --amend -F msg.txt
 # fetch metadata and run checks on https://github.com/nodejs/llnode/pull/167
 # using the contact in ../node/README.md
 git node metadata 167 --repo llnode --readme ../node/README.md
+```
+
+<a id="git-node-metadata-optional-settings"></a>
+
+### Optional Settings
+
+Some projects might not follow the same rules as nodejs/node. To properly
+validate Pull Requests for these projects, node-core-utils accept the following
+optional settings:
+
+```bash
+cd path/to/project
+# waitTimeSingleApproval is the minimum wait time (in hours) before
+# landing a PR with only one approval. Default to 7 days.
+ncu-config set waitTimeSingleApproval 168
+# waitTimeMultiApproval is the minimum wait time (in hours) before
+# landing a PR with only two or more approvals. Default to 48 hours.
+ncu-config set waitTimeMultiApproval 48
 ```
 
 ## `git node v8`

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -49,6 +49,20 @@ class PRChecker {
     );
   }
 
+  get waitTimeSingleApproval() {
+    if (this.argv.waitTimeSingleApproval === undefined) {
+      return WAIT_TIME_SINGLE_APPROVAL;
+    }
+    return this.argv.waitTimeSingleApproval;
+  }
+
+  get waitTimeMultiApproval() {
+    if (this.argv.waitTimeMultiApproval === undefined) {
+      return WAIT_TIME_MULTI_APPROVAL;
+    }
+    return this.argv.waitTimeMultiApproval;
+  }
+
   checkAll(checkComments = false) {
     const status = [
       this.checkCommitsAfterReview(),
@@ -148,8 +162,8 @@ class PRChecker {
     const msFromCreateTime = now.getTime() - createTime.getTime();
     const minutesFromCreateTime = Math.ceil(msFromCreateTime / MINUTE);
     const hoursFromCreateTime = Math.ceil(msFromCreateTime / HOUR);
-    let timeLeftMulti = WAIT_TIME_MULTI_APPROVAL - hoursFromCreateTime;
-    const timeLeftSingle = WAIT_TIME_SINGLE_APPROVAL - hoursFromCreateTime;
+    let timeLeftMulti = this.waitTimeMultiApproval - hoursFromCreateTime;
+    const timeLeftSingle = this.waitTimeSingleApproval - hoursFromCreateTime;
 
     if (approved.length >= 2) {
       if (isFastTracked || isCodeAndLearn) {
@@ -160,7 +174,7 @@ class PRChecker {
       }
       if (timeLeftMulti === 0) {
         const timeLeftMins =
-          WAIT_TIME_MULTI_APPROVAL * 60 - minutesFromCreateTime;
+          this.waitTimeMultiApproval * 60 - minutesFromCreateTime;
         cli.error(`This PR needs to wait ${timeLeftMins} more minutes to land`);
         return false;
       }

--- a/lib/session.js
+++ b/lib/session.js
@@ -50,6 +50,8 @@ class Session {
       upstream: this.upstream,
       branch: this.branch,
       readme: this.readme,
+      waitTimeSingleApproval: this.waitTimeSingleApproval,
+      waitTimeMultiApproval: this.waitTimeMultiApproval,
       prid: this.prid
     };
   }
@@ -76,6 +78,14 @@ class Session {
 
   get readme() {
     return this.config.readme;
+  }
+
+  get waitTimeSingleApproval() {
+    return this.config.waitTimeSingleApproval;
+  }
+
+  get waitTimeMultiApproval() {
+    return this.config.waitTimeMultiApproval;
   }
 
   get pullName() {

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -24,6 +24,11 @@ const requestedChangesReviewers = {
   approved: []
 };
 
+const noReviewers = {
+  requestedChanges: [],
+  approved: []
+};
+
 const approvingReviews = readJSON('reviews_approved.json');
 const requestingChangesReviews = readJSON('reviews_requesting_changes.json');
 
@@ -87,6 +92,7 @@ module.exports = {
   requestedChanges,
   allGreenReviewers,
   singleGreenReviewer,
+  noReviewers,
   requestedChangesReviewers,
   approvingReviews,
   requestingChangesReviews,


### PR DESCRIPTION
Add two new config options: `waitTimeSingleApproval` and
`waitTimeMultiApproval`, which can be used to set how long ncu should
wait before landing a PR with 1 approval or with 2+ approvals.