### PR TITLE
git-node: mention --continue has to be done

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -117,8 +117,9 @@ class LandingSession extends Session {
     const suggestion = this.getRebaseSuggestion(subjects);
 
     cli.log(`There are ${subjects.length} commits in the PR`);
-    cli.log('Please run the following command to complete landing\n\n' +
-            `$ ${suggestion}`);
+    cli.log('Please run the following commands to complete landing\n\n' +
+            `$ ${suggestion}\n` +
+            `$ git node land --continue`);
   }
 
   async apply() {


### PR DESCRIPTION
Its not obvious to first-time users.

Personally, I'd prefer `git rebase upstream/master -i -x "git node land --amend" && git node land --continue` for ease of single-shot cut-n-paste, but maybe that's too unix specific?