### PR TITLE
git-node: add GitHub status as a CI option

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -201,9 +201,20 @@ class PRChecker {
     return cis.find(ci => isFullCI(ci) || isLiteCI(ci));
   }
 
+  checkCI() {
+    const ciType = this.argv.ciType || 'jenkins';
+    if (ciType === 'jenkins') {
+      return this.checkJenkinsCI();
+    } else if (ciType === 'github-check') {
+      return this.checkGitHubCI();
+    }
+    this.cli.error(`Invalid ciType: ${ciType}`);
+    return false;
+  }
+
   // TODO: we might want to check CI status when it's less flaky...
   // TODO: not all PR requires CI...labels?
-  checkCI() {
+  checkJenkinsCI() {
     const { cli, commits, argv } = this;
     const { maxCommits } = argv;
     const thread = this.data.getThread();
@@ -263,6 +274,57 @@ class PRChecker {
 
     this.CIStatus = status;
     return status;
+  }
+
+  checkGitHubCI() {
+    const { cli, commits } = this;
+
+    if (!commits) {
+      cli.error('No commits detected');
+      return false;
+    }
+
+    // NOTE(mmarchini): we only care about the last commit. Maybe in the future
+    // we'll want to check all commits for a successful CI.
+    const { commit } = commits[commits.length - 1];
+
+    this.CIStatus = false;
+    const checkSuites = commit.checkSuites || { nodes: [] };
+    if (!commit.status && checkSuites.nodes.length === 0) {
+      cli.error('No CI runs detected');
+      return false;
+    }
+
+    // GitHub new Check API
+    for (const { status, conclusion } of checkSuites.nodes) {
+      if (status !== 'COMPLETED') {
+        cli.error('CI is still running');
+        return false;
+      }
+
+      if (!['SUCCESS', 'NEUTRAL'].includes(conclusion)) {
+        cli.error('Last CI failed');
+        return false;
+      }
+    }
+
+    // GitHub old commit status API
+    if (commit.status) {
+      const { state } = commit.status;
+      if (state === 'PENDING') {
+        cli.error('CI is still running');
+        return false;
+      }
+
+      if (!['SUCCESS', 'EXPECTED'].includes(state)) {
+        cli.error('Last CI failed');
+        return false;
+      }
+    }
+
+    cli.info('Last CI run was successful');
+    this.CIStatus = true;
+    return true;
   }
 
   checkAuthor() {

--- a/lib/queries/PRCommits.gql
+++ b/lib/queries/PRCommits.gql
@@ -25,6 +25,15 @@ query Commits($prid: Int!, $owner: String!, $repo: String!, $after: String) {
             message
             messageHeadline
             authoredByCommitter
+            checkSuites(first: 10) {
+              nodes {
+                conclusion,
+                status
+              }
+            }
+            status {
+              state
+            }
           }
         }
       }

--- a/lib/request.js
+++ b/lib/request.js
@@ -68,7 +68,8 @@ class Request {
       method: 'POST',
       headers: {
         Authorization: `Basic ${githubCredentials}`,
-        'User-Agent': 'node-core-utils'
+        'User-Agent': 'node-core-utils',
+        Accept: 'application/vnd.github.antiope-preview+json'
       },
       body: JSON.stringify({
         query: query,

--- a/lib/session.js
+++ b/lib/session.js
@@ -55,6 +55,7 @@ class Session {
       readme: this.readme,
       waitTimeSingleApproval: this.waitTimeSingleApproval,
       waitTimeMultiApproval: this.waitTimeMultiApproval,
+      ciType: this.ciType,
       prid: this.prid
     };
   }
@@ -89,6 +90,10 @@ class Session {
 
   get waitTimeMultiApproval() {
     return this.config.waitTimeMultiApproval;
+  }
+
+  get ciType() {
+    return this.config.ciType || 'jenkins';
   }
 
   get pullName() {

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const { readJSON, patchPrototype, readFile } = require('./index');
+const { basename } = require('path');
+const { readdirSync } = require('fs');
+
+const { readJSON, patchPrototype, readFile, path } = require('./index');
 const { Collaborator } = require('../../lib/collaborators');
 const { Review } = require('../../lib/reviews');
 
@@ -88,6 +91,15 @@ const readmeNoCollaborators = readFile('./README/README_no_collaborators.md');
 const readmeNoCollaboratorE = readFile('./README/README_no_collaboratorE.md');
 const readmeUnordered = readFile('./README/README_unordered.md');
 
+const githubCI = {};
+
+for (const item of readdirSync(path('./github-ci'))) {
+  if (!item.endsWith('.json')) {
+    continue;
+  }
+  githubCI[basename(item, '.json')] = readJSON(`./github-ci/${item}`);
+};
+
 module.exports = {
   approved,
   requestedChanges,
@@ -101,6 +113,7 @@ module.exports = {
   commentsWithLiteCI,
   commentsWithLGTM,
   oddCommits,
+  githubCI,
   incorrectGitConfigCommits,
   simpleCommits,
   singleCommitAfterReview,

--- a/test/fixtures/github-ci/both-apis-failure.json
+++ b/test/fixtures/github-ci/both-apis-failure.json
@@ -1,0 +1,24 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "FAILURE"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "FAILURE"
+          }
+        ]
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/both-apis-success.json
+++ b/test/fixtures/github-ci/both-apis-success.json
@@ -1,0 +1,24 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "SUCCESS"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS"
+          }
+        ]
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/check-suite-failure.json
+++ b/test/fixtures/github-ci/check-suite-failure.json
@@ -1,0 +1,20 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "FAILURE"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/fixtures/github-ci/check-suite-pending.json
+++ b/test/fixtures/github-ci/check-suite-pending.json
@@ -1,0 +1,20 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "IN_PROGRESS"
+          }
+        ]
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/check-suite-success.json
+++ b/test/fixtures/github-ci/check-suite-success.json
@@ -1,0 +1,20 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/fixtures/github-ci/commit-status-only-failure.json
+++ b/test/fixtures/github-ci/commit-status-only-failure.json
@@ -1,0 +1,16 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "FAILURE"
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/commit-status-only-pending.json
+++ b/test/fixtures/github-ci/commit-status-only-pending.json
@@ -1,0 +1,16 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "PENDING"
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/commit-status-only-success.json
+++ b/test/fixtures/github-ci/commit-status-only-success.json
@@ -1,0 +1,16 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "SUCCESS"
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/no-status.json
+++ b/test/fixtures/github-ci/no-status.json
@@ -1,0 +1,13 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/status-failure-check-suite-succeed.json
+++ b/test/fixtures/github-ci/status-failure-check-suite-succeed.json
@@ -1,0 +1,24 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "FAILURE"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS"
+          }
+        ]
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/status-succeed-check-suite-failure.json
+++ b/test/fixtures/github-ci/status-succeed-check-suite-failure.json
@@ -1,0 +1,24 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "SUCCESS"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "FAILURE"
+          }
+        ]
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/two-commits-first-ci.json
+++ b/test/fixtures/github-ci/two-commits-first-ci.json
@@ -1,0 +1,25 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-25T11:27:02Z",
+      "oid": "6c0945cbeea2cbbc97d13a3d9e3fe68bd145b985",
+      "messageHeadline": "fixup: adjust spelling",
+      "author": {
+        "login": "bar"
+      },
+      "status": {
+        "state": "SUCCESS"
+      }
+    }
+  },{
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      }
+    }
+  }
+]
+

--- a/test/fixtures/github-ci/two-commits-last-ci.json
+++ b/test/fixtures/github-ci/two-commits-last-ci.json
@@ -1,0 +1,25 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-25T11:27:02Z",
+      "oid": "6c0945cbeea2cbbc97d13a3d9e3fe68bd145b985",
+      "messageHeadline": "fixup: adjust spelling",
+      "author": {
+        "login": "bar"
+      }
+    }
+  },{
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "status": {
+        "state": "SUCCESS"
+      }
+    }
+  }
+]
+


### PR DESCRIPTION
Some project in the org don't use Jenkins, which means PRChecker will
never succeed for pull requests on those projects. These projects
usually have Travis, AppVeyor or other CI systems in place, and those
systems will publish the status to GitHub, which can be retrieved via
API. This commit adds GitHub status as an optional way to validate if a
PR satisfies the CI requirement.

We need to check for the CI status in two fields returned by our GraphQL
query: commit.status for services using the old GitHub integration, and
commits.checkSuites for services using the new GitHub integration via
GitHub Apps.