### PR TITLE
update-v8: add zlib as a V8 dependency

### DIFF
--- a/lib/update-v8/constants.js
+++ b/lib/update-v8/constants.js
@@ -71,5 +71,12 @@ exports.v8Deps = [
       replace: googleTestReplace
     },
     since: 67
+  },
+  {
+    name: 'zlib',
+    repo: 'v8/third_party/zlib',
+    path: 'third_party/zlib',
+    gitignore: '!/third_party/zlib',
+    since: 80
   }
 ];


### PR DESCRIPTION
Add zlib to the list of V8 dependencies, un-breaking LKGR.