### PR TITLE
v8: ignore zlib test and bench directories

### DIFF
--- a/lib/update-v8/constants.js
+++ b/lib/update-v8/constants.js
@@ -26,6 +26,11 @@ const googleTestReplace = `/third_party/googletest/src/*
 /third_party/googletest/src/googletest/include/gtest/*
 !/third_party/googletest/src/googletest/include/gtest/gtest_prod.h`;
 
+const zlibIgnore = `!/third_party/zlib
+/third_party/zlib/contrib/bench
+/third_party/zlib/contrib/tests
+/third_party/zlib/google`;
+
 exports.v8Deps = [
   {
     name: 'trace_event',
@@ -76,7 +81,7 @@ exports.v8Deps = [
     name: 'zlib',
     repo: 'v8/third_party/zlib',
     path: 'third_party/zlib',
-    gitignore: '!/third_party/zlib',
+    gitignore: zlibIgnore,
     since: 80
   }
 ];


### PR DESCRIPTION
They are not needed to build V8 and cause issues with our release CI.

I'm intending to fix this issue:
![image](https://user-images.githubusercontent.com/2352663/70701812-4cc3df80-1ccd-11ea-86f6-68b87daff060.png)
