### PR TITLE
v8: only ignore test in third_party/zlib/google

### DIFF
--- a/lib/update-v8/constants.js
+++ b/lib/update-v8/constants.js
@@ -29,7 +29,7 @@ const googleTestReplace = `/third_party/googletest/src/*
 const zlibIgnore = `!/third_party/zlib
 /third_party/zlib/contrib/bench
 /third_party/zlib/contrib/tests
-/third_party/zlib/google`;
+/third_party/zlib/google/test`;
 
 exports.v8Deps = [
   {


### PR DESCRIPTION
This is needed to fix the Node.js v8-canary builds.

Refs: https://chromium.googlesource.com/chromium/src/third_party/zlib/+/refs/heads/master/google/