### PR TITLE
refactor: extend cli.prompt

### DIFF
--- a/lib/backport_session.js
+++ b/lib/backport_session.js
@@ -162,7 +162,7 @@ class BackportSession extends Session {
     const newBranch = `backport-${this.prid}-to-${this.target}`;
     const shouldCheckout = await cli.prompt(
       `Do you want to checkout to a new branch \`${newBranch}\`` +
-      ' to start backporting?', false);
+      ' to start backporting?', { defaultAnswer: false });
     if (shouldCheckout) {
       await runAsync('git', ['checkout', '-b', newBranch]);
     }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,17 +35,35 @@ class CLI {
     this.figureIndent = ' '.repeat(indent);
   }
 
-  async prompt(question, defaultAnswer = true) {
-    this.separator();
+  async prompt(question, opts = {
+    defaultAnswer: true,
+    noSeparator: false,
+    questionType: 'confirm'
+  }) {
+    if (!opts.noSeparator) {
+      this.separator();
+    }
+
+    const questionType = opts.questionType || 'confirm';
+    const availableTypes = ['input', 'number', 'confirm'];
+    if (!availableTypes.includes(questionType)) {
+      throw new Error(
+        `${questionType} must be one of ${availableTypes.join(', ')}`);
+    }
+
+    const defaultAnswer =
+      (opts.defaultAnswer !== 'undefined') ? opts.defaultAnswer : true;
     if (this.assumeYes) {
       return defaultAnswer;
     }
+
     const { answer } = await inquirer.prompt([{
-      type: 'confirm',
+      type: questionType,
       name: 'answer',
       message: question,
       default: defaultAnswer
     }]);
+
     return answer;
   }
 

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -34,7 +34,7 @@ class LandingSession extends Session {
     // metadata check.
     const defaultAnswer = !cli.assumeYes ? true : metadata.status;
     const shouldContinue = await cli.prompt(
-      `This PR ${status} to land, do you want to continue?`, defaultAnswer);
+      `This PR ${status} to land, do you want to continue?`, { defaultAnswer });
     if (!shouldContinue) {
       return this.abort(false);
     }
@@ -234,7 +234,7 @@ class LandingSession extends Session {
         forceLand = await cli.prompt(
           'The commit did not pass the validation. ' +
           'Do you still want to land it?',
-          false);
+          { defaultAnswer: false });
       }
 
       if (!forceLand) {

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -178,11 +178,15 @@ describe('cli', () => {
     });
 
     it('should return true if default is set to true', async() => {
-      assert.strictEqual(await cli.prompt('Question?', true), true);
+      assert.strictEqual(await cli.prompt('Question?', {
+        defaultAnswer: true
+      }), true);
     });
 
     it('should return false if default is set to false', async() => {
-      assert.strictEqual(await cli.prompt('Question?', false), false);
+      assert.strictEqual(await cli.prompt('Question?', {
+        defaultAnswer: false
+      }), false);
     });
   });
 });


### PR DESCRIPTION
Refs https://github.com/nodejs/node-core-utils/pull/388.

Extend `cli.prompt()` to allow for optional separators at the beginning of the prompt, as well as optional input types. This would allow for prompting input as is done in the above linked PR without adding a new function in the CLI class.

cc @joyeecheung 