### PR TITLE
fix: LTS release commit should contain codename

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -358,7 +358,14 @@ class ReleasePreparation {
   }
 
   async createReleaseCommit() {
-    const { cli, isLTS, ltsCodename, newVersion, isSecurityRelease, date } = this;
+    const {
+      cli,
+      isLTS,
+      ltsCodename,
+      newVersion,
+      isSecurityRelease,
+      date
+    } = this;
 
     const releaseInfo = isLTS ? `'${ltsCodename}' (LTS)` : '(Current)';
     const messageTitle = `${date} Version ${newVersion} ${releaseInfo}`;

--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -358,10 +358,10 @@ class ReleasePreparation {
   }
 
   async createReleaseCommit() {
-    const { cli, isLTS, newVersion, isSecurityRelease, date } = this;
+    const { cli, isLTS, ltsCodename, newVersion, isSecurityRelease, date } = this;
 
-    const releaseType = isLTS ? 'LTS' : 'Current';
-    const messageTitle = `${date} Version ${newVersion} (${releaseType})`;
+    const releaseInfo = isLTS ? `'${ltsCodename}' (LTS)` : '(Current)';
+    const messageTitle = `${date} Version ${newVersion} ${releaseInfo}`;
 
     const messageBody = [];
     if (isSecurityRelease) {


### PR DESCRIPTION
The generated release commit for LTS releases should contain the codename.

Previously, this was the auto-generated output for an LTS release commit:

```
2020-04-08, Version 10.20.0 (LTS)
```

when it should be:

```
2020-04-08, Version 10.20.0 'Dubnium' (LTS)
```

This fixes that issue.

cc @nodejs/releasers 