### PR TITLE
git-node: fix release preparation script

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -153,7 +153,7 @@ class ReleasePreparation {
     cli.ok(`Release preparation for ${newVersion} complete.\n`);
     cli.info(
       'To finish the release proposal, run: \n' +
-      `      $ git push ${`v${semver.major(newVersion)}.x-staging`}\n` +
+      `      $ git push -u ${this.upstream} ${`${newVersion}-proposal`}\n` +
       'Finally, proceed to Jenkins and begin the following CI jobs:\n' +
       '      * https://ci.nodejs.org/job/node-test-pull-request/\n' +
       '      * https://ci.nodejs.org/job/citgm-smoker/');
@@ -278,19 +278,19 @@ class ReleasePreparation {
 
     const data = await fs.readFile(majorChangelogPath, 'utf8');
     const arr = data.split('\n');
-
     const allCommits = this.getChangelog();
     const notableChanges = this.getBranchDiff({ onlyNotableChanges: true });
     const releaseHeader = `## ${date}, Version ${newVersion}` +
                           ` ${releaseInfo}, @${username}\n`;
 
+    const topHeader =
+      `<a href="#${lastRef.substring(1)}">${lastRef.substring(1)}</a><br/>`;
+    const newHeader =
+      `<a href="#${newVersion}">${newVersion}</a><br/>`;
     for (let idx = 0; idx < arr.length; idx++) {
-      const topHeader =
-        `<a href="#${lastRef.substring(1)}">${lastRef.substring(1)}</a><br/>`;
       if (arr[idx].includes(topHeader)) {
-        const newHeader =
-          `<a href="#${newVersion}">${newVersion}</a><br/>`;
         arr.splice(idx, 0, newHeader);
+        idx++;
       } else if (arr[idx].includes(`<a id="${lastRef.substring(1)}"></a>`)) {
         const toAppend = [];
         toAppend.push(`<a id="${newVersion}"></a>`);
@@ -339,7 +339,7 @@ class ReleasePreparation {
         arr[idx] = '#define NODE_VERSION_IS_RELEASE 1';
       } else if (line.includes('#define NODE_VERSION_IS_LTS')) {
         this.isLTS = arr[idx].split(' ')[2] === '1';
-        this.ltsCodename = arr[idx + 1].split(' ')[2];
+        this.ltsCodename = arr[idx + 1].split(' ')[2].slice(1, -1);
       }
     });
 
@@ -381,6 +381,7 @@ class ReleasePreparation {
     });
     messageBody.push('Notable changes:\n\n');
     messageBody.push(notableChanges);
+    messageBody.push('\n\nPR-URL: TODO');
 
     // Create commit and then allow releaser to amend.
     runSync('git', ['add', '.']);


### PR DESCRIPTION
- Prevent out of memory error because of infinitely growing array
- Do not quote LTS codename twice in changelog and commit message
- Add "PR-URL: TODO" to the release commit message
- Ask to push the proposal branch