### PR TITLE
refactor: allow non-empty stderr in runSync

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -56,7 +56,7 @@ exports.runSync = function(cmd, args, options) {
   }, options));
   if (child.error) {
     throw child.error;
-  } else if (child.stderr.length) {
+  } else if (child.status !== 0) {
     throw new Error(child.stderr.toString());
   } else {
     return child.stdout.toString();


### PR DESCRIPTION
Refs https://github.com/nodejs/node-core-utils/pull/402#issuecomment-623726579.

Allow a non-empty `stderr` in `runSync` and instead error on a non-zero exit status; `git` sometimes outputs its messages to `stderr` so this has potential to cause unexpected failures.

cc @targos @joyeecheung 