### PR TITLE
fix: validate ncu-ci args

### DIFF
--- a/bin/ncu-ci
+++ b/bin/ncu-ci
@@ -23,6 +23,14 @@ const Request = require('../lib/request');
 const CLI = require('../lib/cli');
 const yargs = require('yargs');
 
+const commandKeys = [
+  'rate',
+  'walk',
+  'url',
+  'pr',
+  'commit'
+];
+
 // eslint-disable-next-line no-unused-vars
 const argv = yargs
   .command({
@@ -115,13 +123,20 @@ const argv = yargs
     default: false,
     describe: 'Write the results as markdown to clipboard'
   })
-  .option('json', {
+  .option('json <path>', {
     type: 'string',
-    describe: 'Write the results as json to the path'
+    describe: 'Write the results as json to <path>'
   })
-  .option('markdown', {
+  .option('markdown <path>', {
     type: 'string',
-    describe: 'Write the results as markdown to the path'
+    describe: 'Write the results as markdown to <path>'
+  }).check(argv => {
+    if (argv.markdown && commandKeys.includes(argv.markdown)) {
+      throw new Error('--markdown <path> did not specify a valid path');
+    } else if (argv.json && commandKeys.includes(argv.json)) {
+      throw new Error('--json <path> did not specify a valid path');
+    }
+    return true;
   })
   .help()
   .argv;


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/393.

Not a perfect solution, but this validates that the user didn't type something like:
```
ncu-ci --markdown url https://ci.nodejs.org/job/node-test-pull-request/29714/
```
 and throws a helpful error if that's the case.

cc @mmarchini @joyeecheung 