### PR TITLE
git-node: implement --commit option of `git node wpt`

### DIFF
--- a/components/git/wpt.js
+++ b/components/git/wpt.js
@@ -19,6 +19,11 @@ function builder(yargs) {
       type: 'string'
     })
     .options({
+      commit: {
+        describe: 'A specific commit the subset should be updated to',
+        type: 'string',
+        default: undefined
+      },
       nodedir: {
         describe: 'Path to the node.js project directory',
         type: 'string',
@@ -28,7 +33,7 @@ function builder(yargs) {
 }
 
 async function main(argv) {
-  const { name, nodedir } = argv;
+  const { name, nodedir, commit } = argv;
   const cli = new CLI();
   const credentials = await auth({
     github: true
@@ -47,21 +52,22 @@ async function main(argv) {
   }
 
   if (name === 'all' || name === 'resources') {
-    updaters.push(new ResourcesUpdater(cli, request, nodedir));
+    updaters.push(new ResourcesUpdater(cli, request, nodedir, commit));
   }
   if (name === 'all' || name === 'interfaces') {
-    updaters.push(new InterfacesUpdater(cli, request, nodedir, supported));
+    updaters.push(new InterfacesUpdater(cli, request, nodedir,
+      commit, supported));
   }
 
   if (name === 'all') {
     for (const item of supported) {
-      updaters.push(new WPTUpdater(item, cli, request, nodedir));
+      updaters.push(new WPTUpdater(item, cli, request, nodedir, commit));
     }
   } else if (name !== 'resources' && name !== 'interfaces') {
     if (!supported.includes(name)) {
       cli.warn(`Please create ${name}.json in ${statusFolder}`);
     }
-    updaters.push(new WPTUpdater(name, cli, request, nodedir));
+    updaters.push(new WPTUpdater(name, cli, request, nodedir, commit));
   }
 
   for (const updater of updaters) {

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -375,11 +375,28 @@ to the assets, this also updates:
 - `./test/fixtures/wpt/README.md`
 - `./test/fixtures/wpt/LICENSE.md`
 
+```
+git-node wpt <name>
+
+Updates WPT suite
+
+Positionals:
+  name  Subset of the WPT to update                          [string] [required]
+
+Options:
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]
+  --commit   A specific commit the subset should be updated to          [string]
+  --nodedir  Path to the node.js project directory       [string] [default: "."]
+```
+
 ### Example
 
 ```
 $ cd /path/to/node/project
 $ git node wpt url  # Will update test/fixtures/wpt/url and related files
+# Will update test/fixtures/wpt/url and related files to the specified commit
+$ git node wpt url --commit=43feb7f612fe9160639e09a47933a29834904d69
 ```
 
 [node.js abi version registry]: https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json

--- a/lib/wpt/index.js
+++ b/lib/wpt/index.js
@@ -9,7 +9,7 @@ const {
 } = require('../utils');
 
 class WPTUpdater {
-  constructor(path, cli, request, nodedir) {
+  constructor(path, cli, request, nodedir, commit) {
     this.path = path;
     this.nodedir = nodedir;
 
@@ -19,7 +19,8 @@ class WPTUpdater {
       owner: 'web-platform-tests',
       repo: 'wpt',
       branch: 'master',
-      path
+      path,
+      commit
     };
     this.tree = new GitHubTree(cli, request, this.treeParams);
     this.assets = [];
@@ -162,8 +163,8 @@ class WPTUpdater {
 }
 
 class ResourcesUpdater extends WPTUpdater {
-  constructor(cli, request, nodedir) {
-    super('resources', cli, request, nodedir);
+  constructor(cli, request, nodedir, commit) {
+    super('resources', cli, request, nodedir, commit);
   }
 
   async update() {  // override
@@ -194,8 +195,8 @@ class ResourcesUpdater extends WPTUpdater {
 }
 
 class InterfacesUpdater extends WPTUpdater {
-  constructor(cli, request, nodedir, supported) {
-    super('interfaces', cli, request, nodedir);
+  constructor(cli, request, nodedir, commit, supported) {
+    super('interfaces', cli, request, nodedir, commit);
     this.supported = supported;
   }
 


### PR DESCRIPTION
Add an option to explicitly specify the commit the WPT subset
should be updated to instead of always using the latest commit.