### PR TITLE
fix: use plaintext formatting in release commit

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -377,7 +377,7 @@ class ReleasePreparation {
 
     const notableChanges = this.getBranchDiff({
       onlyNotableChanges: true,
-      simple: true
+      format: 'plaintext'
     });
     messageBody.push('Notable changes:\n\n');
     messageBody.push(notableChanges);
@@ -431,12 +431,9 @@ class ReleasePreparation {
       branchDiffOptions = [
         `${upstream}/${releaseBranch}`,
         proposalBranch,
-        `--require-label=${notableLabels.join(',')}`
+        `--require-label=${notableLabels.join(',')}`,
+        `--format=${opts.format || 'markdown'}`
       ];
-
-      if (opts.simple) {
-        branchDiffOptions.push('--simple');
-      }
     } else {
       const excludeLabels = [
         'semver-major',


### PR DESCRIPTION
Refs. https://github.com/nodejs/branch-diff/pull/22.

Leverages new `plaintext` functionality in `branch-diff` so that we can easily pull the notable changes into release commits without markdown cruft. New sample output:

```sh
build:
  * add --error-on-warn configure flag (Daniel Bevenius) https://github.com/nodejs/node/pull/32685
cluster:
  * fix error on worker disconnect/destroy (Santiago Gimeno) https://github.com/nodejs/node/pull/32793
crypto:
  * check DiffieHellman p and g params (Ben Noordhuis) https://github.com/nodejs/node/pull/32739
  * generator must be int32 in DiffieHellman() (Ben Noordhuis) https://github.com/nodejs/node/pull/32739
  * key size must be int32 in DiffieHellman() (Ben Noordhuis) https://github.com/nodejs/node/pull/32739
```

cc @targos