### PR TITLE
fix: default date for release

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -114,8 +114,9 @@ class ReleasePreparation {
     cli.stopSpinner('Updated REPLACEME items in docs');
 
     // Fetch date to use in release commit & changelogs.
+    const todayDate = new Date().toISOString().split('T')[0];
     this.date = await cli.prompt('Enter release date in YYYY-MM-DD format:',
-      { questionType: 'input' });
+      { questionType: 'input', defaultAnswer: todayDate });
 
     cli.startSpinner('Updating CHANGELOG.md');
     await this.updateMainChangelog();


### PR DESCRIPTION
Non-confirmation inputs need to have a default date - if no date is provided for the release, default to today's.

cc @targos @joyeecheung 