### PR TITLE
feat: check CI failures before land

### DIFF
--- a/components/metadata.js
+++ b/components/metadata.js
@@ -11,7 +11,8 @@ const fs = require('fs');
 
 module.exports = async function getMetadata(argv, cli) {
   const credentials = await auth({
-    github: true
+    github: true,
+    jenkins: true
   });
   const request = new Request(credentials);
 
@@ -38,8 +39,8 @@ module.exports = async function getMetadata(argv, cli) {
   cli.write(metadata);
   cli.separator();
 
-  const checker = new PRChecker(cli, data, argv);
-  const status = checker.checkAll(argv.checkComments);
+  const checker = new PRChecker(cli, data, request, argv);
+  const status = await checker.checkAll(argv.checkComments);
   return {
     status,
     request,

--- a/lib/ci/ci_type_parser.js
+++ b/lib/ci/ci_type_parser.js
@@ -26,6 +26,11 @@ const CI_TYPE_ENUM = {
   JOB_CI: 1 << 2
 };
 
+const CI_PROVIDERS = {
+  JENKINS: 'jenkins',
+  GITHUB: 'github-check'
+};
+
 const { JOB_CI, FULL_CI, LITE_CI } = CI_TYPE_ENUM;
 
 const CI_TYPES = new Map([
@@ -209,6 +214,7 @@ module.exports = {
     CITGM, PR, COMMIT, BENCHMARK, LIBUV, V8, NOINTL,
     LINTER, LITE_PR, LITE_COMMIT
   },
+  CI_PROVIDERS,
   isFullCI,
   isLiteCI,
   JobParser,

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -20,9 +20,11 @@ const {
 const {
   JobParser,
   CI_TYPES,
+  CI_PROVIDERS,
   isLiteCI,
   isFullCI
 } = require('./ci/ci_type_parser');
+const { PRBuild } = require('./ci/ci_result_parser');
 
 const GIT_CONFIG_GUIDE_URL = 'https://github.com/nodejs/node/blob/99b1ada/doc/guides/contributing/pull-requests.md#step-1-fork';
 
@@ -31,8 +33,9 @@ class PRChecker {
    * @param {{}} cli
    * @param {PRData} data
    */
-  constructor(cli, data, argv) {
+  constructor(cli, data, request, argv) {
     this.cli = cli;
+    this.request = request;
     this.data = data;
     const {
       pr, reviewers, comments, reviews, commits, collaborators
@@ -66,10 +69,10 @@ class PRChecker {
     return this.argv.waitTimeMultiApproval;
   }
 
-  checkAll(checkComments = false) {
+  async checkAll(checkComments = false) {
     const status = [
       this.checkCommitsAfterReview(),
-      this.checkCI(),
+      await this.checkCI(),
       this.checkReviewsAndWait(new Date(), checkComments),
       this.checkMergeableState(),
       this.checkPRState(),
@@ -201,24 +204,34 @@ class PRChecker {
     return cis.find(ci => isFullCI(ci) || isLiteCI(ci));
   }
 
-  checkCI() {
-    const ciType = this.argv.ciType || 'jenkins';
-    if (ciType === 'jenkins') {
-      return this.checkJenkinsCI();
-    } else if (ciType === 'github-check') {
-      return this.checkGitHubCI();
+  async checkCI() {
+    const ciType = this.argv.ciType || CI_PROVIDERS.JENKINS;
+    const providers = Object.values(CI_PROVIDERS);
+
+    if (!providers.includes(ciType)) {
+      this.cli.error(
+        `Invalid ciType ${ciType} - must be one of ${providers.join(', ')}`);
+      return false;
     }
-    this.cli.error(`Invalid ciType: ${ciType}`);
-    return false;
+
+    let status = false;
+    if (ciType === CI_PROVIDERS.JENKINS) {
+      status = await this.checkJenkinsCI();
+    } else if (ciType === CI_PROVIDERS.GITHUB) {
+      status = this.checkGitHubCI();
+    }
+
+    return status;
   }
 
   // TODO: we might want to check CI status when it's less flaky...
   // TODO: not all PR requires CI...labels?
-  checkJenkinsCI() {
-    const { cli, commits, argv } = this;
+  async checkJenkinsCI() {
+    const { cli, commits, request, argv } = this;
     const { maxCommits } = argv;
     const thread = this.data.getThread();
     const ciMap = new JobParser(thread).parse();
+
     let status = true;
     if (!ciMap.size) {
       cli.error('No CI runs detected');
@@ -226,7 +239,7 @@ class PRChecker {
       return false;
     } else if (!this.hasFullOrLiteCI(ciMap)) {
       status = false;
-      cli.error('No full CI runs or lite CI runs detected');
+      cli.error('No full or lite Jenkins CI runs detected');
     }
 
     let lastCI;
@@ -236,7 +249,8 @@ class PRChecker {
       if (!lastCI || lastCI.date < ci.date) {
         lastCI = {
           typeName: name,
-          date: ci.date
+          date: ci.date,
+          jobId: ci.jobid
         };
       }
     }
@@ -270,6 +284,16 @@ class PRChecker {
           cli.warn(infoMsg);
         }
       }
+
+      // Check the last CI run for its results.
+      const build = new PRBuild(cli, request, lastCI.jobId);
+      const { result, failures } = await build.getResults();
+
+      if (result === 'FAILURE') {
+        cli.error(
+          `${failures.length} failure(s) on the last Jenkins CI run`);
+        status = false;
+      }
     }
 
     this.CIStatus = status;
@@ -298,12 +322,12 @@ class PRChecker {
     // GitHub new Check API
     for (const { status, conclusion } of checkSuites.nodes) {
       if (status !== 'COMPLETED') {
-        cli.error('CI is still running');
+        cli.error('GitHub CI is still running');
         return false;
       }
 
       if (!['SUCCESS', 'NEUTRAL'].includes(conclusion)) {
-        cli.error('Last CI failed');
+        cli.error('Last GitHub CI failed');
         return false;
       }
     }
@@ -312,17 +336,17 @@ class PRChecker {
     if (commit.status) {
       const { state } = commit.status;
       if (state === 'PENDING') {
-        cli.error('CI is still running');
+        cli.error('GitHub CI is still running');
         return false;
       }
 
       if (!['SUCCESS', 'EXPECTED'].includes(state)) {
-        cli.error('Last CI failed');
+        cli.error('Last GitHub CI failed');
         return false;
       }
     }
 
-    cli.info('Last CI run was successful');
+    cli.info('Last GitHub CI successful');
     this.CIStatus = true;
     return true;
   }

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -59,7 +59,7 @@ describe('PRChecker', () => {
         return PRData.prototype.getThread.call(this);
       }
     };
-    const checker = new PRChecker(cli, data, argv);
+    const checker = new PRChecker(cli, data, {}, argv);
 
     let checkReviewsAndWaitStub;
     let checkCIStub;
@@ -90,8 +90,8 @@ describe('PRChecker', () => {
       checkGitConfigStub.restore();
     });
 
-    it('should run necessary checks', () => {
-      const status = checker.checkAll();
+    it('should run necessary checks', async() => {
+      const status = await checker.checkAll();
       assert.strictEqual(status, false);
       assert.strictEqual(checkReviewsAndWaitStub.calledOnce, true);
       assert.strictEqual(checkCIStub.calledOnce, true);
@@ -140,7 +140,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkReviewsAndWait(new Date(NOW), true);
       assert(!status);
@@ -175,7 +175,7 @@ describe('PRChecker', () => {
         collaborators,
         authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(!status);
@@ -212,7 +212,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(!status);
@@ -248,7 +248,9 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, { waitTimeMultiApproval: 23 });
+      const checker = new PRChecker(cli, data, {}, {
+        waitTimeMultiApproval: 23
+      });
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(status);
@@ -285,7 +287,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(!status);
@@ -321,7 +323,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(!status);
@@ -357,7 +359,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(!status);
@@ -391,7 +393,9 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, { waitTimeSingleApproval: 0 });
+      const checker = new PRChecker(cli, data, {}, {
+        waitTimeSingleApproval: 0
+      });
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(status);
@@ -424,7 +428,9 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, { waitTimeSingleApproval: 0 });
+      const checker = new PRChecker(cli, data, {}, {
+        waitTimeSingleApproval: 0
+      });
 
       const status = checker.checkReviewsAndWait(new Date(NOW));
       assert(!status);
@@ -467,7 +473,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       cli.clearCalls();
       const status = checker.checkReviewsAndWait(new Date(NOW));
@@ -513,7 +519,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       cli.clearCalls();
       const status = checker.checkReviewsAndWait(new Date(NOW));
@@ -556,7 +562,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       cli.clearCalls();
       const status = checker.checkReviewsAndWait(new Date(NOW));
@@ -599,7 +605,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       cli.clearCalls();
       const status = checker.checkReviewsAndWait(new Date(NOW));
@@ -609,7 +615,7 @@ describe('PRChecker', () => {
   });
 
   describe('checkCI', () => {
-    it('should error if no CI runs detected', () => {
+    it('should error if no CI runs detected', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
@@ -630,14 +636,14 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should summarize CI runs detected', () => {
+    it('should summarize CI runs detected', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
@@ -693,14 +699,16 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(status);
-      cli.assertCalledWith(expectedLogs);
+      cli.assertCalledWith(expectedLogs, {
+        ignore: ['startSpinner', 'updateSpinner', 'stopSpinner']
+      });
     });
 
-    it('should check commits after last ci', () => {
+    it('should check commits after last ci', async() => {
       const cli = new TestCLI();
       const { commits, comment } = commitsAfterCi;
 
@@ -729,14 +737,16 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
-      cli.assertCalledWith(expectedLogs);
+      cli.assertCalledWith(expectedLogs, {
+        ignore: ['startSpinner', 'updateSpinner', 'stopSpinner']
+      });
     });
 
-    it('should only log last three commits if multiple', () => {
+    it('should only log last three commits if multiple', async() => {
       const cli = new TestCLI();
       const { commits, comment } = mulipleCommitsAfterCi;
 
@@ -768,14 +778,16 @@ describe('PRChecker', () => {
         getThread() {
           return PRData.prototype.getThread.call(this);
         }
-      }, argv);
+      }, {}, argv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
-      cli.assertCalledWith(expectedLogs);
+      cli.assertCalledWith(expectedLogs, {
+        ignore: ['startSpinner', 'updateSpinner', 'stopSpinner']
+      });
     });
 
-    it('should log as expected if passed 0', () => {
+    it('should log as expected if passed 0', async() => {
       const cli = new TestCLI();
       const { commits, comment } = mulipleCommitsAfterCi;
 
@@ -804,14 +816,16 @@ describe('PRChecker', () => {
         getThread() {
           return PRData.prototype.getThread.call(this);
         }
-      }, { maxCommits: 0 });
+      }, {}, { maxCommits: 0 });
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
-      cli.assertCalledWith(expectedLogs);
+      cli.assertCalledWith(expectedLogs, {
+        ignore: ['startSpinner', 'updateSpinner', 'stopSpinner']
+      });
     });
 
-    it('should count LITE CI as valid ci requirement', () => {
+    it('should count LITE CI as valid ci requirement', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
@@ -834,11 +848,13 @@ describe('PRChecker', () => {
         getThread() {
           return PRData.prototype.getThread.call(this);
         }
-      }, { maxCommits: 0 });
+      }, {}, { maxCommits: 0 });
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(status);
-      cli.assertCalledWith(expectedLogs);
+      cli.assertCalledWith(expectedLogs, {
+        ignore: ['startSpinner', 'updateSpinner', 'stopSpinner']
+      });
     });
   });
 
@@ -856,7 +872,7 @@ describe('PRChecker', () => {
     };
     const testArgv = Object.assign({}, argv, { ciType: 'github-check' });
 
-    it('should error if no CI runs detected', () => {
+    it('should error if no CI runs detected', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
@@ -868,204 +884,204 @@ describe('PRChecker', () => {
       const commits = githubCI['no-status'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if both statuses failed', () => {
+    it('should error if both statuses failed', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         error: [
-          ['Last CI failed']
+          ['Last GitHub CI failed']
         ]
       };
 
       const commits = githubCI['both-apis-failure'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should succeed if both statuses succeeded', () => {
+    it('should succeed if both statuses succeeded', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         info: [
-          ['Last CI run was successful']
+          ['Last GitHub CI successful']
         ]
       };
 
       const commits = githubCI['both-apis-success'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if Check suite failed', () => {
+    it('should error if Check suite failed', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         error: [
-          ['Last CI failed']
+          ['Last GitHub CI failed']
         ]
       };
 
       const commits = githubCI['check-suite-failure'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if Check suite pending', () => {
+    it('should error if Check suite pending', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         error: [
-          ['CI is still running']
+          ['GitHub CI is still running']
         ]
       };
 
       const commits = githubCI['check-suite-pending'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should succeed if Check suite succeeded', () => {
+    it('should succeed if Check suite succeeded', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         info: [
-          ['Last CI run was successful']
+          ['Last GitHub CI successful']
         ]
       };
 
       const commits = githubCI['check-suite-success'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if commit status failed', () => {
+    it('should error if commit status failed', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         error: [
-          ['Last CI failed']
+          ['Last GitHub CI failed']
         ]
       };
 
       const commits = githubCI['commit-status-only-failure'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if commit status pending', () => {
+    it('should error if commit status pending', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         error: [
-          ['CI is still running']
+          ['GitHub CI is still running']
         ]
       };
 
       const commits = githubCI['commit-status-only-pending'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should succeed if commit status succeeded', () => {
+    it('should succeed if commit status succeeded', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         info: [
-          ['Last CI run was successful']
+          ['Last GitHub CI successful']
         ]
       };
 
       const commits = githubCI['commit-status-only-success'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if Check succeeded but commit status failed ', () => {
+    it('should error if Check succeeded but commit status failed ', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         error: [
-          ['Last CI failed']
+          ['Last GitHub CI failed']
         ]
       };
 
       const commits = githubCI['status-failure-check-suite-succeed'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if commit status succeeded but Check failed ', () => {
+    it('should error if commit status succeeded but Check failed ', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         error: [
-          ['Last CI failed']
+          ['Last GitHub CI failed']
         ]
       };
 
       const commits = githubCI['status-succeed-check-suite-failure'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should error if last commit doesnt have CI', () => {
+    it('should error if last commit doesnt have CI', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
@@ -1077,35 +1093,35 @@ describe('PRChecker', () => {
       const commits = githubCI['two-commits-first-ci'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
 
-    it('should succeed with two commits if last one has CI', () => {
+    it('should succeed with two commits if last one has CI', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
         info: [
-          ['Last CI run was successful']
+          ['Last GitHub CI successful']
         ]
       };
 
       const commits = githubCI['two-commits-last-ci'];
       const data = Object.assign({}, baseData, { commits });
 
-      const checker = new PRChecker(cli, data, testArgv);
+      const checker = new PRChecker(cli, data, {}, testArgv);
 
-      const status = checker.checkCI();
+      const status = await checker.checkCI();
       assert(status);
       cli.assertCalledWith(expectedLogs);
     });
   });
 
   describe('checkAuthor', () => {
-    it('should check odd commits for first timers', () => {
+    it('should check odd commits for first timers', async() => {
       const cli = new TestCLI();
 
       const expectedLogs = {
@@ -1128,8 +1144,8 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
-      const status = checker.checkAuthor();
+      const checker = new PRChecker(cli, data, {}, argv);
+      const status = await checker.checkAuthor();
       assert(!status);
       cli.assertCalledWith(expectedLogs);
     });
@@ -1149,7 +1165,7 @@ describe('PRChecker', () => {
         collaborators,
         authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
       const status = checker.checkAuthor();
       assert(status);
       cli.assertCalledWith(expectedLogs);
@@ -1185,7 +1201,7 @@ describe('PRChecker', () => {
         }
       };
 
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
       const status = checker.checkGitConfig();
 
       assert.deepStrictEqual(status, true);
@@ -1206,7 +1222,7 @@ describe('PRChecker', () => {
         authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
       const status = checker.checkGitConfig();
 
       assert(status);
@@ -1246,7 +1262,7 @@ describe('PRChecker', () => {
         }
       };
 
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -1278,7 +1294,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -1311,7 +1327,7 @@ describe('PRChecker', () => {
           return PRData.prototype.getThread.call(this);
         }
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -1331,7 +1347,7 @@ describe('PRChecker', () => {
         commits,
         authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
@@ -1350,7 +1366,7 @@ describe('PRChecker', () => {
         getThread() {
           return PRData.prototype.getThread.call(this);
         }
-      }, argv);
+      }, {}, argv);
 
       const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, true);
@@ -1381,7 +1397,7 @@ describe('PRChecker', () => {
         }
       };
 
-      const checker = new PRChecker(cli, data, { maxCommits: 1 });
+      const checker = new PRChecker(cli, data, {}, { maxCommits: 1 });
       const status = checker.checkCommitsAfterReview();
       cli.assertCalledWith(expectedLogs);
       assert(!status);
@@ -1411,7 +1427,7 @@ describe('PRChecker', () => {
         }
       };
 
-      const checker = new PRChecker(cli, data, { maxCommits: 0 });
+      const checker = new PRChecker(cli, data, {}, { maxCommits: 0 });
       const status = checker.checkCommitsAfterReview();
       cli.assertCalledWith(expectedLogs);
       assert(!status);
@@ -1439,7 +1455,7 @@ describe('PRChecker', () => {
         collaborators,
         authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkMergeableState();
       assert.deepStrictEqual(status, false);
@@ -1459,7 +1475,7 @@ describe('PRChecker', () => {
         commits,
         authorIsNew: () => true
       };
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
 
       const status = checker.checkMergeableState();
       assert.deepStrictEqual(status, true);
@@ -1491,7 +1507,7 @@ describe('PRChecker', () => {
         authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
       const status = checker.checkPRState();
       assert.strictEqual(status, false);
       cli.assertCalledWith(expectedLogs);
@@ -1514,7 +1530,7 @@ describe('PRChecker', () => {
         authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
       const status = checker.checkPRState();
       assert.strictEqual(status, false);
       cli.assertCalledWith(expectedLogs);
@@ -1533,7 +1549,7 @@ describe('PRChecker', () => {
         authorIsNew: () => true
       };
 
-      const checker = new PRChecker(cli, data, argv);
+      const checker = new PRChecker(cli, data, {}, argv);
       const status = checker.checkPRState();
       assert.strictEqual(status, true);
       cli.assertCalledWith(expectedLogs);


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/377.

We were previously checking for actual CI results in GitHub Actions-based CI, but not for Jenkins - this adds in and updates logic to aggregate Jenkins results into landing preparation.

Using https://github.com/nodejs/node/pull/33498 as a test case:

Before:
<img width="644" alt="Screen Shot 2020-05-22 at 9 58 11 AM" src="https://user-images.githubusercontent.com/2036040/82691452-c6fc7680-9c12-11ea-938a-f58400167ff2.png">

After:
<img width="639" alt="Screen Shot 2020-05-22 at 9 57 28 AM" src="https://user-images.githubusercontent.com/2036040/82691470-d24fa200-9c12-11ea-98ad-38ccac75613d.png">

cc @sam-github @joyeecheung @targos 