### PR TITLE
fix: check missing config in Session ctor

### DIFF
--- a/components/git/land.js
+++ b/components/git/land.js
@@ -129,9 +129,7 @@ module.exports = {
 
 async function main(state, argv, cli, req, dir) {
   let session = new LandingSession(cli, req, dir);
-  if (session.warnForMissing()) {
-    return;
-  }
+
   if (state !== AMEND && state !== CONTINUE && session.warnForWrongBranch()) {
     return;
   }

--- a/lib/session.js
+++ b/lib/session.js
@@ -25,6 +25,10 @@ class Session {
 
     const { upstream, owner, repo } = this;
 
+    if (this.warnForMissing()) {
+      throw new Error('Failed to create new session');
+    }
+
     const upstreamHref = runSync('git', [
       'config', '--get',
       `remote.${upstream}.url`]).trim();

--- a/lib/sync_session.js
+++ b/lib/sync_session.js
@@ -9,9 +9,6 @@ class SyncSession extends Session {
   }
 
   async sync() {
-    if (this.warnForMissing()) {
-      return;
-    }
     if (this.warnForWrongBranch()) {
       return;
     }


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/423.

We were checking for missing config components after the Session was created, but the session ctor itself assumes those components will be present since it tries to use them to check the remote repo URL. This PR moves that check into the ctor itself for a better error experience:

<img width="592" alt="Screen Shot 2020-05-28 at 11 03 03 AM" src="https://user-images.githubusercontent.com/2036040/83177385-d0cf1f80-a0d3-11ea-85f6-731074470006.png">

cc @joyeecheung @targos 