### PR TITLE
git-node: auto amend metadata and open manual amend on request

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -197,16 +197,11 @@ class LandingSession extends Session {
     cli.separator('New Message');
     cli.log(message.trim());
     const takeMessage = await cli.prompt('Use this message?');
+    await runAsync('git', ['commit', '--amend', '-F', messageFile]);
     if (takeMessage) {
-      await runAsync('git', ['commit', '--amend', '-F', messageFile]);
       return true;
     }
-
-    // TODO: fire the configured git editor on that file
-    cli.log(`Please manually edit ${messageFile}, then run\n` +
-      `\`git commit --amend -F ${messageFile}\` ` +
-      'to finish amending the message');
-    process.exit(1);  // make it work with git rebase -x
+    await runAsync('git', ['commit', '--amend']);
   }
 
   async final() {


### PR DESCRIPTION
This makes sure manual amend is started in case the user requested
that without the need to edit any intermediate files.

Refs: https://github.com/nodejs/node-core-utils/issues/425

TODO: Add tests