### PR TITLE
fix: use git apply not system apply

### DIFF
--- a/components/git/v8.js
+++ b/components/git/v8.js
@@ -82,9 +82,14 @@ function main(argv) {
     options.v8Dir = path.resolve(options.v8Dir);
   }
 
-  options.execGitNode = function execGitNode(...args) {
-    return execa('git', args, { cwd: options.nodeDir });
+  options.execGitNode = function execGitNode(cmd, args, input) {
+    args.unshift(cmd);
+    return execa('git', args, {
+      cwd: options.nodeDir,
+      ...input && { input }
+    });
   };
+
   options.execGitV8 = function execGitV8(...args) {
     return execa('git', args, { cwd: options.v8Dir });
   };

--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 
-const execa = require('execa');
 const fs = require('fs-extra');
 const inquirer = require('inquirer');
 const Listr = require('listr');
@@ -74,8 +73,8 @@ function commitSquashedBackport() {
           messageBody += formatted + '\n\n';
         }
       }
-      await ctx.execGitNode('add', 'deps/v8');
-      await ctx.execGitNode('commit', '-m', messageTitle, '-m', messageBody);
+      await ctx.execGitNode('add', ['deps/v8']);
+      await ctx.execGitNode('commit', ['-m', messageTitle, '-m', messageBody]);
     }
   };
 };
@@ -86,8 +85,8 @@ function commitPatch(patch) {
     task: async(ctx) => {
       const messageTitle = formatMessageTitle([patch]);
       const messageBody = formatMessageBody(patch, false);
-      await ctx.execGitNode('add', 'deps/v8');
-      await ctx.execGitNode('commit', '-m', messageTitle, '-m', messageBody);
+      await ctx.execGitNode('add', ['deps/v8']);
+      await ctx.execGitNode('commit', ['-m', messageTitle, '-m', messageBody]);
     }
   };
 }
@@ -200,13 +199,10 @@ function applyPatchTask(patch) {
 
 async function applyPatch(ctx, patch) {
   try {
-    await execa(
-      'patch',
-      ['-p1', '--merge', '--no-backup-if-mismatch', '--directory=deps/v8'],
-      {
-        cwd: ctx.nodeDir,
-        input: patch.data
-      }
+    await ctx.execGitNode(
+      'apply',
+      ['-p1', '--3way', '--directory=deps/v8'],
+      patch.data /* input */
     );
   } catch (e) {
     patch.hadConflicts = true;
@@ -246,7 +242,7 @@ function incrementEmbedderVersion() {
         commonGypiPath,
         commonGypi.replace(embedderRegex, embedderString)
       );
-      await ctx.execGitNode('add', 'common.gypi');
+      await ctx.execGitNode('add', ['common.gypi']);
     }
   };
 }


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/421.

Switches to `git apply` vs system `apply`, since the available options for system `apply` differ between systems.

cc @targos 