### PR TITLE
fix: correct for new execGitNode syntax

### DIFF
--- a/lib/update-v8/commitUpdate.js
+++ b/lib/update-v8/commitUpdate.js
@@ -7,7 +7,7 @@ module.exports = function() {
     title: 'Commit V8 update',
     task: async(ctx) => {
       const newV8Version = util.getNodeV8Version(ctx.nodeDir).join('.');
-      await ctx.execGitNode('add', 'deps/v8');
+      await ctx.execGitNode('add', ['deps/v8']);
       const moreArgs = [];
       let message;
       if (ctx.minor) {
@@ -21,7 +21,7 @@ module.exports = function() {
       } else {
         message = `deps: update V8 to ${newV8Version}`;
       }
-      await ctx.execGitNode('commit', '-m', message, ...moreArgs);
+      await ctx.execGitNode('commit', ['-m', message, ...moreArgs]);
     },
     skip: (ctx) => ctx.skipped
   };

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -29,15 +29,16 @@ function bumpNodeModule() {
       await updateModuleVersion(ctx.nodeDir, newModuleVersion, v8Version);
       await ctx.execGitNode(
         'add',
-        'doc/abi_version_registry.json',
-        'src/node_version.h'
+        ['doc/abi_version_registry.json', 'src/node_version.h']
       );
       await ctx.execGitNode(
         'commit',
-        '-m',
-        getCommitTitle(newModuleVersion),
-        '-m',
-        getCommitBody(v8Version)
+        [
+          '-m',
+          getCommitTitle(newModuleVersion),
+          '-m',
+          getCommitBody(v8Version)
+        ]
       );
     },
     skip: (ctx) => !ctx.versionBump
@@ -103,11 +104,10 @@ function resetEmbedderString() {
           commonGypiPath,
           commonGypi.replace(embedderRegex, embedderString)
         );
-        await ctx.execGitNode('add', 'common.gypi');
+        await ctx.execGitNode('add', ['common.gypi']);
         await ctx.execGitNode(
           'commit',
-          '-m',
-          'build: reset embedder string to "-node.0"'
+          ['-m', 'build: reset embedder string to "-node.0"']
         );
       } else {
         return task.skip('Embedder version is already 0');


### PR DESCRIPTION
Refs https://github.com/nodejs/node-core-utils/pull/432.

Corrects usages of `ctx.execGitNode` to account for new signature.

cc @targos 