### PR TITLE
fix: write file to the current folder

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -14,7 +14,7 @@ exports.appendFile = function(file, content) {
 
 exports.writeFile = function(file, content) {
   const parts = path.parse(file);
-  if (!fs.existsSync(parts.dir)) {
+  if (parts.dir !== '' && !fs.existsSync(parts.dir)) {
     fs.mkdirSync(parts.dir, { recursive: true });
   }
   // TODO(joyeecheung): what if the file is a dir?


### PR DESCRIPTION
Trying to run:
```
ncu-ci walk pr --stats=true --cache=true --markdown results.md
```
will fail with:
```
Error: ENOENT: no such file or directory, mkdir
    at Object.mkdirSync (fs.js:940:3)
    at exports.writeFile (C:\Users\ja\AppData\Local\nvs\node\14.1.0\x64\node_modules\node-core-utils\lib\file.js:19:8)
    at WalkCommand.serialize (C:\Users\ja\AppData\Local\nvs\node\14.1.0\x64\node_modules\node-core-utils\bin\ncu-ci:229:9)
    at main (C:\Users\ja\AppData\Local\nvs\node\14.1.0\x64\node_modules\node-core-utils\bin\ncu-ci:371:24)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  errno: -4058,
  syscall: 'mkdir',
  code: 'ENOENT'
}
```
(at least on Windows).

This fixes this by first checking if there is any folder to create before calling `mkdir`.