### PR TITLE
fix: lint during the landing process

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -199,7 +199,13 @@ class LandingSession extends Session {
 
     const cleanLint = await this.validateLint(patch);
     if (!cleanLint) {
-      const correctedLint = await cli.prompt('Corrected lint errors?');
+      const tryFixLint = await cli.prompt(
+        'Try fixing JS lint with \'make lint-js-fix\'?');
+      if (tryFixLint) {
+        await runAsync('make', ['lint-js-fix']);
+      }
+
+      const correctedLint = await cli.prompt('Corrected all lint errors?');
       if (correctedLint) {
         await runAsync('git', ['add', '.']);
 

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -132,18 +132,12 @@ class LandingSession extends Session {
   }
 
   async validateLint() {
-    const { cli } = this;
-
     // The linter is currently only run on non-Windows platforms.
     if (os.platform() === 'win32') {
       return true;
     }
 
     const linted = await runAsync('make', ['lint']);
-    if (!linted) {
-      cli.warn('There are lint errors in your patch. ' +
-        'Please fix them before proceeding');
-    }
     return linted;
   }
 
@@ -197,12 +191,17 @@ class LandingSession extends Session {
 
     const patch = await this.downloadAndPatch();
 
-    const cleanLint = await this.validateLint(patch);
+    const cleanLint = await this.validateLint();
     if (!cleanLint) {
       const tryFixLint = await cli.prompt(
-        'Try fixing JS lint with \'make lint-js-fix\'?');
+        'Lint failed - try fixing with \'make lint-js-fix\'?');
       if (tryFixLint) {
         await runAsync('make', ['lint-js-fix']);
+        const fixed = await this.validateLint();
+        if (!fixed) {
+          cli.warn('Patch still contains lint errors. ' +
+            'Please fix manually before proceeding');
+        }
       }
 
       const correctedLint = await cli.prompt('Corrected all lint errors?');

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const os = require('os');
 const {
   getUnmarkedDeprecations,
   updateDeprecations
@@ -130,8 +131,25 @@ class LandingSession extends Session {
     return command;
   }
 
-  async suggestAfterPatch(patch) {
+  async validateLint() {
     const { cli } = this;
+
+    // The linter is currently only run on non-Windows platforms.
+    if (os.platform() === 'win32') {
+      return true;
+    }
+
+    const linted = await runAsync('make', ['lint']);
+    if (!linted) {
+      cli.warn('There are lint errors in your patch. ' +
+        'Please fix them before proceeding');
+    }
+    return linted;
+  }
+
+  async tryCompleteLanding(patch) {
+    const { cli } = this;
+
     const subjects = patch.match(/Subject: \[PATCH.*?\].*/g);
     if (!subjects) {
       cli.warn('Cannot get number of commits in the patch. ' +
@@ -154,6 +172,7 @@ class LandingSession extends Session {
       if (!canFinal) {
         return;
       }
+
       return this.final();
     }
 
@@ -167,16 +186,36 @@ class LandingSession extends Session {
 
   async apply() {
     const { cli } = this;
+
+    // Bail if another landing session is currently in progress.
     if (!this.isApplying()) {
-      cli.warn('This session can not proceed to apply patches, ' +
-        'run `git node land --abort`');
+      cli.warn('Landing session already in progress - ' +
+        'to start a new one run `git node land --abort`');
       return;
     }
     await this.tryResetBranch();
 
     const patch = await this.downloadAndPatch();
+
+    const cleanLint = await this.validateLint(patch);
+    if (!cleanLint) {
+      const correctedLint = await cli.prompt('Corrected lint errors?');
+      if (correctedLint) {
+        await runAsync('git', ['add', '.']);
+
+        // Final message will be edited later - don't try to change it here.
+        await runAsync('git', ['commit', '--amend', '--no-edit']);
+      } else {
+        cli.info('Please fix lint errors and then run ' +
+        '`git node land --amend` followed by ' +
+        '`git node land --continue`.');
+        process.exit(1);
+      }
+    }
+
     this.startAmending();
-    await this.suggestAfterPatch(patch);
+
+    await this.tryCompleteLanding(patch);
   }
 
   async amend() {
@@ -239,7 +278,8 @@ class LandingSession extends Session {
   async final() {
     const { cli, owner, repo, upstream, branch, prid } = this;
 
-    if (!this.readyToFinal()) {  // check git rebase/am has been done
+    // Check that git rebase/am has been completed.
+    if (!this.readyToFinal()) {
       cli.warn('Not yet ready to final');
       cli.log('A git rebase/am is in progress.' +
         ' Please complete it before running git node land --final');
@@ -301,13 +341,14 @@ class LandingSession extends Session {
       return this.amend();
     }
     if (this.isApplying()) {
-      // We are resolving conflict
+      // We're still resolving conflicts.
       if (this.amInProgress()) {
         cli.log('Looks like you are resolving a `git am` conflict');
         cli.log('Please run `git status` for help');
-      } else {  // The conflict has been resolved
+      } else {
+        // Conflicts has been resolved - amend.
         this.startAmending();
-        return this.suggestAfterPatch(this.patch);
+        return this.tryCompleteLanding(this.patch);
       }
       return;
     }


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/427.

Runs `make lint` after the patch has been downloaded and applied, and optionally stage and amend updated files if lint fails.