### PR TITLE
fix: warn on whitespace during landing

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -67,7 +67,7 @@ class LandingSession extends Session {
     cli.separator();
     // TODO: check that patches downloaded match metadata.commits
     try {
-      await forceRunAsync('git', ['am', '--whitespace=fix', this.patchPath], {
+      await forceRunAsync('git', ['am', this.patchPath], {
         ignoreFailure: false
       });
     } catch (ex) {
@@ -78,7 +78,6 @@ class LandingSession extends Session {
         await runAsync('git', [
           'am',
           '-3',
-          '--whitespace=fix',
           this.patchPath
         ]);
       } else {


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/400.

Changes `downloadAndPatch()` such that whitespace issues aren't automatically fixed and a warning message is output to console instead (default behavior for the whitespace option of `git apply`)

cc @mmarchini @targos 