### PR TITLE
fix: also exclude backport-open label from branch diff

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -465,7 +465,8 @@ class ReleasePreparation {
         `dont-land-on-v${majorVersion}.x`,
         `backport-requested-v${majorVersion}.x`,
         `backported-to-v${majorVersion}.x`,
-        `backport-blocked-v${majorVersion}.x`
+        `backport-blocked-v${majorVersion}.x`,
+        `backport-open-v${majorVersion}.x`
       ];
 
       let comparisonBranch = 'master';

--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -466,7 +466,8 @@ class ReleasePreparation {
         `backport-requested-v${majorVersion}.x`,
         `backported-to-v${majorVersion}.x`,
         `backport-blocked-v${majorVersion}.x`,
-        `backport-open-v${majorVersion}.x`
+        `backport-open-v${majorVersion}.x`,
+        'baking-for-lts'
       ];
 
       let comparisonBranch = 'master';


### PR DESCRIPTION
We should also be excluding PRs with the `backport-open-vX.Yx` label from branch diffs.

cc @targos @BridgeAR 