### PR TITLE
ncu-ci: create INFRA_FAILURES category

### DIFF
--- a/lib/ci/ci_failure_parser.js
+++ b/lib/ci/ci_failure_parser.js
@@ -34,10 +34,12 @@ const JENKINS_FAILURE = 'JENKINS_FAILURE';
 const GIT_FAILURE = 'GIT_FAILURE';
 const NCU_FAILURE = 'NCU_FAILURE';
 const RESUME_FAILURE = 'RESUME_FAILURE';
+const INFRA_FAILURE = 'INFRA_FAILURE';
 
 const FAILURE_TYPES = {
   BUILD_FAILURE, JS_TEST_FAILURE, CC_TEST_FAILURE,
-  JENKINS_FAILURE, GIT_FAILURE, NCU_FAILURE, RESUME_FAILURE
+  JENKINS_FAILURE, GIT_FAILURE, NCU_FAILURE, RESUME_FAILURE,
+  INFRA_FAILURE
 };
 
 class CIResult {
@@ -57,6 +59,14 @@ class BuildFailure extends CIResult {
   constructor(ctx, reason) {
     super(ctx, reason);
     this.type = BUILD_FAILURE;
+  }
+}
+
+// Usually needs to fix something in the Jenkins agent (or just restart it)
+class InfraFailure extends CIResult {
+  constructor(ctx, reason) {
+    super(ctx, reason);
+    this.type = INFRA_FAILURE;
   }
 }
 
@@ -126,6 +136,25 @@ function failureMatcher(Failure, patterns, ctx, text) {
 
 // The elements are ranked by priority
 const FAILURE_FILTERS = [{
+  // NOTE(mmarchini): infra-related issues should have the highest priority, as
+  // they can cause other issues to happen.
+  filter(ctx, text) {
+    const patterns = [{
+      pattern: /Read-only file system/g,
+      context: { index: 0, contextBefore: 1, contextAfter: 0 }
+    },
+    {
+      pattern: /Device or resource busy/g,
+      context: { index: 0, contextBefore: 1, contextAfter: 0 }
+    },
+    {
+      pattern: /There is not enough space in the file system./g,
+      context: { index: 0, contextBefore: 1, contextAfter: 0 }
+    }
+    ];
+    return failureMatcher(InfraFailure, patterns, ctx, text);
+  }
+}, {
   // TODO: match indentation to avoid skipping context with '...'
   filter(ctx, text) {
     const pattern = /not ok \d+[\s\S]+? {2}\.\.\.\r?\n/mg;
@@ -203,9 +232,6 @@ const FAILURE_FILTERS = [{
 }, {
   filter(ctx, text) {
     const patterns = [{
-      pattern: /There is not enough space in the file system./g,
-      context: { index: 0, contextBefore: 0, contextAfter: 5 }
-    }, {
       pattern: /sh: line /g,
       context: { index: 0, contextBefore: 0, contextAfter: 1 }
     }, {


### PR DESCRIPTION
Some errors we see are caused by underlying infrastructure issues (most
commonly filesystem corruption). Correctly classifying can help when
collecting statistics, when pinging the build team, or even for
automated notification (see
https://github.com/nodejs/build/issues/2359).