### PR TITLE
feat: set error code in some failure cases

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -164,6 +164,10 @@ class CLI {
       this.log(prefix + chalk.bold(`${error}  ${obj}`));
     }
   }
+
+  setExitCode(statusCode) {
+    process.exitCode = statusCode;
+  }
 };
 
 CLI.SPINNER_STATUS = SPINNER_STATUS;

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -53,6 +53,7 @@ class LandingSession extends Session {
       await this.tryResetBranch();
     }
     cli.ok(`Aborted \`git node land\` session in ${this.ncuDir}`);
+    cli.setExitCode(1);
   }
 
   async downloadAndPatch() {

--- a/lib/session.js
+++ b/lib/session.js
@@ -35,6 +35,7 @@ class Session {
     if (!new RegExp(`${owner}/${repo}(?:.git)?$`).test(upstreamHref)) {
       cli.warn('Remote repository URL does not point to the expected ' +
         `repository ${owner}/${repo}`);
+      cli.setExitCode(1);
     }
   }
 
@@ -343,6 +344,7 @@ class Session {
         '`master` branch, you can run:\n\n' +
         '  $ ncu-config set branch master');
       cli.separator();
+      cli.setExitCode(1);
     }
     if (!upstream) {
       cli.warn('You have not told git-node the remote you want to sync with.');
@@ -352,6 +354,7 @@ class Session {
         ' `remote-upstream`, you can run:\n\n' +
         '  $ ncu-config set upstream remote-upstream');
       cli.separator();
+      cli.setExitCode(1);
     }
     return missing;
   }
@@ -363,6 +366,7 @@ class Session {
       cli.warn(
         'You are in detached HEAD state. Please run git-node on a valid ' +
         'branch');
+      cli.setExitCode(1);
       return true;
     }
     if (rev === branch) {
@@ -377,6 +381,7 @@ class Session {
       '   reconfigure the target branch with:\n\n' +
       `  $ ncu-config set branch ${rev}`);
     cli.separator();
+    cli.setExitCode(1);
     return true;
   // TODO warn if backporting onto master branch
   }


### PR DESCRIPTION
Adds an method to `cli` to set the process exit code, and use that
method on some known failure situations (missing config and `git node land`
failed checks). There are still more places where we should set exit
code.

Ref: https://github.com/nodejs/node-core-utils/issues/442