### PR TITLE
land: allow --yes to be used with other options

### DIFF
--- a/components/git/land.js
+++ b/components/git/land.js
@@ -89,6 +89,7 @@ function handler(argv) {
 
   const provided = [];
   for (const type of Object.keys(landOptions)) {
+    if (type === 'yes') continue;  // --yes is not an action
     if (argv[type]) {
       provided.push(type);
     }
@@ -134,6 +135,9 @@ async function main(state, argv, cli, req, dir) {
     return;
   }
 
+  if (argv.yes) {
+    cli.setAssumeYes();
+  }
   try {
     session.restore();
   } catch (err) { // JSON error?


### PR DESCRIPTION
--yes only worked with plain `git node land`, other options such as
--continue or --abort didn't accept --yes. Now it's possible to use
--yes with other options.