### PR TITLE
fix: spacing in warnForWrongBranch()

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -522,7 +522,7 @@ class ReleasePreparation {
     cli.separator();
     cli.info(
       `Switch to \`${stagingBranch}\` with \`git` +
-      `checkout ${stagingBranch}\` before proceeding.`);
+      ` checkout ${stagingBranch}\` before proceeding.`);
     cli.separator();
     return true;
   }


### PR DESCRIPTION
Fixes a teeny spacing issue in `warnForWrongBranch()` when running release prep:

Before:
```sh
node on git:v14.x-staging ❯ g node release --prepare                           8:33PM
   ⚠  You are trying to create a new release proposal branch for v15, but you're checked out on v14.x-staging and not v15.x-staging.
--------------------------------------------------------------------------------
   ℹ  Switch to `v15.x-staging` with `gitcheckout v15.x-staging` before proceeding.
--------------------------------------------------------------------------------
```

After: 
```sh
node on git:v14.x-staging ❯ g node release --prepare                           8:34PM
   ⚠  You are trying to create a new release proposal branch for v15, but you're checked out on v14.x-staging and not v15.x-staging.
--------------------------------------------------------------------------------
   ℹ  Switch to `v15.x-staging` with `git checkout v15.x-staging` before proceeding.
--------------------------------------------------------------------------------
```

cc @targos @BridgeAR 