### PR TITLE
land: fix --abort exit status code

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -38,6 +38,7 @@ class LandingSession extends Session {
     const shouldContinue = await cli.prompt(
       `This PR ${status} to land, do you want to continue?`, { defaultAnswer });
     if (!shouldContinue) {
+      cli.setExitCode(1);
       return this.abort(false);
     }
 
@@ -47,13 +48,19 @@ class LandingSession extends Session {
   }
 
   async abort(tryResetBranch = true) {
-    const { cli } = this;
-    this.cleanFiles();
-    if (tryResetBranch) {
-      await this.tryResetBranch();
+    try {
+      const { cli } = this;
+      this.cleanFiles();
+      if (tryResetBranch) {
+        await this.tryResetBranch();
+      }
+      cli.ok(`Aborted \`git node land\` session in ${this.ncuDir}`);
+    } catch (ex) {
+      const { cli } = this;
+      cli.setExitCode(1);
+      cli.error(`Couldn't abort \`git node land\` session in ${this.ncuDir}`);
+      throw ex;
     }
-    cli.ok(`Aborted \`git node land\` session in ${this.ncuDir}`);
-    cli.setExitCode(1);
   }
 
   async downloadAndPatch() {


### PR DESCRIPTION
`--abort` shouldn't exit with error status code unless something goes
wrong.