### PR TITLE
land: optional deprecations update

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -88,17 +88,20 @@ class LandingSession extends Session {
     }
 
     // Check for and maybe assign any unmarked deprecations in the codebase.
-    const unmarkedDeprecations = await getUnmarkedDeprecations();
-    const unmarkedDepCount = unmarkedDeprecations.length;
-    if (unmarkedDepCount > 0) {
-      cli.startSpinner('Assigning deprecation numbers to DEPOXXX items');
+    if (this.updateDeprecations !== 'yes') {
+      const unmarkedDeprecations = await getUnmarkedDeprecations();
+      const unmarkedDepCount = unmarkedDeprecations.length;
+      if (unmarkedDepCount > 0) {
+        cli.startSpinner('Assigning deprecation numbers to DEPOXXX items');
 
-      // Update items then stage files and amend the last commit.
-      await updateDeprecations(unmarkedDeprecations);
-      await runAsync('git', ['add', 'doc', 'lib', 'src', 'test']);
-      await runAsync('git', ['commit', '--amend', '--no-edit']);
+        // Update items then stage files and amend the last commit.
+        await updateDeprecations(unmarkedDeprecations);
+        await runAsync('git', ['add', 'doc', 'lib', 'src', 'test']);
+        await runAsync('git', ['commit', '--amend', '--no-edit']);
 
-      cli.stopSpinner(`Updated ${unmarkedDepCount} DEPOXXX items in codebase`);
+        cli
+          .stopSpinner(`Updated ${unmarkedDepCount} DEPOXXX items in codebase`);
+      }
     }
 
     cli.ok('Patches applied');

--- a/lib/session.js
+++ b/lib/session.js
@@ -60,6 +60,7 @@ class Session {
       readme: this.readme,
       waitTimeSingleApproval: this.waitTimeSingleApproval,
       waitTimeMultiApproval: this.waitTimeMultiApproval,
+      updateDeprecations: this.updateDeprecations,
       ciType: this.ciType,
       prid: this.prid
     };
@@ -107,6 +108,10 @@ class Session {
 
   get pullDir() {
     return path.join(this.ncuDir, `${this.prid}`);
+  }
+
+  get updateDeprecations() {
+    return this.config.updateDeprecations || 'yes';
   }
 
   startLanding() {


### PR DESCRIPTION
node-core-utils is also used on other repositories across the Node.js
Org where deprecations are not logged into a file. Making it opt-out
allows node-core-utils to still be used on those repositories.