### PR TITLE
fix: landing when no Jenkins CI has been run for PR

### DIFF
--- a/lib/ci/ci_result_parser.js
+++ b/lib/ci/ci_result_parser.js
@@ -117,7 +117,7 @@ class Job {
 
   async getBuildData() {
     const { cli, path } = this;
-    cli.startSpinner(`Querying data of ${path}`);
+    cli.startSpinner(`Querying data for ${path}`);
     const data = await this.getAPIData();
     cli.stopSpinner('Build data downloaded');
     return data;
@@ -679,6 +679,18 @@ class PRBuild extends TestBuild {
     const {
       result, subBuilds, changeSet, actions, timestamp
     } = data;
+
+    // No builds found.
+    if (data.status === '404') {
+      const failure = new BuildFailure(this, 'No builds found for PR');
+      this.failures = [failure];
+      return {
+        result: data.result,
+        builds: { failed: [], aborted: [], pending: [], unstable: [] },
+        failures: this.failures
+      };
+    }
+
     this.setBuildData(data);
 
     // No sub build at all


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/452.

Fixes the following error:

```
------------------------------ Generated metadata ------------------------------
PR-URL: 
Backport-PR-URL: https://github.com/nodejs/node/pull/33126
Refs: https://github.com/nodejs/node/pull/32763
--------------------------------------------------------------------------------
   ℹ  Last Full PR CI on 2020-04-28T15:56:53Z: https://ci.nodejs.org/job/node-test-pull-request/31061/
   ⚠  Commits were pushed after the last Full PR CI run:
   ⚠  - stream: runtime deprecate Transform._transformState
✔  Build data downloaded
{
  servlet: 'Stapler',
  message: 'Not Found',
  url: '/job/node-test-pull-request/31061/api/json',
  status: '404'
}
TypeError: Cannot read property 'find' of undefined
    at PRBuild.setBuildData (/Users/codebytere/Developer/node-core-utils/lib/ci/ci_result_parser.js:208:28)
    at PRBuild.getResults (/Users/codebytere/Developer/node-core-utils/lib/ci/ci_result_parser.js:696:10)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async PRChecker.checkJenkinsCI (/Users/codebytere/Developer/node-core-utils/lib/pr_checker.js:290:36)
    at async PRChecker.checkCI (/Users/codebytere/Developer/node-core-utils/lib/pr_checker.js:219:16)
    at async PRChecker.checkAll (/Users/codebytere/Developer/node-core-utils/lib/pr_checker.js:75:7)
    at async getMetadata (/Users/codebytere/Developer/node-core-utils/components/metadata.js:43:18)
    at async main (/Users/codebytere/Developer/node-core-utils/components/git/land.js:163:22)
```

caused when no Jenkins CI has been run in so long that it's a 404. Seen when trying to land https://ci.nodejs.org/job/node-test-pull-request/31061/.

cc @targos @mmarchini 