### PR TITLE
fix: print full command in case of failure

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -16,7 +16,7 @@ function runAsyncBase(cmd, args, options = {}) {
         if (ignoreFailure) {
           return reject(new Error(IGNORE));
         }
-        const err = new Error(`${cmd} failed: ${code}`);
+        const err = new Error(`${cmd} ${args} failed: ${code}`);
         err.code = code;
         err.messageOnly = true;
         return reject(err);
@@ -57,7 +57,8 @@ exports.runSync = function(cmd, args, options) {
   if (child.error) {
     throw child.error;
   } else if (child.status !== 0) {
-    throw new Error(child.stderr.toString());
+    throw new Error(`${cmd} ${args} failed with stderr: ` +
+                    child.stderr.toString());
   } else {
     return child.stdout.toString();
   }


### PR DESCRIPTION
This is extremely useful for debugging when stderr is empty.

@Trott @BethGriggs 