### PR TITLE
git-node: group notable changes during release prep

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -457,7 +457,8 @@ class ReleasePreparation {
         `${upstream}/${releaseBranch}`,
         proposalBranch,
         `--require-label=${notableLabels.join(',')}`,
-        `--format=${opts.format || 'markdown'}`
+        `--format=${opts.format || 'markdown'}`,
+        '--group'
       ];
     } else {
       const excludeLabels = [


### PR DESCRIPTION
Changelogs were previously grouped but Notable Changes should be as well.

cc @MylesBorins 