### PR TITLE
fix: ensure node-test-commit job id in daily-master

### DIFF
--- a/bin/ncu-ci
+++ b/bin/ncu-ci
@@ -239,8 +239,15 @@ class CICommand {
         case DAILY_MASTER: {
           const daily = new DailyBuild(cli, request, job.jobid);
           const data = await daily.getBuildData();
-          build = new CommitBuild(cli, request, data.subBuilds[0].buildNumber);
-          break;
+          const testCommitBuild = data.subBuilds.filter(subBuild => {
+            return subBuild.jobName === 'node-test-commit';
+          })[0];
+          if (testCommitBuild) {
+            build = new CommitBuild(cli, request, testCommitBuild.buildNumber);
+            break;
+          } else {
+            throw new Error('Could not find \'node-test-commit\' job');
+          }
         }
         default:
           throw new Error(`Unknown job type ${job.type}`);

--- a/lib/ci/ci_result_parser.js
+++ b/lib/ci/ci_result_parser.js
@@ -225,13 +225,6 @@ class TestBuild extends Job {
     this.builtOn = builtOn;
   }
 
-  setDailyBuildData({ result, changeSet, actions, timestamp, builtOn }) {
-    this.change = changeSet.items[0] || {};
-    this.date = new Date(timestamp);
-    this.result = result;
-    this.builtOn = builtOn;
-  }
-
   get sourceURL() {
     const { params } = this;
 


### PR DESCRIPTION
Refs https://github.com/nodejs/node-core-utils/pull/379.


Fixes the following error:

```
node-core-utils on git:fix-set-daily-build-data ❯ ncu-ci daily                 11:55AM✔  Done--------------------------------------------------------------------------------
[1/16] Running health
--------------------------------------------------------------------------------
| UTC Time         | RUNNING | SUCCESS | UNSTABLE | ABORTED | FAILURE | Green Rate |
| ---------------- | ------- | ------- | -------- | ------- | ------- | ---------- |
| 2020-07-20 18:55 | 0       | 6       | 5        | 1       | 34      | 13.33%     |

--------------------------------------------------------------------------------
[2/16] Running https://ci.nodejs.org/job/node-daily-master/2004/
--------------------------------------------------------------------------------
{
  link: 'https://ci.nodejs.org/job/node-daily-master/2004/',
  jobid: 2004,
  type: 'DAILY_MASTER'
}
✔  Build data downloaded
✔  Build data downloaded
TypeError: Cannot read property 'find' of undefined
    at CommitBuild.setBuildData (/Users/codebytere/Developer/node-core-utils/lib/ci/ci_result_parser.js:217:28)
    at CommitBuild.getResults (/Users/codebytere/Developer/node-core-utils/lib/ci/ci_result_parser.js:638:10)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async DailyCommand.drain (/Users/codebytere/Developer/node-core-utils/bin/ncu-ci:253:7)
    at async main (/Users/codebytere/Developer/node-core-utils/bin/ncu-ci:460:3)
```

Which was occurring because we have several sub-builds:
```
[
  {
    build: { _class: 'hudson.matrix.MatrixBuild' },
    buildNumber: 34,
    jobName: 'node-test-commit-ibmi',
    result: 'FAILURE',
    url: 'job/node-test-commit-ibmi/34/'
  },
  {
    build: {
      _class: 'com.tikal.jenkins.plugins.multijob.MultiJobBuild',
      subBuilds: [Array]
    },
    buildNumber: 39692,
    jobName: 'node-test-commit',
    result: 'FAILURE',
    url: 'job/node-test-commit/39692/'
  },
  {
    build: { _class: 'hudson.model.FreeStyleBuild' },
    buildNumber: 15437,
    jobName: 'node-test-commit-custom-suites-freestyle',
    result: 'SUCCESS',
    url: 'job/node-test-commit-custom-suites-freestyle/15437/'
  }
]
```

And so need to filter for the `'node-test-commit'` one instead of just grabbing the one at the first index.

Also removes `setDailyBuildData`, as the function was unused.

cc @AshCripps @joyeecheung 