### PR TITLE
fix: repo/path mismatch in v8 update

### DIFF
--- a/lib/update-v8/constants.js
+++ b/lib/update-v8/constants.js
@@ -34,8 +34,7 @@ const zlibIgnore = `!/third_party/zlib
 exports.v8Deps = [
   {
     name: 'trace_event',
-    repo: 'v8/base/trace_event/common',
-    path: 'base/trace_event/common',
+    repo: 'base/trace_event/common',
     gitignore: {
       match: '/base\n',
       replace: ''
@@ -44,8 +43,7 @@ exports.v8Deps = [
   },
   {
     name: 'gtest',
-    repo: 'v8/testing/gtest',
-    path: 'testing/gtest',
+    repo: 'testing/gtest',
     gitignore: {
       match: '/testing/gtest',
       replace: gtestReplace
@@ -55,22 +53,19 @@ exports.v8Deps = [
   },
   {
     name: 'jinja2',
-    repo: 'v8/third_party/jinja2',
-    path: 'third_party/jinja2',
+    repo: 'third_party/jinja2',
     gitignore: '!/third_party/jinja2',
     since: 56
   },
   {
     name: 'markupsafe',
-    repo: 'v8/third_party/markupsafe',
-    path: 'third_party/markupsafe',
+    repo: 'third_party/markupsafe',
     gitignore: '!/third_party/markupsafe',
     since: 56
   },
   {
     name: 'googletest',
-    repo: 'v8/third_party/googletest/src',
-    path: 'third_party/googletest/src',
+    repo: 'third_party/googletest/src',
     gitignore: {
       match: '/third_party/googletest/src',
       replace: googleTestReplace
@@ -79,8 +74,7 @@ exports.v8Deps = [
   },
   {
     name: 'zlib',
-    repo: 'v8/third_party/zlib',
-    path: 'third_party/zlib',
+    repo: 'third_party/zlib',
     gitignore: zlibIgnore,
     since: 80
   }

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -113,7 +113,7 @@ function updateV8Deps() {
           }
         }
         const [repo, commit] = await readDeps(ctx.nodeDir, dep.repo);
-        const thePath = path.join(ctx.nodeDir, 'deps/v8', dep.path);
+        const thePath = path.join(ctx.nodeDir, 'deps/v8', dep.repo);
         await fetchFromGit(thePath, repo, commit);
       }
       /* eslint-enable */


### PR DESCRIPTION
Closes https://github.com/nodejs/node-v8/issues/166.

It appears that the latest version of V8 has stripped the `v8/` prefix out of pathing, so e.g in DEPS:

```js
  'v8/build':
    Var('chromium_url') + '/chromium/src/build.git' + '@' + '1b904cc30093c25d5fd48389bd58e3f7409bcf80',
  'v8/third_party/depot_tools':
    Var('chromium_url') + '/chromium/tools/depot_tools.git' + '@' + '454f4ba4b3a69feb03c73f93d789062033433b4c',
  'v8/third_party/icu':
    Var('chromium_url') + '/chromium/deps/icu.git' + '@' + 'f2223961702f00a8833874b0560d615a2cc42738',
  'v8/third_party/instrumented_libraries':
    Var('chromium_url') + '/chromium/src/third_party/instrumented_libraries.git' + '@' + 'bb3f1802c237dd19105dd0f7919f99e536a39d10',
  'v8/buildtools':
    Var('chromium_url') + '/chromium/src/buildtools.git' + '@' + '204a35a2a64f7179f8b76d7a0385653690839e21',
  'v8/buildtools/clang_format/script':
    Var('chromium_url') + '/chromium/llvm-project/cfe/tools/clang-format.git' + '@' + '96636aa0e9f047f17447f2d45a094d0b59ed7917',
  'v8/buildtools/linux64': {
    'packages': [
      {
        'package': 'gn/gn/linux-amd64',
        'version': Var('gn_version'),
      }
    ],
    'dep_type': 'cipd',
    'condition': 'host_os == "linux"',
  },
```

is now:
```js
  'build':
    Var('chromium_url') + '/chromium/src/build.git' + '@' + '1b904cc30093c25d5fd48389bd58e3f7409bcf80',
  'third_party/depot_tools':
    Var('chromium_url') + '/chromium/tools/depot_tools.git' + '@' + '454f4ba4b3a69feb03c73f93d789062033433b4c',
  'tthird_party/icu':
    Var('chromium_url') + '/chromium/deps/icu.git' + '@' + 'f2223961702f00a8833874b0560d615a2cc42738',
  'third_party/instrumented_libraries':
    Var('chromium_url') + '/chromium/src/third_party/instrumented_libraries.git' + '@' + 'bb3f1802c237dd19105dd0f7919f99e536a39d10',
  'buildtools':
    Var('chromium_url') + '/chromium/src/buildtools.git' + '@' + '204a35a2a64f7179f8b76d7a0385653690839e21',
  'buildtools/clang_format/script':
    Var('chromium_url') + '/chromium/llvm-project/cfe/tools/clang-format.git' + '@' + '96636aa0e9f047f17447f2d45a094d0b59ed7917',
  'buildtools/linux64': {
    'packages': [
      {
        'package': 'gn/gn/linux-amd64',
        'version': Var('gn_version'),
      }
    ],
    'dep_type': 'cipd',
    'condition': 'host_os == "linux"',
  },
```

Tested with: `git-node v8 major --no-version-bump ` on latest Node.js master

cc @mmarchini @gengjiawen