### PR TITLE
chore(land): remove lite-ci checks

### DIFF
--- a/lib/ci/ci_type_parser.js
+++ b/lib/ci/ci_type_parser.js
@@ -17,14 +17,10 @@ const LIBUV = 'LIBUV';
 const NOINTL = 'NOINTL';
 const V8 = 'V8';
 const LINTER = 'LINTER';
-const LITE_PR = 'LITE_PR';
-const LITE_PR_PIPELINE = 'LITE_PR_PIPELINE';
-const LITE_COMMIT = 'LITE_COMMIT';
 const DAILY_MASTER = 'DAILY_MASTER';
 
 const CI_TYPE_ENUM = {
   FULL_CI: 1 << 0,
-  LITE_CI: 1 << 1,
   JOB_CI: 1 << 2
 };
 
@@ -33,7 +29,7 @@ const CI_PROVIDERS = {
   GITHUB: 'github-check'
 };
 
-const { JOB_CI, FULL_CI, LITE_CI } = CI_TYPE_ENUM;
+const { JOB_CI, FULL_CI } = CI_TYPE_ENUM;
 
 const CI_TYPES = new Map([
   [CITGM, {
@@ -46,7 +42,7 @@ const CI_TYPES = new Map([
     name: 'CITGM',
     jobName: 'citgm-smoker-nobuild',
     pattern: /job\/citgm-smoker-nobuild\/(\d+)/,
-    type: JOB_CI | LITE_CI
+    type: JOB_CI
   }],
   [PR, {
     name: 'Full PR',
@@ -90,24 +86,6 @@ const CI_TYPES = new Map([
     pattern: /job\/node-test-linter\/(\d+)/,
     type: JOB_CI
   }],
-  [LITE_PR, {
-    name: 'Lite PR',
-    jobName: 'node-test-pull-request-lite',
-    pattern: /job\/node-test-pull-request-lite\/(\d+)/,
-    type: JOB_CI | LITE_CI
-  }],
-  [LITE_PR_PIPELINE, {
-    name: 'Lite PR Pipeline',
-    jobName: 'node-test-pull-request-lite-pipeline',
-    pattern: /node-test-pull-request-lite-pipeline\/(\d+)/,
-    type: LITE_CI
-  }],
-  [LITE_COMMIT, {
-    name: 'Lite Commit',
-    jobName: 'node-test-commit-lite',
-    pattern: /job\/node-test-commit-lite\/(\d+)/,
-    type: JOB_CI | LITE_CI
-  }],
   [DAILY_MASTER, {
     name: 'Node Daily Master',
     jobName: 'node-daily-master',
@@ -122,14 +100,6 @@ function isFullCI(key) {
     return false;
   }
   return !!(data.type & FULL_CI);
-}
-
-function isLiteCI(key) {
-  const data = CI_TYPES.get(key);
-  if (!data) {
-    return false;
-  }
-  return !!(data.type & LITE_CI);
 }
 
 // Given a ci.nodejs.org/*** link, parse the job type and ID
@@ -234,13 +204,10 @@ module.exports = {
     V8,
     NOINTL,
     LINTER,
-    LITE_PR,
-    LITE_COMMIT,
     DAILY_MASTER
   },
   CI_PROVIDERS,
   isFullCI,
-  isLiteCI,
   JobParser,
   parseJobFromURL
 };

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -21,7 +21,6 @@ const {
   JobParser,
   CI_TYPES,
   CI_PROVIDERS,
-  isLiteCI,
   isFullCI
 } = require('./ci/ci_type_parser');
 const { PRBuild } = require('./ci/ci_result_parser');
@@ -199,9 +198,9 @@ class PRChecker {
     }
   }
 
-  hasFullOrLiteCI(ciMap) {
+  hasFullCI(ciMap) {
     const cis = [...ciMap.keys()];
-    return cis.find(ci => isFullCI(ci) || isLiteCI(ci));
+    return cis.find(isFullCI);
   }
 
   async checkCI() {
@@ -237,9 +236,9 @@ class PRChecker {
       cli.error('No CI runs detected');
       this.CIStatus = false;
       return false;
-    } else if (!this.hasFullOrLiteCI(ciMap)) {
+    } else if (!this.hasFullCI(ciMap)) {
       status = false;
-      cli.error('No full or lite Jenkins CI runs detected');
+      cli.error('No full Jenkins CI runs detected');
     }
 
     let lastCI;

--- a/test/fixtures/comments_with_ci.json
+++ b/test/fixtures/comments_with_ci.json
@@ -22,13 +22,5 @@
   {
     "publishedAt": "2017-10-27T04:16:36.458Z",
     "bodyText": "Linter CI: https://ci.nodejs.org/job/node-test-linter/13127/"
-  },
-  {
-    "publishedAt": "2017-10-28T04:16:36.458Z",
-    "bodyText": "CI https://ci.nodejs.org/job/node-test-commit-lite/246/"
-  },
-  {
-    "publishedAt": "2017-10-29T04:16:36.458Z",
-    "bodyText": "@contributer build started: https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/7213/pipeline/"
   }
 ]

--- a/test/fixtures/comments_with_lite_ci.json
+++ b/test/fixtures/comments_with_lite_ci.json
@@ -1,6 +1,0 @@
-[
-  {
-    "publishedAt": "2018-02-09T21:38:30Z",
-    "bodyText": "CI: https://ci.nodejs.org/job/node-test-commit-lite/246/"
-  }
-]

--- a/test/fixtures/commits_after_ci.json
+++ b/test/fixtures/commits_after_ci.json
@@ -39,8 +39,5 @@
   "comment": [{
     "bodyText": "CI: https://ci.nodejs.org/job/node-test-pull-request/10984/",
     "publishedAt": "2017-10-24T11:19:25Z"
-  },{
-    "bodyText": "Lite-CI: https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/10984",
-    "publishedAt": "2017-10-22T11:19:25Z"
   }]
 }

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -35,7 +35,6 @@ const noReviewers = {
 const approvingReviews = readJSON('reviews_approved.json');
 const requestingChangesReviews = readJSON('reviews_requesting_changes.json');
 
-const commentsWithLiteCI = readJSON('comments_with_lite_ci.json');
 const commentsWithCI = readJSON('comments_with_ci.json');
 const commentsWithLGTM = readJSON('comments_with_lgtm.json');
 
@@ -110,7 +109,6 @@ module.exports = {
   approvingReviews,
   requestingChangesReviews,
   commentsWithCI,
-  commentsWithLiteCI,
   commentsWithLGTM,
   oddCommits,
   githubCI,

--- a/test/unit/ci_type_parser.test.js
+++ b/test/unit/ci_type_parser.test.js
@@ -44,35 +44,11 @@ const expected = new Map([
     link: 'https://ci.nodejs.org/job/node-test-linter/13127/',
     date: '2017-10-27T04:16:36.458Z',
     jobid: 13127
-  }],
-  ['LITE_COMMIT', {
-    link: 'https://ci.nodejs.org/job/node-test-commit-lite/246/',
-    date: '2017-10-28T04:16:36.458Z',
-    jobid: 246
-  }],
-  ['LITE_PR_PIPELINE', {
-    link: 'https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/7213/pipeline/',
-    date: '2017-10-29T04:16:36.458Z',
-    jobid: 7213
   }]
 ]);
 describe('JobParser', () => {
   it('should parse CI results', () => {
     const results = new JobParser(commentsWithCI).parse();
     assert.deepStrictEqual([...results.entries()], [...expected.entries()]);
-  });
-
-  it('should parse pipeline links', () => {
-    const data = [{
-      publishedAt: '2017-10-29T04:16:36.458Z',
-      bodyText: '@contributer build started: https://ci.nodejs.org/blue/organizations/jenkins/node-test-pull-request-lite-pipeline/detail/node-test-pull-request-lite-pipeline/3009/pipeline/'
-    }];
-    const results = new JobParser(data).parse();
-    assert.deepStrictEqual([...results.entries()], [
-      ['LITE_PR_PIPELINE', {
-        link: 'https://ci.nodejs.org/blue/organizations/jenkins/node-test-pull-request-lite-pipeline/detail/node-test-pull-request-lite-pipeline/3009/pipeline/',
-        date: '2017-10-29T04:16:36.458Z',
-        jobid: 3009
-      }]]);
   });
 });

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -23,7 +23,6 @@ const {
   requestingChangesReviews,
   noReviewers,
   commentsWithCI,
-  commentsWithLiteCI,
   commentsWithLGTM,
   singleCommitAfterReview,
   multipleCommitsAfterReview,
@@ -675,14 +674,6 @@ describe('PRChecker', () => {
           [
             'Last Linter CI on 2017-10-27T04:16:36.458Z: ' +
             'https://ci.nodejs.org/job/node-test-linter/13127/'
-          ],
-          [
-            'Last Lite Commit CI on 2017-10-28T04:16:36.458Z: ' +
-            'https://ci.nodejs.org/job/node-test-commit-lite/246/'
-          ],
-          [
-            'Last Lite PR Pipeline CI on 2017-10-29T04:16:36.458Z: ' +
-            'https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/7213/pipeline/'
           ]
         ]
       };
@@ -720,7 +711,6 @@ describe('PRChecker', () => {
           ['- feat: add something']
         ],
         info: [
-          ['Last Lite PR Pipeline CI on 2017-10-22T11:19:25Z: https://ci.nodejs.org/job/node-test-pull-request-lite-pipeline/10984'],
           ['Last Full PR CI on 2017-10-24T11:19:25Z: https://ci.nodejs.org/job/node-test-pull-request/10984/']
         ]
       };
@@ -820,38 +810,6 @@ describe('PRChecker', () => {
 
       const status = await checker.checkCI();
       assert(!status);
-      cli.assertCalledWith(expectedLogs, {
-        ignore: ['startSpinner', 'updateSpinner', 'stopSpinner']
-      });
-    });
-
-    it('should count LITE CI as valid ci requirement', async() => {
-      const cli = new TestCLI();
-
-      const expectedLogs = {
-        info: [
-          [
-            'Last Lite Commit CI on 2018-02-09T21:38:30Z: ' +
-            'https://ci.nodejs.org/job/node-test-commit-lite/246/'
-          ]
-        ]
-      };
-
-      const checker = new PRChecker(cli, {
-        pr: firstTimerPR,
-        reviewers: allGreenReviewers,
-        comments: commentsWithLiteCI,
-        reviews: approvingReviews,
-        commits: [],
-        collaborators,
-        authorIsNew: () => true,
-        getThread() {
-          return PRData.prototype.getThread.call(this);
-        }
-      }, {}, { maxCommits: 0 });
-
-      const status = await checker.checkCI();
-      assert(status);
       cli.assertCalledWith(expectedLogs, {
         ignore: ['startSpinner', 'updateSpinner', 'stopSpinner']
       });


### PR DESCRIPTION

Lite CI is not used anymore, but some PRs got Lite-CI runs after some
changes to the bot. node-core-utils Lite-CI parsing is not working
though, therefore ncu will fail to land those PRs. Removing Lite-CI
checks fix the issue and also reduces complexity.

Fix: https://github.com/nodejs/node-core-utils/issues/466