### PR TITLE
fix(v8): support non-relative paths in V8 DEPS

### DIFF
--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -216,7 +216,7 @@ function incrementV8Version() {
   return {
     title: 'Increment V8 version',
     task: async(ctx) => {
-      const incremented = ++ctx.currentVersion[3];
+      const incremented = ++ctx.currentVersion.patch;
       const versionHPath = `${ctx.nodeDir}/deps/v8/include/v8-version.h`;
       let versionH = await fs.readFile(versionHPath, 'utf8');
       versionH = versionH.replace(

--- a/lib/update-v8/commitUpdate.js
+++ b/lib/update-v8/commitUpdate.js
@@ -6,12 +6,12 @@ module.exports = function() {
   return {
     title: 'Commit V8 update',
     task: async(ctx) => {
-      const newV8Version = util.getNodeV8Version(ctx.nodeDir).join('.');
+      const newV8Version = util.getNodeV8Version(ctx.nodeDir);
       await ctx.execGitNode('add', ['deps/v8']);
       const moreArgs = [];
       let message;
       if (ctx.minor) {
-        const prev = ctx.currentVersion.join('.');
+        const prev = ctx.currentVersion.toString();
         const next = ctx.latestVersion.join('.');
         moreArgs.push(
           '-m',

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -58,7 +58,7 @@ function checkoutBranch() {
           ctx.branch = version;
         }
       }
-      if (version === ctx.currentVersion.join('.')) {
+      if (version === ctx.currentVersion.toString()) {
         throw new Error(`Current version is already ${version}`);
       }
       ctx.newVersion = version.split('.').map((s) => parseInt(s, 10));
@@ -101,7 +101,12 @@ function updateV8Deps() {
     title: 'Update V8 DEPS',
     task: async(ctx) => {
       const newV8Version = getNodeV8Version(ctx.nodeDir);
-      const deps = filterForVersion(v8Deps, newV8Version);
+      const repoPrefix = newV8Version.majorMinor >= 86 ? '' : 'v8/';
+      const deps = filterForVersion(v8Deps.map((v8Dep) => ({
+        ...v8Dep,
+        repo: `${repoPrefix}${v8Dep.repo}`,
+        path: v8Dep.repo
+      })), newV8Version);
       if (deps.length === 0) return;
       /* eslint-disable no-await-in-loop */
       for (const dep of deps) {
@@ -113,7 +118,7 @@ function updateV8Deps() {
           }
         }
         const [repo, commit] = await readDeps(ctx.nodeDir, dep.repo);
-        const thePath = path.join(ctx.nodeDir, 'deps/v8', dep.repo);
+        const thePath = path.join(ctx.nodeDir, 'deps/v8', dep.path);
         await fetchFromGit(thePath, repo, commit);
       }
       /* eslint-enable */

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -25,7 +25,8 @@ function getLatestV8Version() {
   return {
     title: 'Get latest V8 version',
     task: async(ctx) => {
-      const currentV8Tag = ctx.currentVersion.slice(0, 3).join('.');
+      const version = ctx.currentVersion;
+      const currentV8Tag = `${version.major}.${version.minor}.${version.build}`;
       const result = await execa('git', ['tag', '-l', `${currentV8Tag}.*`], {
         cwd: ctx.v8Dir,
         encoding: 'utf8'
@@ -48,7 +49,7 @@ function minorUpdate() {
       return doMinorUpdate(ctx, latestStr);
     },
     skip: (ctx) => {
-      if (ctx.currentVersion[3] >= ctx.latestVersion[3]) {
+      if (ctx.currentVersion.patch >= ctx.latestVersion[3]) {
         ctx.skipped = 'V8 is up-to-date';
         return ctx.skipped;
       }
@@ -58,10 +59,9 @@ function minorUpdate() {
 }
 
 async function doMinorUpdate(ctx, latestStr) {
-  const currentStr = ctx.currentVersion.join('.');
   const { stdout: diff } = await execa(
     'git',
-    ['format-patch', '--stdout', `${currentStr}...${latestStr}`],
+    ['format-patch', '--stdout', `${ctx.currentVersion}...${latestStr}`],
     { cwd: ctx.v8Dir, encoding: 'utf8' }
   );
   try {

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -26,7 +26,7 @@ function bumpNodeModule() {
         v8Version,
         ctx.nodeMajorVersion
       );
-      await updateModuleVersion(ctx.nodeDir, newModuleVersion, v8Version);
+      await updateModuleVersion(ctx.nodeDir, newModuleVersion);
       await ctx.execGitNode(
         'add',
         ['doc/abi_version_registry.json', 'src/node_version.h']
@@ -56,7 +56,7 @@ async function updateModuleVersionRegistry(
   const newVersion = registry.NODE_MODULE_VERSION[0].modules + 1;
   const newLine =
     `{ "modules": ${newVersion}, "runtime": "node", ` +
-    `"variant": "v8_${v8Version[0]}.${v8Version[1]}", ` +
+    `"variant": "v8_${v8Version.major}.${v8Version.minor}", ` +
     `"versions": "${nodeMajorVersion}.0.0-pre" },\n    `;
   const firstLineIndex = registryStr.indexOf('{ "modules"');
   const newRegistry =
@@ -83,8 +83,8 @@ function getCommitTitle(moduleVersion) {
 
 function getCommitBody(v8Version) {
   return `Major V8 updates are usually API/ABI incompatible with previous
-versions. This commit adapts NODE_MODULE_VERSION for V8 ${v8Version[0]}.${
-  v8Version[1]
+versions. This commit adapts NODE_MODULE_VERSION for V8 ${v8Version.major}.${
+  v8Version.minor
 }.
 
 Refs: https://github.com/nodejs/CTC/blob/master/meetings/2016-09-28.md`;

--- a/lib/update-v8/util.js
+++ b/lib/update-v8/util.js
@@ -13,20 +13,28 @@ function getNodeV8Version(cwd) {
     const minor = parseInt(/V8_MINOR_VERSION (\d+)/.exec(v8VersionH)[1], 10);
     const build = parseInt(/V8_BUILD_NUMBER (\d+)/.exec(v8VersionH)[1], 10);
     const patch = parseInt(/V8_PATCH_LEVEL (\d+)/.exec(v8VersionH)[1], 10);
-    if (patch === 0) return [major, minor, build];
-    else return [major, minor, build, patch];
+    return {
+      major,
+      minor,
+      build,
+      patch,
+      majorMinor: major * 10 + minor,
+      toString() {
+        return this.patch
+          ? `${this.major}.${this.minor}.${this.build}`
+          : `${this.major}.${this.minor}.${this.build}.${this.patch}`;
+      }
+    };
   } catch (e) {
     throw new Error('Could not find V8 version');
   }
 };
 
 function filterForVersion(list, version) {
-  const major = version[0];
-  const minor = version[1];
-  const number = major * 10 + minor;
-  return list.filter(
-    (dep) => dep.since <= number && (dep.until || Infinity) >= number
-  );
+  return list.filter((dep) => {
+    return dep.since <= version.majorMinor &&
+      (dep.until || Infinity) >= version.majorMinor;
+  });
 }
 
 async function addToGitignore(nodeDir, value) {


### PR DESCRIPTION
V8 versions < 8.6 do not specify a relative path in the DEPS file.

Fixes: https://github.com/nodejs/node-v8/issues/166
Refs: https://github.com/v8/v8/commit/56bf834a2b122616d00c6cc85243e4d80a1ca241
Refs: https://github.com/nodejs/node-core-utils/commit/57b7df8016a3d1495be4f67fc3cc34db21a2b3a6

I tested the code with `--branch=8.5-lkgr` and `--branch=lkgr` (8.6/master)