### PR TITLE
fix(land): prevent duplicate and self-refs

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -32,27 +32,27 @@ class LinkParser {
   }
 
   getRefsUrlsFromArray(arr) {
-    const result = [];
+    const result = new Set();
     for (const item of arr) {
       const m = item.match(REF_RE);
       if (!m) continue;
       const ref = m[1];
       const url = this.getUrlFromOP(ref);
-      if (url) result.push(url);
+      if (url) result.add(url);
     }
-    return result;
+    return Array.from(result);
   }
 
   getPRUrlsFromArray(arr) {
-    const result = [];
+    const result = new Set();
     for (const item of arr) {
       const m = item.match(PR_RE);
       if (!m) continue;
       const prUrl = m[1];
       const url = this.getUrlFromOP(prUrl);
-      if (url) result.push(url);
+      if (url) result.add(url);
     }
-    return result;
+    return Array.from(result);
   }
 
   // Do this so we can reliably get the correct url.

--- a/lib/metadata_gen.js
+++ b/lib/metadata_gen.js
@@ -32,7 +32,7 @@ class MetadataGenerator {
 
     const parser = new LinkParser(owner, repo, op);
     const fixes = parser.getFixes();
-    const refs = parser.getRefs();
+    const refs = parser.getRefs().filter(f => f !== prUrl);
     const altPrUrl = parser.getAltPrUrl();
 
     const meta = [];

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -77,6 +77,8 @@ const firstTimerPrivatePR = readJSON('first_timer_pr_with_private_email.json');
 const semverMajorPR = readJSON('semver_major_pr.json');
 const fixAndRefPR = readJSON('pr_with_fixes_and_refs.json');
 const fixCrossPR = readJSON('pr_with_fixes_cross.json');
+const duplicateRefPR = readJSON('pr_with_duplicate_refs.json');
+const selfRefPR = readJSON('pr_with_self_ref.json');
 const backportPR = readJSON('pr_with_backport.json');
 const conflictingPR = readJSON('conflicting_pr.json');
 const emptyProfilePR = readJSON('empty_profile_pr.json');
@@ -137,5 +139,7 @@ module.exports = {
   readmeNoCollaboratorE,
   readmeUnordered,
   closedPR,
-  mergedPR
+  mergedPR,
+  selfRefPR,
+  duplicateRefPR
 };

--- a/test/fixtures/pr_with_duplicate_refs.json
+++ b/test/fixtures/pr_with_duplicate_refs.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2017-10-24T11:13:43Z",
+  "url": "https://github.com/nodejs/node/pull/16438",
+  "bodyHTML":
+    "<p>Refs: <a href=\"https://github.com/nodejs/node/pull/16439\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load issue title\" data-id=\"271243248\" data-permission-text=\"Issue title is private\" data-url=\"https://github.com/nodejs/node/pull/16439\">#16439</a>\nRefs: <a href=\"https://github.com/nodejs/node/pull/16439\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load issue title\" data-id=\"271243248\" data-permission-text=\"Issue title is private\" data-url=\"https://github.com/nodejs/node/pull/16439\">#16439</a></p>",
+  "bodyText": "Refs: https://github.com/nodejs/node/pull/16439\nRefs: https://github.com/nodejs/node/pull/16439",
+  "labels": {
+    "nodes": [
+      {
+        "name": "build"
+      },
+      {
+        "name": "npm"
+      },
+      {
+        "name": "python"
+      }
+    ]
+  }
+}

--- a/test/fixtures/pr_with_self_ref.json
+++ b/test/fixtures/pr_with_self_ref.json
@@ -1,0 +1,20 @@
+{
+  "createdAt": "2017-10-24T11:13:43Z",
+  "url": "https://github.com/nodejs/node/pull/16438",
+  "bodyHTML":
+    "<p>Refs: <a href=\"https://github.com/nodejs/node/pull/16438\" class=\"issue-link js-issue-link\" data-error-text=\"Failed to load issue title\" data-id=\"271243248\" data-permission-text=\"Issue title is private\" data-url=\"https://github.com/nodejs/node/pull/16438\">#16438</a></p>",
+  "bodyText": "Refs: https://github.com/nodejs/node/pull/16438",
+  "labels": {
+    "nodes": [
+      {
+        "name": "build"
+      },
+      {
+        "name": "npm"
+      },
+      {
+        "name": "python"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/350.
Closes https://github.com/nodejs/node-core-utils/issues/133.

Handles two potential edge cases:
* Duplicate `Refs: ` and `Fixes: ` items
* A ref to one's own PR.