### PR TITLE
fix: check $HOME/config on linux

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,33 +8,27 @@ const GLOBAL_CONFIG = Symbol('globalConfig');
 const PROJECT_CONFIG = Symbol('projectConfig');
 const LOCAL_CONFIG = Symbol('localConfig');
 
-exports.GLOBAL_CONFIG = GLOBAL_CONFIG;
-exports.PROJECT_CONFIG = PROJECT_CONFIG;
-exports.LOCAL_CONFIG = LOCAL_CONFIG;
-
 function getNcurcPath() {
-  if (process.env.XDG_CONFIG_HOME !== 'undefined' &&
-      process.env.XDG_CONFIG_HOME !== undefined) {
-    return path.join(process.env.XDG_CONFIG_HOME, 'ncurc');
-  } else {
-    return path.join(os.homedir(), '.ncurc');
+  let configHome = os.homedir();
+  if (process.platform === 'linux') {
+    configHome = process.env.XDG_CONFIG_HOME || `${os.homedir()}/config`;
   }
+  return path.join(configHome, '.ncurc');
 }
-exports.getNcurcPath = getNcurcPath;
 
-exports.getMergedConfig = function(dir, home) {
-  const globalConfig = exports.getConfig(GLOBAL_CONFIG, home);
-  const projectConfig = exports.getConfig(PROJECT_CONFIG, dir);
-  const localConfig = exports.getConfig(LOCAL_CONFIG, dir);
+function getMergedConfig(dir, home) {
+  const globalConfig = getConfig(GLOBAL_CONFIG, home);
+  const projectConfig = getConfig(PROJECT_CONFIG, dir);
+  const localConfig = getConfig(LOCAL_CONFIG, dir);
   return Object.assign(globalConfig, projectConfig, localConfig);
-};
+}
 
-exports.getConfig = function(configType, dir) {
-  const configPath = exports.getConfigPath(configType, dir);
+function getConfig(configType, dir) {
+  const configPath = getConfigPath(configType, dir);
   return readJson(configPath);
-};
+}
 
-exports.getConfigPath = function(configType, dir) {
+function getConfigPath(configType, dir) {
   switch (configType) {
     case GLOBAL_CONFIG:
       return getNcurcPath();
@@ -43,32 +37,46 @@ exports.getConfigPath = function(configType, dir) {
       return projectRcPath;
     }
     case LOCAL_CONFIG: {
-      const ncuDir = exports.getNcuDir(dir);
+      const ncuDir = getNcuDir(dir);
       const configPath = path.join(ncuDir, 'config');
       return configPath;
     }
     default:
       throw Error('Invalid configType');
   }
-};
+}
 
-exports.writeConfig = function(configType, obj, dir) {
-  writeJson(exports.getConfigPath(configType, dir), obj);
-};
+function writeConfig(configType, obj, dir) {
+  writeJson(getConfigPath(configType, dir), obj);
+}
 
-exports.updateConfig = function(configType, obj, dir) {
-  const config = exports.getConfig(configType, dir);
-  const configPath = exports.getConfigPath(configType, dir);
+function updateConfig(configType, obj, dir) {
+  const config = getConfig(configType, dir);
+  const configPath = getConfigPath(configType, dir);
   writeJson(configPath, Object.assign(config, obj));
-};
+}
 
-exports.getHomeDir = function(home) {
+function getHomeDir(home) {
   if (process.env.XDG_CONFIG_HOME) {
     return process.env.XDG_CONFIG_HOME;
   }
   return home || os.homedir();
-};
+}
 
-exports.getNcuDir = function(dir) {
+function getNcuDir(dir) {
   return path.join(dir || process.cwd(), '.ncu');
+}
+
+module.exports = {
+  GLOBAL_CONFIG,
+  PROJECT_CONFIG,
+  LOCAL_CONFIG,
+  getConfig,
+  getConfigPath,
+  getHomeDir,
+  getNcuDir,
+  getNcurcPath,
+  getMergedConfig,
+  updateConfig,
+  writeConfig
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,7 @@ const LOCAL_CONFIG = Symbol('localConfig');
 function getNcurcPath() {
   let configHome = os.homedir();
   if (process.platform === 'linux') {
-    configHome = process.env.XDG_CONFIG_HOME || `${os.homedir()}/config`;
+    configHome = process.env.XDG_CONFIG_HOME || `${os.homedir()}/.config`;
   }
   return path.join(configHome, '.ncurc');
 }

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -53,7 +53,7 @@ describe('auth', async function() {
   });
 
   it('prefers XDG_CONFIG_HOME/ncurc to HOME/.ncurc', async function() {
-    if (!isLinux) this.skip();
+    if (!isLinux || !process.env.XDG_CONFIG_HOME) this.skip();
 
     this.timeout(2000);
     await runAuthScript(
@@ -90,8 +90,8 @@ function runAuthScript(
 
       let ncurcPath;
       if (isLinux && envVar === 'HOME') {
-        fs.mkdirSync(`${newEnv[envVar]}/config`, { recursive: true });
-        ncurcPath = path.resolve(newEnv[envVar], 'config',
+        fs.mkdirSync(`${newEnv[envVar]}/.config`, { recursive: true });
+        ncurcPath = path.resolve(newEnv[envVar], '.config',
           envVar === 'HOME' ? '.ncurc' : 'ncurc');
       } else {
         fs.mkdirSync(newEnv[envVar], { recursive: true });


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/268.

Ensures that on Linux, `.ncurc` is placed in either `XDG_CONFIG_HOME` or `$HOME/config` and cleans up exports a bit to match style in other parts of the project.