### PR TITLE
fix: return value for validateLint

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -137,8 +137,12 @@ class LandingSession extends Session {
       return true;
     }
 
-    const linted = await runAsync('make', ['lint']);
-    return linted;
+    try {
+      await runAsync('make', ['lint']);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async tryCompleteLanding(patch) {
@@ -216,6 +220,8 @@ class LandingSession extends Session {
         '`git node land --continue`.');
         process.exit(1);
       }
+    } else {
+      cli.ok('Lint passed cleanly');
     }
 
     this.startAmending();


### PR DESCRIPTION
Fixes an issue where `make lint` doesn't return anything, so `await`ing it would always return `undefined` on success and false-positive fail. Also adds logging output for successful lint.

cc @nodejs/node-core-utils 