### PR TITLE
fix: potential non-url Fixes being added to metadata

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -5,6 +5,8 @@ const FIX_RE = /(Close[ds]?|Fix(e[ds])?|Resolve[sd]?)\s*:\s*(\S+)/i;
 const REFS_RE = /Refs?\s*:\s*(\S+)/mgi;
 const REF_RE = /Refs?\s*:\s*(\S+)/i;
 const PR_RE = /PR-URL\s*:\s*(\S+)/i;
+const LINK_RE = /#?\d+|\S+\/\S+#\d+/;
+
 const cheerio = require('cheerio');
 
 /**
@@ -22,7 +24,7 @@ class LinkParser {
     const result = [];
     for (const item of arr) {
       const m = item.match(FIX_RE);
-      if (!m) continue;
+      if (!m || !LINK_RE.test(m[3])) continue;
       const fix = m[3];
       const url = fix.replace(/^#/,
         `${owner}/${repo}#`).replace('#', '/issues/');

--- a/lib/links.js
+++ b/lib/links.js
@@ -5,7 +5,7 @@ const FIX_RE = /(Close[ds]?|Fix(e[ds])?|Resolve[sd]?)\s*:\s*(\S+)/i;
 const REFS_RE = /Refs?\s*:\s*(\S+)/mgi;
 const REF_RE = /Refs?\s*:\s*(\S+)/i;
 const PR_RE = /PR-URL\s*:\s*(\S+)/i;
-const LINK_RE = /#?\d+|\S+\/\S+#\d+/;
+const LINK_RE = /(#?\d+)|(\S+\/\S+(\/#?|\/?)\d+)/;
 
 const cheerio = require('cheerio');
 


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/233.

Filters out anything from being added to `Fixes` metadata that does not look e.g like:

Fixes #16
Fixes nodejs/build#1961
Fixes https://github.com/nodejs/node/issue/12345