### PR TITLE
fix: git node metadata arg passing

### DIFF
--- a/components/git/land.js
+++ b/components/git/land.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { parsePRFromURL } = require('../../lib/links');
-const getMetadata = require('../metadata');
+const { getMetadata } = require('../metadata');
 const CLI = require('../../lib/cli');
 const Request = require('../../lib/request');
 const { runPromise } = require('../../lib/run');

--- a/components/git/metadata.js
+++ b/components/git/metadata.js
@@ -3,7 +3,7 @@
 const yargs = require('yargs');
 
 const { parsePRFromURL } = require('../../lib/links');
-const getMetadata = require('../metadata');
+const { getMetadata } = require('../metadata');
 const CLI = require('../../lib/cli');
 const config = require('../../lib/config').getMergedConfig();
 const { runPromise, IGNORE } = require('../../lib/run');
@@ -80,7 +80,7 @@ function handler(argv) {
   const cli = new CLI(logStream);
 
   const merged = Object.assign({}, argv, parsed, config);
-  return runPromise(getMetadata(merged, cli)
+  return runPromise(getMetadata(merged, false, cli)
     .then(({ status }) => {
       if (status === false) {
         throw new Error(IGNORE);

--- a/components/metadata.js
+++ b/components/metadata.js
@@ -9,7 +9,7 @@ const MetadataGenerator = require('../lib/metadata_gen');
 
 const fs = require('fs');
 
-module.exports = async function getMetadata(argv, skipRefs, cli) {
+async function getMetadata(argv, skipRefs, cli) {
   const credentials = await auth({
     github: true,
     jenkins: true
@@ -49,3 +49,5 @@ module.exports = async function getMetadata(argv, skipRefs, cli) {
     checker
   };
 };
+
+module.exports = { getMetadata };


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/499.

Fixes incorrect arguments being passed to `getMetadata` and also updates export/import to be more in line with other components.

cc @nodejs/node-core-utils 