### PR TITLE
feat: support NCU_VERBOSITY=debug environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ CLI tools for Node.js Core collaborators.
   - [Install](#install)
   - [Setting up credentials](#setting-up-credentials)
   - [Make sure your credentials won't be committed](#make-sure-your-credentials-wont-be-committed)
+  - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -98,6 +99,15 @@ serialized configurations.
 
 If you ever accidentally commit your access token on GitHub, you can simply
 revoke that token and use a new one.
+
+### Troubleshooting
+
+If you encounter an error that you cannot fix by yourself, please
+
+1. Make sure you update NCU to the latest version
+2. Try again with the `NCU_VERBOSITY=debug` environment variable set and
+  open an issue at https://github.com/nodejs/node-core-utils/issues with
+  detailed logs.
 
 ## Contributing
 

--- a/bin/get-metadata
+++ b/bin/get-metadata
@@ -3,6 +3,8 @@
 
 const path = require('path');
 const { runAsync } = require('../lib/run');
+const { setVerbosityFromEnv } = require('../lib/verbosity');
+setVerbosityFromEnv();
 
 const script = path.join(__dirname, 'git-node');
 runAsync(process.execPath, [script, 'metadata', ...process.argv.slice(2)]);

--- a/bin/git-node
+++ b/bin/git-node
@@ -4,6 +4,8 @@
 const yargs = require('yargs');
 const path = require('path');
 const epilogue = require('../components/git/epilogue');
+const { setVerbosityFromEnv } = require('../lib/verbosity');
+setVerbosityFromEnv();
 
 const commandDir = path.join(__dirname, '..', 'components', 'git');
 

--- a/bin/ncu-ci
+++ b/bin/ncu-ci
@@ -14,6 +14,8 @@ const {
     DAILY_MASTER
   }
 } = require('../lib/ci/ci_type_parser');
+const { setVerbosityFromEnv } = require('../lib/verbosity');
+setVerbosityFromEnv();
 
 const { listBuilds } = require('../lib/ci/ci_utils');
 

--- a/bin/ncu-config
+++ b/bin/ncu-config
@@ -6,6 +6,9 @@ const {
   getConfig, updateConfig, GLOBAL_CONFIG, PROJECT_CONFIG, LOCAL_CONFIG
 } = require('../lib/config');
 
+const { setVerbosityFromEnv } = require('../lib/verbosity');
+setVerbosityFromEnv();
+
 const yargs = require('yargs');
 const argv = yargs
   .command({

--- a/bin/ncu-team
+++ b/bin/ncu-team
@@ -7,6 +7,9 @@ const { runPromise } = require('../lib/run');
 const CLI = require('../lib/cli');
 const TeamInfo = require('../lib/team_info');
 
+const { setVerbosityFromEnv } = require('../lib/verbosity');
+setVerbosityFromEnv();
+
 require('yargs') // eslint-disable-line
   .command({
     command: 'list <team> [org]',

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,17 @@ const fs = require('fs');
 const path = require('path');
 const { CI_DOMAIN } = require('./ci/ci_type_parser');
 const proxy = require('./proxy');
+const {
+  isDebugVerbosity,
+  debuglog
+} = require('./verbosity');
+
+function wrappedFetch(url, options, ...args) {
+  if (isDebugVerbosity()) {
+    debuglog('[fetch]', url);
+  }
+  return fetch(url, options, ...args);
+}
 
 class Request {
   constructor(credentials) {
@@ -23,7 +34,7 @@ class Request {
       options.headers = options.headers || {};
       Object.assign(options.headers, this.getJenkinsHeaders());
     }
-    return fetch(url, options);
+    return wrappedFetch(url, options);
   }
 
   async text(url, options = {}) {
@@ -32,7 +43,16 @@ class Request {
 
   async json(url, options = {}) {
     options.headers = options.headers || {};
-    return this.fetch(url, options).then(res => res.json());
+    const text = await this.text(url, options);
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      if (isDebugVerbosity()) {
+        debuglog('[Request] Cannot parse JSON response from',
+          url, ':\n', text);
+      }
+      throw e;
+    }
   }
 
   async gql(name, variables, path) {
@@ -81,7 +101,7 @@ class Request {
       })
     };
 
-    const result = await fetch(url, options).then(res => res.json());
+    const result = await this.json(url, options);
     if (result.errors) {
       const { type, message } = result.errors[0];
       const err = new Error(`[${type}] GraphQL request Error: ${message}`);

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const { spawn, spawnSync } = require('child_process');
-
+const {
+  isDebugVerbosity,
+  debuglog
+} = require('./verbosity');
 const IGNORE = '__ignore__';
 
 function runAsyncBase(cmd, args, {
@@ -10,10 +13,14 @@ function runAsyncBase(cmd, args, {
   captureStdout = false
 } = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, Object.assign({
+    const opt = Object.assign({
       cwd: process.cwd(),
       stdio: captureStdout ? ['inherit', 'pipe', 'inherit'] : 'inherit'
-    }, spawnArgs));
+    }, spawnArgs);
+    if (isDebugVerbosity()) {
+      debuglog('[Spawn]', `${cmd} ${(args || []).join(' ')}`, opt);
+    }
+    const child = spawn(cmd, args, opt);
     let stdout;
     if (captureStdout) {
       stdout = '';
@@ -64,9 +71,13 @@ exports.runAsync = function(cmd, args, options) {
 };
 
 exports.runSync = function(cmd, args, options) {
-  const child = spawnSync(cmd, args, Object.assign({
+  const opt = Object.assign({
     cwd: process.cwd()
-  }, options));
+  }, options);
+  if (isDebugVerbosity()) {
+    debuglog('[SpawnSync]', `${cmd} ${(args || []).join(' ')}`, opt);
+  }
+  const child = spawnSync(cmd, args, opt);
   if (child.error) {
     throw child.error;
   } else if (child.status !== 0) {

--- a/lib/verbosity.js
+++ b/lib/verbosity.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const chalk = require('chalk');
+const util = require('util');
+
+const VERBOSITY = {
+  NONE: 0,
+  DEBUG: 2
+};
+
+let verbosity = VERBOSITY.NONE;
+
+exports.isDebugVerbosity = function() {
+  return verbosity === VERBOSITY.DEBUG;
+};
+
+exports.setVerbosityFromEnv = function() {
+  const env = (process.env.NCU_VERBOSITY || '').toUpperCase();
+  if (Object.keys(VERBOSITY).includes(env)) {
+    verbosity = VERBOSITY[env];
+  }
+};
+
+exports.debuglog = function(...args) {
+  // Prepend a line break in case it's logged while the spinner is running
+  console.error(chalk.green(util.format('\n[DEBUG]', ...args)));
+};
+
+exports.VERBOSITY = VERBOSITY;


### PR DESCRIPTION
Support NCU_VERBOSITY=debug which tells ncu to log CLI commands
and HTTP requests to the command line for debugging.

Refs: https://github.com/nodejs/node-core-utils/issues/467

I switched to using environment variables instead of options since it's easier to turn the setting on/off that way. Also I left out `Pipe stdout and stderr, also do not use spinners if verbosity is on in case the output is overwritten` mentioned in https://github.com/nodejs/node-core-utils/issues/467 in this PR since that requires a bit more refactoring.

cc @nodejs/node-core-utils 

<img width="1141" alt="Screen Shot 2020-09-22 at 11 41 58 AM" src="https://user-images.githubusercontent.com/4299420/93842208-a6c7eb80-fcc8-11ea-8057-8710441c13d1.png">
