### PR TITLE
fix: undefined failures & JSON error

### DIFF
--- a/bin/ncu-ci
+++ b/bin/ncu-ci
@@ -351,11 +351,11 @@ class CICommand {
       await build.getResults();
       build.display();
 
-      if (argv.json) {
-        const json = build.formatAsJson();
-        if (json !== undefined) {
-          this.json = this.json.concat(json);
-        }
+      // Set this.json regardless of whether the user has passed
+      // --json - it's needed for failure aggregation.
+      const json = build.formatAsJson();
+      if (json !== undefined) {
+        this.json = this.json.concat(json);
       }
 
       if ((argv.copy || argv.markdown) && !argv.stats) {

--- a/lib/ci/failure_aggregator.js
+++ b/lib/ci/failure_aggregator.js
@@ -3,9 +3,9 @@
 const _ = require('lodash');
 const chalk = require('chalk');
 const { getMachineUrl, parsePRFromURL } = require('../links');
+const { FAILURE_TYPES_NAME } = require('./ci_failure_parser');
 const {
   parseJobFromURL,
-  FAILURE_TYPES_NAME,
   CI_TYPES
 } = require('./ci_type_parser');
 const {


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/496.

Fixes two things: 

- `FAILURE_TYPES_NAME` should be imported from `CIFailureParser`
- `this.json` should be set regardless of whether the user has chosen to pass `--json`

cc @mmarchini 