### PR TITLE
chore: update release-please-action to v2.5.5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v1.6.3
+      - uses: GoogleCloudPlatform/release-please-action@v2.5.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node


### PR DESCRIPTION
The nature of the breaking changes is explained here: https://github.com/googleapis/release-please/pull/536

Closes: #508