### PR TITLE
fix(v8): correct order of ternary

### DIFF
--- a/lib/update-v8/util.js
+++ b/lib/update-v8/util.js
@@ -21,8 +21,8 @@ function getNodeV8Version(cwd) {
       majorMinor: major * 10 + minor,
       toString() {
         return this.patch
-          ? `${this.major}.${this.minor}.${this.build}`
-          : `${this.major}.${this.minor}.${this.build}.${this.patch}`;
+          ? `${this.major}.${this.minor}.${this.build}.${this.patch}`
+          : `${this.major}.${this.minor}.${this.build}`;
       }
     };
   } catch (e) {


### PR DESCRIPTION
Actually include patch number in the version string when there is a
patch number.