### PR TITLE
chore: fix tests on Windows and enable it in actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force checking out with LF on Windows to avoid issues in tests that read files.
+* text=auto eol=lf

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,8 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        # TODO(targos): fix and add windows-latest
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Use a gitattributes file to force text files to be checked out with LF
line endings. This resolves issues on Windows with tests that compare
values with the contents of files on disk.