### PR TITLE
fix: throw on missing info during release prep

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -25,6 +25,12 @@ class ReleasePreparation {
     this.date = '';
     this.config = getMergedConfig(this.dir);
 
+    // Ensure the preparer has set an upstream and username.
+    if (this.warnForMissing()) {
+      cli.error('Failed to begin the release preparation process.');
+      return;
+    }
+
     // Allow passing optional new version.
     if (argv.newVersion) {
       const newVersion = semver.clean(argv.newVersion);
@@ -202,6 +208,33 @@ class ReleasePreparation {
 
   get username() {
     return this.config.username;
+  }
+
+  warnForMissing() {
+    const { cli, upstream, username } = this;
+
+    const missing = !username || !upstream;
+    if (!upstream) {
+      cli.warn('You have not told git-node the remote you want to sync with.');
+      cli.separator();
+      cli.info(
+        'For example, if your remote pointing to nodejs/node is' +
+        ' `remote-upstream`, you can run:\n\n' +
+        '  $ ncu-config set upstream remote-upstream');
+      cli.separator();
+      cli.setExitCode(1);
+    }
+    if (!username) {
+      cli.warn('You have not told git-node your username.');
+      cli.separator();
+      cli.info(
+        'To fix this, you can run: ' +
+        '  $ ncu-config set username <your_username>');
+      cli.separator();
+      cli.setExitCode(1);
+    }
+
+    return missing;
   }
 
   calculateNewVersion() {


### PR DESCRIPTION
Fixes the following potential error:

```
Error: git config,--get,remote.undefined.url failed with stderr:
    at exports.runSync (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/lib/run.js:84:11)
    at new ReleasePreparation (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/lib/prepare_release.js:50:26)
    at main (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/components/git/release.js:71:18)
    at release (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/components/git/release.js:53:21)
    at Object.handler (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/components/git/release.js:38:12)
    at Object.runCommand (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/node_modules/yargs/build/lib/command.js:196:48)
    at Object.parseArgs [as _parseArgs] (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/node_modules/yargs/build/lib/yargs.js:1043:55)
    at Object.get [as argv] (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/node_modules/yargs/build/lib/yargs.js:986:25)
    at Object.<anonymous> (/Users/mylesborins/.nvm/versions/node/v14.15.0/lib/node_modules/node-core-utils/bin/git-node:22:3)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
```

by catching and returning when `ncu-config` data is not present.

cc @nodejs/node-core-utils @MylesBorins 