### PR TITLE
fix: fetch most recent 100 commits

### DIFF
--- a/lib/queries/PRCommits.gql
+++ b/lib/queries/PRCommits.gql
@@ -1,7 +1,7 @@
 query Commits($prid: Int!, $owner: String!, $repo: String!, $after: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prid) {
-      commits(first: 100, after: $after) {
+      commits(last: 100, after: $after) {
         totalCount
         pageInfo {
           hasNextPage


### PR DESCRIPTION
Closes https://github.com/nodejs/node-core-utils/issues/477.

Swaps `first` to `last` in `PRCommits.gql`

cc @mmarchini @targos 