### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "branch-diff": "^1.10.0",
     "chalk": "^4.1.0",
     "changelog-maker": "^2.5.0",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.5",
     "clipboardy": "^2.3.0",
     "core-validate-commit": "^3.13.1",
-    "execa": "^4.1.0",
+    "execa": "^5.0.0",
     "figures": "^3.2.0",
     "form-data": "^3.0.0",
     "fs-extra": "^9.0.1",
@@ -47,23 +47,23 @@
     "listr-input": "^0.2.1",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
-    "ora": "^5.1.0",
+    "ora": "^5.2.0",
     "proxy-agent": "^4.0.0",
     "replace-in-file": "^6.1.0",
     "rimraf": "^3.0.2",
-    "yargs": "^16.1.0"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "eslint": "^7.12.1",
-    "eslint-config-standard": "^16.0.1",
+    "eslint": "^7.16.0",
+    "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.2",
+    "eslint-plugin-standard": "^4.1.0",
     "intelli-espower-loader": "^1.0.1",
-    "mocha": "^8.2.0",
+    "mocha": "^8.2.1",
     "nyc": "^15.1.0",
     "power-assert": "^1.6.1",
-    "sinon": "^9.2.1"
+    "sinon": "^9.2.2"
   }
 }


### PR DESCRIPTION
Breaking change in execa:

> Remove faulty emulated ENOENT error on Windows (#447) bdbd975
This is only a breaking change if you depend on the exact error message.