### PR TITLE
fix: accommodate case changes in README header

### DIFF
--- a/lib/collaborators.js
+++ b/lib/collaborators.js
@@ -74,10 +74,10 @@ function parseCollaborators(readme, cli) {
   const collaborators = new Map();
   let m;
 
-  const tscIndex = readme.indexOf(TSC_TITLE);
-  const tsceIndex = readme.indexOf(TSCE_TITLE);
-  const clIndex = readme.indexOf(CL_TITLE);
-  const cleIndex = readme.indexOf(CLE_TITLE);
+  const tscIndex = readme.toUpperCase().indexOf(TSC_TITLE.toUpperCase());
+  const tsceIndex = readme.toUpperCase().indexOf(TSCE_TITLE.toUpperCase());
+  const clIndex = readme.toUpperCase().indexOf(CL_TITLE.toUpperCase());
+  const cleIndex = readme.toUpperCase().indexOf(CLE_TITLE.toUpperCase());
 
   if (tscIndex === -1) {
     throw new Error(`Couldn't find ${TSC_TITLE} in the README`);

--- a/test/fixtures/README/README.md
+++ b/test/fixtures/README/README.md
@@ -237,7 +237,7 @@ For more information about the governance of the Node.js project, see
 * [bar](https://github.com/bar) -
 **Bar User** &lt;bar@example.com&gt; (she/her)
 
-### TSC Emeriti
+### TSC emeriti
 
 * [test](https://github.com/test) -
 **Test** &lt;test@example.com&gt;
@@ -257,7 +257,7 @@ For more information about the governance of the Node.js project, see
 * [ExtraSpace](https://github.com/extraspace) -
 **Extra Space**  &lt;extraspace@example.com&gt; (he/him)
 
-### Collaborator Emeriti
+### Collaborator emeriti
 
 * [bee](https://github.com/bee) -
 **bee** &lt;bee@example.com&gt;


### PR DESCRIPTION
Because of changes to the README, node-core-utils `git node land` is now
broken. This fixes it. Please fast-track?