### PR TITLE
fix(wpt): download files as buffer instead of text

### DIFF
--- a/lib/github/tree.js
+++ b/lib/github/tree.js
@@ -58,10 +58,10 @@ class GitHubTree {
     return `${this.repoUrl}/tree/${commit.slice(0, 10)}/${this.path}`;
   }
 
-  async text(assetPath) {
+  async buffer(assetPath) {
     await this.getLastCommit();
     const url = this.getAssetUrl(assetPath);
-    return this.request.text(url);
+    return this.request.buffer(url);
   }
 
   /**

--- a/lib/request.js
+++ b/lib/request.js
@@ -37,6 +37,10 @@ class Request {
     return wrappedFetch(url, options);
   }
 
+  async buffer(url, options = {}) {
+    return this.fetch(url, options).then(res => res.buffer());
+  }
+
   async text(url, options = {}) {
     return this.fetch(url, options).then(res => res.text());
   }

--- a/lib/wpt/index.js
+++ b/lib/wpt/index.js
@@ -49,7 +49,7 @@ class WPTUpdater {
   // If filepath starts with '/', the path is relative to WPT project root,
   // otherwise it's relative to the path of this updater
   async pullTextFile(dest, filepath) {
-    const content = await this.tree.text(filepath);
+    const content = await this.tree.buffer(filepath);
     const filename = path.join(dest, filepath);
     writeFile(filename, content);
     this.cli.updateSpinner(`Downloaded ${filename}`);


### PR DESCRIPTION
There are binary files in the WPT repository and downloading them as
text corrupts them.

Refs: nodejs/node#37294