### PR TITLE
feat: add `--lite` option for `git-node land`

### DIFF
--- a/components/git/land.js
+++ b/components/git/land.js
@@ -71,6 +71,13 @@ const landOptions = {
     describe: 'Query Jenkins CI results when checking the PR',
     default: true,
     type: 'boolean'
+  },
+  lite: {
+    type: 'boolean',
+    default: false,
+    describe: 'Eliminates some requirements, such as configuring a Jenkins ' +
+    'API token, and parsing TSC members and Collaborators from README.md. ' +
+    'Suitable for using "git-node land" in repositories other than nodejs/node.'
   }
 };
 

--- a/components/metadata.js
+++ b/components/metadata.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 async function getMetadata(argv, skipRefs, cli) {
   const credentials = await auth({
     github: true,
-    jenkins: true
+    jenkins: !argv.lite
   });
   const request = new Request(credentials);
 

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -34,34 +34,47 @@ git-node land [prid|options]
 Manage the current landing session or start a new one for a pull request
 
 Positionals:
-  prid, options  ID of the Pull Request                                 [number]
+  prid, options  ID or URL of the Pull Request
 
 Options:
-  --version       Show version number                                  [boolean]
-  --help          Show help                                            [boolean]
-  --apply         Apply a patch with the given PR id                    [number]
-  --amend         Amend the current commit                             [boolean]
-  --continue, -c  Continue the landing session                         [boolean]
-  --final         Verify the landed PR and clean up                    [boolean]
-  --abort         Abort the current landing session                    [boolean]
-  --backport      Land a backport PR on a staging branch               [boolean]
-  --yes           Assume "yes" as answer to all prompts and run
-                  non-interactively. If an undesirable situation occurs, such as
-                  a pull request or commit check fails, then git node land will
-                  abort.                              [boolean] [default: false]
-  --skipRefs      Prevent Fixes and Refs information from being added to commit
-                  metadata                            [boolean] [default: false]
-
+      --version     Show version number                                [boolean]
+      --help        Show help                                          [boolean]
+      --yes         Assume "yes" as answer to all prompts and run
+                    non-interactively. If an undesirable situation occurs, such
+                    as a pull request or commit check fails, then git node land
+                    will abort.                       [boolean] [default: false]
+      --skipRefs    Prevent adding Fixes and Refs information to commit metadata
+                                                      [boolean] [default: false]
+      --lint        Run linter while landing commits  [boolean] [default: false]
+      --checkCI     Query Jenkins CI results when checking the PR
+                                                       [boolean] [default: true]
+      --lite        Eliminates some requirements, such as configuring a Jenkins
+                    API token, and parsing TSC members and Collaborators from
+                    README.md. Suitable for using "git-node land" in
+                    repositories other than nodejs/node.
+                                                      [boolean] [default: false]
+      --apply       Apply a patch with the given PR id                  [number]
+      --amend       Amend the current commit                           [boolean]
+  -c, --continue    Continue the landing session                       [boolean]
+      --final       Verify the landed PR and clean up                  [boolean]
+      --abort       Abort the current landing session                  [boolean]
+      --backport    Land a backport PR onto a staging branch
+                                                      [boolean] [default: false]
+      --autorebase  Automatically rebase branches with multiple commits
+                                                      [boolean] [default: false]
+      --fixupAll    Automatically fixup all commits to the first one dismissing
+                    other commit messages             [boolean] [default: false]
 
 Examples:
-  git node land 12344            Land https://github.com/nodejs/node/pull/12344
-                                 in the current directory
-  git node land --abort          Abort the current session
-  git node land --amend          Append metadata to the current commit message
-  git node land --final          Verify the landed PR and clean up
-  git node land --continue       Continue the current landing session
-  git node land --backport 30072 Land https://github.com/nodejs/node/pull/30072
-                                 as a backport in the current directory
+  git node land https://github.com/nodejs/  Land https://github.com/nodejs/node/
+  node/pull/12344                           pull/12344 in the current directory
+  git node land 12344                       Land https://github.com/nodejs/node/
+                                            pull/12344 in the current directory
+  git node land --abort                     Abort the current session
+  git node land --amend                     Append metadata to the current
+                                            commit message
+  git node land --final                     Verify the landed PR and clean up
+  git node land --continue                  Continue the current landing session
 ```
 
 <a id="git-node-land-prerequisites"></a>

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -23,7 +23,7 @@ const LINT_RESULTS = {
 
 class LandingSession extends Session {
   constructor(cli, req, dir,
-    { prid, backport, lint, autorebase, fixupAll, checkCI } = {}) {
+    { prid, backport, lint, autorebase, fixupAll, checkCI, lite } = {}) {
     super(cli, dir, prid);
     this.req = req;
     this.backport = backport;
@@ -32,6 +32,7 @@ class LandingSession extends Session {
     this.fixupAll = fixupAll;
     this.expectedCommitShas = [];
     this.checkCI = !!checkCI;
+    this.lite = !!lite;
   }
 
   get argv() {
@@ -40,6 +41,7 @@ class LandingSession extends Session {
     args.lint = this.lint;
     args.autorebase = this.autorebase;
     args.fixupAll = this.fixupAll;
+    args.lite = this.lite;
     return args;
   }
 

--- a/lib/pr_data.js
+++ b/lib/pr_data.js
@@ -58,11 +58,16 @@ class PRData {
   async getAll(argv) {
     const { prStr } = this;
     this.cli.startSpinner(`Loading data for ${prStr}`);
-    await Promise.all([
-      this.getCollaborators(),
+    const listOfPromises = [
       this.getThreadData(),
       this.getCommits()
-    ]).then(() => {
+    ];
+    if (!this.argv.lite) {
+      // Parse TSC members/Collaborators, except in "lite" mode.
+      listOfPromises.unshift(this.getCollaborators());
+    }
+
+    await Promise.all(listOfPromises).then(() => {
       this.cli.stopSpinner(`Done loading data for ${prStr}`);
     });
     this.analyzeReviewers();

--- a/lib/session.js
+++ b/lib/session.js
@@ -64,7 +64,8 @@ class Session {
       updateDeprecations: this.updateDeprecations,
       ciType: this.ciType,
       prid: this.prid,
-      checkCI: this.checkCI
+      checkCI: this.checkCI,
+      lite: this.lite
     };
   }
 


### PR DESCRIPTION
Makes it possible to use `git-node land` in repositories other than
`nodejs/node`. This is helpful for producing Node-style commit
footers, and enforcing some Node PR/commit conventions.

---

Context: Looking into whether `git-node land` can be used for landing stuff at the `node-gyp` repo. With this change, the answer would be "yes."

See: https://github.com/nodejs/node-gyp/issues/2286

cc @rvagg thoughts? (I like that `git-node land` takes some of the work out of using Node-style commit message prefixes, and maintaining commit message footers such as `Reviewed-By:` and `PR-URL:`, but dropping all that and just using `release-please` and "conventional commit"-style commit messages would be even easier.)

Note to `node-core-utils` maintainers: If `node-gyp` maintainers aren't interested in this `--lite` flag feature, then I don't think there is a real-world user for it. In that case, with no real-world users, I wouldn't recommend merging this. Basically, I can only see this being useful if `node-gyp` maintainers want it (or someone pops up in the comments here to say they want it).