### PR TITLE
fix(pr-checker): SKIPPED shouldn't be treated as fail

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -7,6 +7,8 @@ const HOUR = MINUTE * 60;
 const WAIT_TIME_MULTI_APPROVAL = 24 * 2;
 const WAIT_TIME_SINGLE_APPROVAL = 24 * 7;
 
+const GITHUB_SUCCESS_CONCLUSIONS = ['SUCCESS', 'NEUTRAL', 'SKIPPED'];
+
 const {
   REVIEW_SOURCES: { FROM_COMMENT, FROM_REVIEW_COMMENT }
 } = require('./reviews');
@@ -335,7 +337,7 @@ class PRChecker {
         return false;
       }
 
-      if (!['SUCCESS', 'NEUTRAL'].includes(conclusion)) {
+      if (!GITHUB_SUCCESS_CONCLUSIONS.includes(conclusion)) {
         cli.error('Last GitHub CI failed');
         return false;
       }
@@ -372,7 +374,7 @@ class PRChecker {
         return false;
       }
 
-      if (!['SUCCESS', 'NEUTRAL'].includes(conclusion)) {
+      if (!GITHUB_SUCCESS_CONCLUSIONS.includes(conclusion)) {
         cli.error('Last GitHub CI failed');
         return false;
       }

--- a/test/fixtures/github-ci/check-suite-skipped.json
+++ b/test/fixtures/github-ci/check-suite-skipped.json
@@ -1,0 +1,20 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "SKIPPED"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -1427,6 +1427,25 @@ describe('PRChecker', () => {
       cli.assertCalledWith(expectedLogs);
     });
 
+    it('should succeed if check suite status skipped', async() => {
+      const cli = new TestCLI();
+
+      const expectedLogs = {
+        info: [
+          ['Last GitHub CI successful']
+        ]
+      };
+
+      const commits = githubCI['check-suite-skipped'];
+      const data = Object.assign({}, baseData, { commits });
+
+      const checker = new PRChecker(cli, data, {}, testArgv);
+
+      const status = await checker.checkCI();
+      assert(status);
+      cli.assertCalledWith(expectedLogs);
+    });
+
     it('should succeed if commit status succeeded', async() => {
       const cli = new TestCLI();
 


### PR DESCRIPTION
SKIPPED status on GitHub API doesn't necessarily mean a run failed. For
example, the staleComment and fastTrack Actions on nodejs/node will skip
if the last event was not a comment or label, respectively.