### PR TITLE
fix(update-v8): force-add all files after cloning V8

### DIFF
--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -26,6 +26,7 @@ module.exports = function() {
         removeDepsV8(),
         cloneLocalV8(),
         removeDepsV8Git(),
+        addDepsV8(),
         updateV8Deps(),
         applyNodeChanges()
       ]);
@@ -93,6 +94,17 @@ function removeDepsV8Git() {
   return {
     title: 'Remove deps/v8/.git',
     task: (ctx) => fs.remove(path.join(ctx.nodeDir, 'deps/v8/.git'))
+  };
+}
+
+function addDepsV8() {
+  return {
+    title: 'Track all files in deps/v8',
+    // Add all V8 files with --force before updating DEPS. We have to do this
+    // because some files are checked in by V8 despite .gitignore rules.
+    task: (ctx) => execa('git', ['add', '--force', 'deps/v8'], {
+      cwd: ctx.nodeDir
+    })
   };
 }
 


### PR DESCRIPTION
Add all V8 files with --force before updating DEPS. We have to do this
because some files are checked in by V8 despite .gitignore rules.
