### PR TITLE
fix(cli-separator): negative value on a long text

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -130,7 +130,7 @@ class CLI {
       return;
     }
     const rest = (length - text.length - 2);
-    const half = sep.repeat(Math.floor(rest / 2));
+    const half = sep.repeat(Math.abs(Math.floor(rest / 2)));
     if (rest % 2 === 0) {
       this.log(`${half} ${chalk.bold(text)} ${half}`);
     } else {


### PR DESCRIPTION
When `text` is longer than 78 characters (with default `length`), `rest` is negative, which raises an error at `repeat`, making some commands unusable (when a long argument is given).

```
RangeError: Invalid count value
    at String.repeat (<anonymous>)
    at CLI.separator (C:\Users\me\AppData\Local\Volta\tools\image\packages\node-core-utils\node_modules\node-core-utils\lib\cli.js:133:22)
    at WPTUpdater.checkNeedsUpdate (C:\Users\me\AppData\Local\Volta\tools\image\packages\node-core-utils\node_modules\node-core-utils\lib\wpt\index.js:127:14)
    at WPTUpdater.update (C:\Users\me\AppData\Local\Volta\tools\image\packages\node-core-utils\node_modules\node-core-utils\lib\wpt\index.js:155:36)
    at main (C:\Users\me\AppData\Local\Volta\tools\image\packages\node-core-utils\node_modules\node-core-utils\components\git\wpt.js:78:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```