### PR TITLE
fix(v8): use V8's main branch

### DIFF
--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -40,7 +40,7 @@ function checkoutBranch() {
     title: 'Checkout V8 branch',
     task: async(ctx) => {
       let version = ctx.branch;
-      await ctx.execGitV8('checkout', 'origin/master');
+      await ctx.execGitV8('checkout', 'origin/main');
       if (!versionReg.test(version)) {
         // try to get the latest tag
         const res = await ctx.execGitV8(


### PR DESCRIPTION
It became the default recently.

Refs: https://chromium.googlesource.com/v8/v8.git/
