### PR TITLE
git-node: improve instructions logs when manual amending is required

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -379,6 +379,10 @@ class LandingSession extends Session {
 
       if (!forceLand) {
         cli.info('Please fix the commit message and try again.');
+        cli.log('Please manually ammend the commit message, by running\n' +
+          '`git commit --amend`\n' +
+          'Once commit message is fixed, finish the landing command running\n' +
+          '`git node land --continue`');
         process.exit(1);
       }
     }


### PR DESCRIPTION
I had to manually change the commit message in one PR, and totally forgot to continue the landing process with `git node land --continue` this may be helpful for new collaborators.