### PR TITLE
feat: prepare ncu for new README format

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
     "space-before-function-paren": ["error", "never"],
     "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
     "camelcase": "off",
-    "max-len": [2, 80, 4, {"ignoreUrls": true}],
+    "max-len": [2, 80, 4, {"ignoreRegExpLiterals": true, "ignoreUrls": true}],
     "object-property-newline": "off"
   },
   "env": {

--- a/lib/collaborators.js
+++ b/lib/collaborators.js
@@ -6,8 +6,7 @@ const TSC_TITLE = '### TSC (Technical Steering Committee)';
 const TSCE_TITLE = '### TSC Emeriti';
 const CL_TITLE = '### Collaborators';
 const CLE_TITLE = '### Collaborator Emeriti';
-const CONTACT_RE =
-  /\* +\[(.+?)\]\(.+?\) +-\s\*\*(.+?)\*\* +(?:&lt;|<)(.+?)(?:&gt;|>)/mg;
+const CONTACT_RE = /\* +\[(.+?)\]\(.+?\) +-\s+\*\*(.+?)\*\* +(?:&lt;|\\<)(.+?)(?:&gt;|>)/mg;
 
 const TSC = 'TSC';
 const COLLABORATOR = 'COLLABORATOR';

--- a/lib/collaborators.js
+++ b/lib/collaborators.js
@@ -6,7 +6,8 @@ const TSC_TITLE = '### TSC (Technical Steering Committee)';
 const TSCE_TITLE = '### TSC Emeriti';
 const CL_TITLE = '### Collaborators';
 const CLE_TITLE = '### Collaborator Emeriti';
-const CONTACT_RE = /\* +\[(.+?)\]\(.+?\) +-\s\*\*(.+?)\*\* +&lt;(.+?)&gt;/mg;
+const CONTACT_RE =
+  /\* +\[(.+?)\]\(.+?\) +-\s\*\*(.+?)\*\* +(?:&lt;|<)(.+?)(?:&gt;|>)/mg;
 
 const TSC = 'TSC';
 const COLLABORATOR = 'COLLABORATOR';

--- a/test/fixtures/README/README.md
+++ b/test/fixtures/README/README.md
@@ -235,7 +235,7 @@ For more information about the governance of the Node.js project, see
 ### TSC (Technical Steering Committee)
 
 * [bar](https://github.com/bar) -
-**Bar User** &lt;bar@example.com&gt; (she/her)
+  **Bar User** \<bar@example.com> (she/her)
 
 ### TSC emeriti
 
@@ -245,7 +245,7 @@ For more information about the governance of the Node.js project, see
 ### Collaborators
 
 * [bar](https://github.com/bar) -
-**Bar User** &lt;bar@example.com&gt; (she/her)
+  **Bar User** \<bar@example.com> (she/her)
 * [Baz](https://github.com/Baz) -
 **Baz User** &lt;baz@example.com&gt; (he/him)
 * [foo](https://github.com/foo) -


### PR DESCRIPTION
This accommodates both the current README format and the upcoming README
format.

Refs: https://github.com/nodejs/node/pull/40137