### PR TITLE
update-v8: add abseil-cpp as a V8 dependency

### DIFF
--- a/lib/update-v8/constants.js
+++ b/lib/update-v8/constants.js
@@ -42,6 +42,12 @@ exports.v8Deps = [
     since: 55
   },
   {
+    name: 'abseil-cpp',
+    repo: 'third_party/abseil-cpp',
+    gitignore: '!third_party/abseil-cpp',
+    since: 96
+  },
+  {
     name: 'gtest',
     repo: 'testing/gtest',
     gitignore: {

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -147,6 +147,9 @@ async function readDeps(nodeDir, depName) {
   let deps;
   eval(depsDeclaration); // eslint-disable-line no-eval
   const dep = deps[depName];
+  if (typeof dep === 'object') {
+    return dep.url.split('@');
+  }
   return dep.split('@');
 }
 


### PR DESCRIPTION
Add new V8 dependency introduced in V8 9.6.

Refs: https://github.com/nodejs/node-v8/issues/211

cc @targos @nodejs/v8-update 