### PR TITLE
fix(update-v8): remove abseil-cpp from V8 dependencies

### DIFF
--- a/lib/update-v8/constants.js
+++ b/lib/update-v8/constants.js
@@ -42,12 +42,6 @@ exports.v8Deps = [
     since: 55
   },
   {
-    name: 'abseil-cpp',
-    repo: 'third_party/abseil-cpp',
-    gitignore: '!third_party/abseil-cpp',
-    since: 96
-  },
-  {
     name: 'gtest',
     repo: 'testing/gtest',
     gitignore: {


### PR DESCRIPTION
It was removed upstream because of issues with GCC.
