### PR TITLE
fix: update proxy-agent to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "ora": "^5.3.0",
-    "proxy-agent": "^4.0.1",
+    "proxy-agent": "^5.0.0",
     "replace-in-file": "^6.2.0",
     "rimraf": "^3.0.2",
     "yargs": "^16.2.0"


### PR DESCRIPTION
This eliminates 3 high-severity warnings from npm install.