### PR TITLE
fix: update detection of changelog links

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -331,7 +331,8 @@ class ReleasePreparation {
     const data = await fs.readFile(mainChangelogPath, 'utf8');
     const arr = data.split('\n');
 
-    const hrefLink = `doc/changelogs/CHANGELOG_V${versionComponents.major}.md`;
+    const major = versionComponents.major;
+    const hrefLink = `doc/changelogs/CHANGELOG\\_V${major}.md`;
     const newRefLink = `<a href="${hrefLink}#${newVersion}">${newVersion}</a>`;
     const lastRefLink = `<a href="${hrefLink}#${lastRef}">${lastRef}</a>`;
 


### PR DESCRIPTION
The Node.js `CHANGELOG.md` file was changed so that `_` characters in
links are now escaped.

Refs: https://github.com/nodejs/node/pull/40322

---

Note that we'll need to update again after https://github.com/nodejs/node/pull/40475 but for now this needs to work against the current `v16.x-staging` branch.