### PR TITLE
refactor(cli): apply optimizations

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,6 +21,8 @@ const QUESTION_TYPE = {
   CONFIRM: 'confirm'
 };
 
+const formatter = new Intl.ListFormat('en', { type: 'disjunction' });
+
 function head(text, length = 11) {
   return chalk.bold(text.padEnd(length));
 }
@@ -56,12 +58,11 @@ class CLI {
     const availableTypes = Object.values(QUESTION_TYPE);
     if (!availableTypes.includes(questionType)) {
       throw new Error(
-        `${questionType} must be one of ${availableTypes.join(', ')}`);
+        `${questionType} must be one of ${formatter.format(availableTypes)}`);
     }
 
-    const defaultAnswer = (opts.defaultAnswer === undefined)
-      ? true
-      : opts.defaultAnswer;
+    const defaultAnswer = (opts.defaultAnswer === undefined) ||
+      opts.defaultAnswer;
     if (typeof defaultAnswer === 'boolean' &&
         questionType !== QUESTION_TYPE.CONFIRM) {
       throw new Error(
@@ -97,14 +98,18 @@ class CLI {
 
   stopSpinner(rawText, status = SUCCESS) {
     let symbol;
-    if (status === SUCCESS) {
-      symbol = success;
-    } else if (status === FAILED) {
-      symbol = error;
-    } else if (status === WARN) {
-      symbol = warning;
-    } else if (status === INFO) {
-      symbol = info;
+    switch (status) {
+      case SUCCESS:
+        symbol = success;
+        break;
+      case FAILED:
+        symbol = error;
+        break;
+      case WARN:
+        symbol = warning;
+        break;
+      case INFO:
+        symbol = info;
     }
     const text = ' ' + rawText;
     this.spinner.stopAndPersist({
@@ -157,9 +162,9 @@ class CLI {
     const prefix = options.newline ? this.eolIndent : this.figureIndent;
     if (obj instanceof Error) {
       this.log(`${prefix}${error}  ${obj.message}`);
-      this.log(`${obj.stack}`);
+      this.log(obj.stack);
       if (obj.data) {
-        this.log(`${JSON.stringify(obj.data, null, 2)}`);
+        this.log(JSON.stringify(obj.data, null, 2));
       }
     } else {
       this.log(prefix + chalk.bold(`${error}  ${obj}`));


### PR DESCRIPTION
• List the available types by a `ListFormat` formatter.
• Replace unnecessary conditional check.
• Use switch statement for better readablity and performance.
• Avoid casting strings to strings.