### PR TITLE
fix: update detection of changelog links (take 2)

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -332,16 +332,18 @@ class ReleasePreparation {
     const arr = data.split('\n');
 
     const major = versionComponents.major;
-    const hrefLink = `doc/changelogs/CHANGELOG\\_V${major}.md`;
+    const hrefLink = `doc/changelogs/CHANGELOG_V${major}.md`;
+    const escapedHrefLink = hrefLink.replace(/_/g, '\\_');
     const newRefLink = `<a href="${hrefLink}#${newVersion}">${newVersion}</a>`;
     const lastRefLink = `<a href="${hrefLink}#${lastRef}">${lastRef}</a>`;
 
     for (let idx = 0; idx < arr.length; idx++) {
       if (isLTSTransition) {
-        if (arr[idx].includes(hrefLink)) {
+        if (arr[idx].includes(escapedHrefLink)) {
+          arr[idx] = arr[idx].replace('**Current**', '**Long Term Support**');
+        } else if (arr[idx].includes(hrefLink)) {
           const eolDate = getEOLDate(date);
           const eol = eolDate.toISOString().split('-').slice(0, 2).join('-');
-          arr[idx] = arr[idx].replace('**Current**', '**Long Term Support**');
           arr[idx] = arr[idx].replace('"Current"', `"LTS Until ${eol}"`);
           arr[idx] = arr[idx].replace('<sup>Current</sup>', '<sup>LTS</sup>');
         } else if (arr[idx].includes('**Long Term Support**')) {


### PR DESCRIPTION
Underscores in the links to the changelogs are escaped for markdown
links but not escaped for HTML links.

Refs: https://github.com/nodejs/node-core-utils/pull/573
Refs: https://github.com/nodejs/node/pull/40617