### PR TITLE
fix: update for recent changelog format change

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -345,7 +345,7 @@ class ReleasePreparation {
           const eolDate = getEOLDate(date);
           const eol = eolDate.toISOString().split('-').slice(0, 2).join('-');
           arr[idx] = arr[idx].replace('"Current"', `"LTS Until ${eol}"`);
-          arr[idx] = arr[idx].replace('<sup>Current</sup>', '<sup>LTS</sup>');
+          arr[idx] = arr[idx].replace('(Current)', '(LTS)');
         } else if (arr[idx].includes('**Long Term Support**')) {
           arr[idx] = arr[idx].replace(
             '**Long Term Support**',


### PR DESCRIPTION
The Node.js `CHANGELOG.md` has replaced use of `<sup>` tags.

Refs: https://github.com/nodejs/node/pull/40475