### PR TITLE
fix: prepare for one last README change

### DIFF
--- a/lib/collaborators.js
+++ b/lib/collaborators.js
@@ -6,7 +6,7 @@ const TSC_TITLE = '### TSC (Technical Steering Committee)';
 const TSCE_TITLE = '### TSC Emeriti';
 const CL_TITLE = '### Collaborators';
 const CLE_TITLE = '### Collaborator Emeriti';
-const CONTACT_RE = /\* +\[(.+?)\]\(.+?\) +-\s+\*\*(.+?)\*\* +(?:&lt;|\\<)(.+?)(?:&gt;|>)/mg;
+const CONTACT_RE = /\* +\[(.+?)\]\(.+?\) +-\s+\*\*([^*]+?)\*\* +(?:&lt;|\\<|<<)([^>]+?)(?:&gt;|>)/mg;
 
 const TSC = 'TSC';
 const COLLABORATOR = 'COLLABORATOR';

--- a/test/fixtures/README/README.md
+++ b/test/fixtures/README/README.md
@@ -235,7 +235,7 @@ For more information about the governance of the Node.js project, see
 ### TSC (Technical Steering Committee)
 
 * [bar](https://github.com/bar) -
-  **Bar User** \<bar@example.com> (she/her)
+  **Bar User** <<bar@example.com>> (she/her)
 
 ### TSC emeriti
 
@@ -245,7 +245,7 @@ For more information about the governance of the Node.js project, see
 ### Collaborators
 
 * [bar](https://github.com/bar) -
-  **Bar User** \<bar@example.com> (she/her)
+  **Bar User** <<bar@example.com>> (she/her)
 * [Baz](https://github.com/Baz) -
 **Baz User** &lt;baz@example.com&gt; (he/him)
 * [foo](https://github.com/foo) -


### PR DESCRIPTION
Using remark to format markdown files is going to require one final
README.md format change. This accommodates that change while being
backward-compatible with previous formats.