### PR TITLE
chore: resolve all npm install warnings

### DIFF
--- a/lib/update-v8/applyNodeChanges.js
+++ b/lib/update-v8/applyNodeChanges.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 const fs = require('fs-extra');
-const Listr = require('listr');
+const { Listr } = require('listr2');
 
 const {
   getNodeV8Version,

--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -4,8 +4,7 @@ const path = require('path');
 
 const fs = require('fs-extra');
 const inquirer = require('inquirer');
-const Listr = require('listr');
-const input = require('listr-input');
+const { Listr } = require('listr2');
 
 const { shortSha } = require('../utils');
 
@@ -156,10 +155,10 @@ function generatePatches() {
 function applyPatches() {
   return {
     title: 'Apply patches to deps/v8',
-    task: async(ctx) => {
+    task: async(ctx, task) => {
       const { patches } = ctx;
       for (const patch of patches) {
-        await applyPatch(ctx, patch);
+        await applyPatch(ctx, task, patch);
       }
     }
   };
@@ -181,7 +180,7 @@ function applyPatchTask(patch) {
       const todo = [
         {
           title: 'Apply patch',
-          task: (ctx) => applyPatch(ctx, patch)
+          task: (ctx, task) => applyPatch(ctx, task, patch)
         }
       ];
       if (ctx.bump !== false) {
@@ -197,7 +196,7 @@ function applyPatchTask(patch) {
   };
 }
 
-async function applyPatch(ctx, patch) {
+async function applyPatch(ctx, task, patch) {
   try {
     await ctx.execGitNode(
       'apply',
@@ -206,7 +205,9 @@ async function applyPatch(ctx, patch) {
     );
   } catch (e) {
     patch.hadConflicts = true;
-    return input("Resolve merge conflicts and enter 'RESOLVED'", {
+    return task.prompt({
+      type: 'input',
+      message: "Resolve merge conflicts and enter 'RESOLVED'",
       validate: value => value.toUpperCase() === 'RESOLVED'
     });
   }

--- a/lib/update-v8/index.js
+++ b/lib/update-v8/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Listr = require('listr');
+const { Listr } = require('listr2');
 
 const backport = require('./backport');
 const updateVersionNumbers = require('./updateVersionNumbers');

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const execa = require('execa');
 const fs = require('fs-extra');
-const Listr = require('listr');
+const { Listr } = require('listr2');
 
 const common = require('./common');
 const {

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const execa = require('execa');
 const fs = require('fs-extra');
-const Listr = require('listr');
+const { Listr } = require('listr2');
 
 const common = require('./common');
 

--- a/lib/update-v8/updateV8Clone.js
+++ b/lib/update-v8/updateV8Clone.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const execa = require('execa');
-const Listr = require('listr');
+const { Listr } = require('listr2');
 const fs = require('fs-extra');
 
 const { v8Git } = require('./constants');

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 const fs = require('fs-extra');
-const Listr = require('listr');
+const { Listr } = require('listr2');
 
 const util = require('./util');
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "fs-extra": "^9.1.0",
     "ghauth": "^4.0.0",
     "inquirer": "^7.3.3",
-    "listr": "^0.14.3",
-    "listr-input": "^0.2.1",
+    "listr2": "^3.13.1",
     "lodash": "^4.17.21",
     "log-symbols": "^4.1.0",
     "node-fetch": "^2.6.1",
@@ -62,7 +61,7 @@
     "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-standard": "^4.1.0",
     "intelli-espower-loader": "^1.0.1",
-    "mocha": "^8.3.0",
+    "mocha": "^9.1.3",
     "nyc": "^15.1.0",
     "power-assert": "^1.6.1",
     "sinon": "^9.2.4"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "listr": "^0.14.3",
     "listr-input": "^0.2.1",
     "lodash": "^4.17.21",
+    "log-symbols": "^4.1.0",
     "node-fetch": "^2.6.1",
     "ora": "^5.3.0",
     "proxy-agent": "^5.0.0",


### PR DESCRIPTION
Replaces listr with listr2 and updates mocha. `npm install` no longer
reports audit issues on install.

I am not confident about the listr changes, especially replacing the use of listr-input with inquirer. Unfortunately, those are all in the v8-update code and it does not seem to be covered by tests. Perhaps @targos can test it?