### PR TITLE
fix: display the correct amount of remaining time for fast-tracked PRs

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -196,7 +196,7 @@ class PRChecker {
       if (timeLeftSingle < 0) {
         return true;
       }
-      timeLeftMulti = timeLeftMulti < 0 ? 0 : timeLeftMulti;
+      timeLeftMulti = timeLeftMulti < 0 || isFastTracked ? 0 : timeLeftMulti;
       cli.error(`This PR needs to wait ${timeLeftSingle} more hours to land ` +
                 `(or ${timeLeftMulti} hours if there is one more approval)`);
       return false;


### PR DESCRIPTION
Refs: https://github.com/nodejs/node-auto-test/pull/40#issuecomment-955670657