### PR TITLE
chore: update Node.js in CI workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use latest Node.js LTS
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: lts/*
       - name: Install dependencies
         run: npm install
       - name: Lint
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
- Use latest LTS for lint job
- Add version 17.x to test matrix
