### PR TITLE
feat(land): avoid landing on the wrong default branch

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -467,7 +467,7 @@ class LandingSession extends Session {
       { owner: this.owner, repo: this.repo });
     if ((rev === 'master' || rev === 'main') && defaultBranchRef.name !== rev) {
       this.cli.warn(`You are running git-node-land on \`${rev}\`,` +
-                    ` but the default branch is ${defaultBranchRef.name}.`);
+                    ` but the default branch is \`${defaultBranchRef.name}\`.`);
       this.cli.setExitCode(1);
       return true;
     }

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -456,6 +456,22 @@ class LandingSession extends Session {
   async status() {
     // TODO
   }
+
+  async warnForWrongBranch() {
+    if (super.warnForWrongBranch()) {
+      return true;
+    }
+    const rev = this.getCurrentBranch();
+    const { repository: { defaultBranchRef } } = await this.req.gql(
+      'DefaultBranchRef',
+      { owner: this.owner, repo: this.repo });
+    if ((rev === 'master' || rev === 'main') && defaultBranchRef.name !== rev) {
+      this.cli.warn(`You are running git-node-land on \`${rev}\`,` +
+                    ` but the default branch is ${defaultBranchRef.name}.`);
+      this.cli.setExitCode(1);
+      return true;
+    }
+  }
 }
 
 module.exports = LandingSession;

--- a/lib/queries/DefaultBranchRef.gql
+++ b/lib/queries/DefaultBranchRef.gql
@@ -1,0 +1,8 @@
+query DefaultBranchRef($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    defaultBranchRef {
+      name
+    }
+  }
+}
+


### PR DESCRIPTION
Fail if the user is trying to land a commit on "master" or "main", and
the default branch name doesn't match.
