### PR TITLE
fix: update detection of changelog links

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -333,17 +333,15 @@ class ReleasePreparation {
 
     const major = versionComponents.major;
     const hrefLink = `doc/changelogs/CHANGELOG_V${major}.md`;
-    const escapedHrefLink = hrefLink.replace(/_/g, '\\_');
     const newRefLink = `<a href="${hrefLink}#${newVersion}">${newVersion}</a>`;
     const lastRefLink = `<a href="${hrefLink}#${lastRef}">${lastRef}</a>`;
 
     for (let idx = 0; idx < arr.length; idx++) {
       if (isLTSTransition) {
-        if (arr[idx].includes(escapedHrefLink)) {
-          arr[idx] = arr[idx].replace('**Current**', '**Long Term Support**');
-        } else if (arr[idx].includes(hrefLink)) {
+        if (arr[idx].includes(hrefLink)) {
           const eolDate = getEOLDate(date);
           const eol = eolDate.toISOString().split('-').slice(0, 2).join('-');
+          arr[idx] = arr[idx].replace('**Current**', '**Long Term Support**');
           arr[idx] = arr[idx].replace('"Current"', `"LTS Until ${eol}"`);
           arr[idx] = arr[idx].replace('(Current)', '(LTS)');
         } else if (arr[idx].includes('**Long Term Support**')) {


### PR DESCRIPTION
Upstream changes to the Node.js `CHANGELOG.md` no longer escape `_`
characters in markdown links.

Refs: https://github.com/nodejs/node/pull/40645
Refs: https://github.com/nodejs/node-core-utils/pull/575#issuecomment-952262877

---

Hopefully the churn has settled down now 🤞.