### PR TITLE
fix: fixupAll flag should take precedence over autorebase

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -214,6 +214,12 @@ class LandingSession extends Session {
       }
 
       return this.final();
+    } else if (this.fixupAll) {
+      cli.log(`There are ${subjects.length} commits in the PR. ` +
+        'Attempting to fixup everything into first commit.');
+      await runAsync('git', ['reset', '--soft', `HEAD~${subjects.length - 1}`]);
+      await runAsync('git', ['commit', '--amend', '--no-edit']);
+      return await this.amend() && this.final();
     } else if (this.autorebase && this.canAutomaticallyRebase(subjects)) {
       // Run git rebase in interactive mode with autosquash but without editor
       // so that it will perform everything automatically.
@@ -239,12 +245,6 @@ class LandingSession extends Session {
         cli.log(`Couldn't rebase ${count} commits in the PR automatically`);
         this.makeRebaseSuggestion(subjects);
       }
-    } else if (this.fixupAll) {
-      cli.log(`There are ${subjects.length} commits in the PR. ` +
-        'Attempting to fixup everything into first commit.');
-      await runAsync('git', ['reset', '--soft', `HEAD~${subjects.length - 1}`]);
-      await runAsync('git', ['commit', '--amend', '--no-edit']);
-      return await this.amend() && this.final();
     } else {
       this.makeRebaseSuggestion(subjects);
     }


### PR DESCRIPTION
When running `git node land <pr> --autorebase --fixupAll`, ncu should squash all the commits first, then ignore the `--autorebase` flag as there is only one commit left.

This comes up in the CQ for nodejs/node repo, we could fix the CQ script so it only supply one flag or the other, but since I didn't find any documentation stating the `--fixupAll` is ignored when using `--autorebase`, I thought it would be worth fixing it.

Refs: https://github.com/nodejs/node/pull/40696#issuecomment-967642528