### PR TITLE
lib, test: prepare for npm audit fix

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -40,7 +40,8 @@ function buildYargs(args = null) {
     .option('check-comments', {
       demandOption: false,
       describe: 'Check for \'LGTM\' in comments',
-      type: 'boolean'
+      type: 'boolean',
+      default: false
     })
     .help()
     .alias('help', 'h')

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -54,7 +54,8 @@ async function auth(getCredentials = ghauth) {
     username: credentials.user,
     token: credentials.token
   }, null, '  ');
-  await writeFile(authFile, json, { mode:
+  await writeFile(authFile, json, {
+    mode:
     0o600 /* owner read/write */
   });
 

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -16,8 +16,10 @@ const LINTER = 'LINTER';
 const CI_TYPES = new Map([
   [CITGM, { name: 'CITGM', re: /citgm/ }],
   [FULL,
-    { name: 'Full',
-      re: /node-test-pull-request|node-test-commit\// }],
+    {
+      name: 'Full',
+      re: /node-test-pull-request|node-test-commit\//
+    }],
   [BENCHMARK, { name: 'Benchmark', re: /benchmark/ }],
   [LIBUV, { name: 'libuv', re: /libuv/ }],
   [NOINTL, { name: 'No Intl', re: /nointl/ }],
@@ -46,7 +48,7 @@ class CIParser {
       for (const ci of cis) {
         const entry = result.get(ci.type);
         if (!entry || entry.date < c.publishedAt) {
-          result.set(ci.type, {link: ci.link, date: c.publishedAt});
+          result.set(ci.type, { link: ci.link, date: c.publishedAt });
         }
       }
     }

--- a/lib/metadata_gen.js
+++ b/lib/metadata_gen.js
@@ -32,7 +32,7 @@ class MetadataGenerator {
     const fixes = parser.getFixes();
     const refs = parser.getRefs();
 
-    let meta = [
+    const meta = [
       `PR-URL: ${prUrl}`,
       ...fixes.map((fix) => `Fixes: ${fix}`),
       ...refs.map((ref) => `Refs: ${ref}`),

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -86,10 +86,10 @@ class PRChecker {
     let status = true;
 
     if (rejected.length === 0) {
-      logger.info(`Rejections: 0`);
+      logger.info('Rejections: 0');
     } else {
       status = false;
-      let hint = this.getTSCHint(rejected);
+      const hint = this.getTSCHint(rejected);
       logger.warn(`Rejections: ${rejected.length}${hint}`);
       for (const { reviewer, review } of rejected) {
         logger.warn(`${reviewer.getName()} rejected in ${review.ref}`);
@@ -97,13 +97,13 @@ class PRChecker {
     }
     if (approved.length === 0) {
       status = false;
-      logger.warn(`Approvals: 0`);
+      logger.warn('Approvals: 0');
     } else {
-      let hint = this.getTSCHint(approved);
+      const hint = this.getTSCHint(approved);
       logger.info(`Approvals: ${approved.length}${hint}`);
 
       if (comments) {
-        for (const {reviewer, review} of approved) {
+        for (const { reviewer, review } of approved) {
           if (review.source === FROM_COMMENT ||
             review.source === FROM_REVIEW_COMMENT) {
             logger.warn(
@@ -236,7 +236,7 @@ class PRChecker {
       const { oid, author } = c.commit;
       const hash = oid.slice(0, 7);
       logger.warn(`Author ${author.email} of commit ${hash} ` +
-                  `does not match committer or PR author`);
+                  'does not match committer or PR author');
     }
     return false;
   }

--- a/lib/request.js
+++ b/lib/request.js
@@ -34,7 +34,7 @@ class Request {
       uri: 'https://api.github.com/graphql',
       method: 'POST',
       headers: {
-        'Authorization': `Basic ${this.credentials}`,
+        Authorization: `Basic ${this.credentials}`,
         'User-Agent': 'node-core-utils'
       },
       json: true,

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -144,10 +144,10 @@ class ReviewAnalyzer {
       rejected: []
     };
     const collaborators = this.collaborators;
-    for (const [ login, review ] of reviewers) {
+    for (const [login, review] of reviewers) {
       const reviewer = collaborators.get(login.toLowerCase());
       if (review.state === APPROVED) {
-        result.approved.push({reviewer, review});
+        result.approved.push({ reviewer, review });
       } else if (review.state === CHANGES_REQUESTED) {
         result.rejected.push({ reviewer, review });
       }

--- a/test/fixtures/reviewers_approved.json
+++ b/test/fixtures/reviewers_approved.json
@@ -36,7 +36,7 @@
     },
     "review": {
       "state": "APPROVED",
-      "date": "2017-10-24T14:49:52Z",
+      "date": "2017-10-24T15:49:52Z",
       "ref": "https://github.com/nodejs/node/pull/16438#pullrequestreview-71488236",
       "source": "review"
     }

--- a/test/fixtures/reviews_approved.json
+++ b/test/fixtures/reviews_approved.json
@@ -28,21 +28,21 @@
 },
 {
   "bodyText": "LGTM",
-  "state": "APPROVED",
-  "author": {
-    "login": "Baz"
-  },
-  "url": "https://github.com/nodejs/node/pull/16438#pullrequestreview-71488236",
-  "publishedAt": "2017-10-24T14:49:52Z"
-},
-{
-  "bodyText": "LGTM",
   "state": "COMMENTED",
   "author": {
     "login": "Quux"
   },
   "url": "https://github.com/nodejs/node/pull/16438#pullrequestreview-71817236",
   "publishedAt": "2017-10-24T14:49:52Z"
+},
+{
+  "bodyText": "LGTM",
+  "state": "APPROVED",
+  "author": {
+    "login": "Baz"
+  },
+  "url": "https://github.com/nodejs/node/pull/16438#pullrequestreview-71488236",
+  "publishedAt": "2017-10-24T15:49:52Z"
 },
 {
   "bodyText": "A few nits",

--- a/test/unit/args.test.js
+++ b/test/unit/args.test.js
@@ -5,8 +5,8 @@ const assert = require('assert');
 
 const expected = {
   checkComments: false,
-  owner: `nodejs`,
-  repo: `node`,
+  owner: 'nodejs',
+  repo: 'node',
   prid: 16637,
   file: undefined
 };

--- a/test/unit/auth.test.js
+++ b/test/unit/auth.test.js
@@ -64,9 +64,11 @@ function runAuthScript(
     }
 
     const proc = spawn(process.execPath,
-      [ require.resolve(`../fixtures/${fixture}`) ],
-      { timeout: 1500,
-        env: Object.assign({}, process.env, { USERPROFILE: HOME, HOME }) });
+      [require.resolve(`../fixtures/${fixture}`)],
+      {
+        timeout: 1500,
+        env: Object.assign({}, process.env, { USERPROFILE: HOME, HOME })
+      });
     let stderr = '';
     proc.stderr.setEncoding('utf8');
     proc.stderr.on('data', (chunk) => { stderr += chunk; });

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -319,7 +319,7 @@ describe('PRChecker', () => {
 
     it('should check commits after last ci', () => {
       const logger = new TestLogger();
-      const {commits, comment} = commitsAfterCi;
+      const { commits, comment } = commitsAfterCi;
 
       const expectedLogs = {
         warn: [
@@ -384,7 +384,7 @@ describe('PRChecker', () => {
   });
 
   describe('checkCommitsAfterReview', () => {
-    let logger = new TestLogger();
+    const logger = new TestLogger();
 
     afterEach(() => {
       logger.clear();
@@ -395,8 +395,8 @@ describe('PRChecker', () => {
 
       const expectedLogs = {
         warn: [
-          [ 'Changes were pushed since the last review:' ],
-          [ '- single commit was pushed after review' ]
+          ['Changes were pushed since the last review:'],
+          ['- single commit was pushed after review']
         ],
         info: [],
         trace: [],
@@ -412,7 +412,7 @@ describe('PRChecker', () => {
         commits
       });
 
-      let status = checker.checkCommitsAfterReview();
+      const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
@@ -422,9 +422,9 @@ describe('PRChecker', () => {
 
       const expectedLogs = {
         warn: [
-          [ 'Changes were pushed since the last review:' ],
-          [ '- src: add requested feature' ],
-          [ '- nit: fix errors' ]
+          ['Changes were pushed since the last review:'],
+          ['- src: add requested feature'],
+          ['- nit: fix errors']
         ],
         info: [],
         trace: [],
@@ -440,7 +440,7 @@ describe('PRChecker', () => {
         commits
       });
 
-      let status = checker.checkCommitsAfterReview();
+      const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, false);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
@@ -464,14 +464,14 @@ describe('PRChecker', () => {
         commits
       });
 
-      let status = checker.checkCommitsAfterReview();
+      const status = checker.checkCommitsAfterReview();
       assert.deepStrictEqual(status, true);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
   });
 
   describe('checkMergeableState', () => {
-    let logger = new TestLogger();
+    const logger = new TestLogger();
 
     afterEach(() => {
       logger.clear();
@@ -494,7 +494,7 @@ describe('PRChecker', () => {
         collaborators
       });
 
-      let status = checker.checkMergeableState();
+      const status = checker.checkMergeableState();
       assert.deepStrictEqual(status, false);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });
@@ -518,7 +518,7 @@ describe('PRChecker', () => {
         commits
       });
 
-      let status = checker.checkMergeableState();
+      const status = checker.checkMergeableState();
       assert.deepStrictEqual(status, true);
       assert.deepStrictEqual(logger.logs, expectedLogs);
     });


### PR DESCRIPTION
I tried to run `npm audit fix` today and here are the changes that are necessary for the tests to pass with the upgrade, so opening a PR first to fix them. The first commit makes the test data more deterministic (probably an issue that's exposed by my particular setup as this fails on the main branch too)  by making the dates different so that the items can be sorted properly by date. The second fixes a breakage caused by a breaking change in yargs by explicitly making the checkComments default to false (instead of counting on it being coerced from undefined to that). The last one are just format changes required by eslint upgrades.