### PR TITLE
Fix PR checker for GitHub Actions CI

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -339,43 +339,6 @@ class PRChecker {
     return status;
   }
 
-  checkActionsCI() {
-    const { cli, commits } = this;
-
-    if (!commits || commits.length === 0) {
-      cli.error('No commits detected');
-      return false;
-    }
-
-    // NOTE(mmarchini): we only care about the last commit. Maybe in the future
-    // we'll want to check all commits for a successful CI.
-    const { commit } = commits[commits.length - 1];
-
-    this.CIStatus = false;
-    const checkSuites = commit.checkSuites || { nodes: [] };
-    if (!commit.status && checkSuites.nodes.length === 0) {
-      cli.error('No GitHub CI runs detected');
-      return false;
-    }
-
-    // GitHub new Check API
-    for (const { status, conclusion } of checkSuites.nodes) {
-      if (status !== 'COMPLETED') {
-        cli.error('GitHub CI is still running');
-        return false;
-      }
-
-      if (!GITHUB_SUCCESS_CONCLUSIONS.includes(conclusion)) {
-        cli.error('Last GitHub CI failed');
-        return false;
-      }
-    }
-
-    cli.ok('Last GitHub Actions successful');
-    this.CIStatus = true;
-    return true;
-  }
-
   checkGitHubCI() {
     const { cli, commits } = this;
 
@@ -396,7 +359,13 @@ class PRChecker {
     }
 
     // GitHub new Check API
-    for (const { status, conclusion } of checkSuites.nodes) {
+    for (const { status, conclusion, app } of checkSuites.nodes) {
+      if (app && app.slug === 'dependabot') {
+        // Ignore Dependabot check suites. They are expected to show up
+        // sometimes and never complete.
+        continue;
+      }
+
       if (status !== 'COMPLETED') {
         cli.error('GitHub CI is still running');
         return false;
@@ -422,7 +391,7 @@ class PRChecker {
       }
     }
 
-    cli.info('Last GitHub CI successful');
+    cli.ok('Last GitHub CI successful');
     this.CIStatus = true;
     return true;
   }
@@ -460,14 +429,14 @@ class PRChecker {
   }
 
   async checkNodejsCI() {
-    let status = this.checkActionsCI();
+    let status = this.checkGitHubCI();
     if (
       this.pr.labels.nodes.some((l) => l.name === 'needs-ci') ||
       this.requiresJenkinsRun()
     ) {
       status &= await this.checkJenkinsCI();
     } else {
-      this.cli.info('Green GitHub Actions CI is sufficient');
+      this.cli.info('Green GitHub CI is sufficient');
     }
     return status;
   }

--- a/lib/queries/PRCommits.gql
+++ b/lib/queries/PRCommits.gql
@@ -25,7 +25,7 @@ query Commits($prid: Int!, $owner: String!, $repo: String!, $after: String) {
             message
             messageHeadline
             authoredByCommitter
-            checkSuites(first: 10) {
+            checkSuites(first: 100) {
               nodes {
                 conclusion,
                 status

--- a/lib/queries/PRCommits.gql
+++ b/lib/queries/PRCommits.gql
@@ -27,6 +27,9 @@ query Commits($prid: Int!, $owner: String!, $repo: String!, $after: String) {
             authoredByCommitter
             checkSuites(first: 100) {
               nodes {
+                app {
+                  slug
+                }
                 conclusion,
                 status
               }

--- a/test/fixtures/github-ci/success-dependabot-queued.json
+++ b/test/fixtures/github-ci/success-dependabot-queued.json
@@ -1,0 +1,28 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "app": {
+              "slug": "dependabot"
+            },
+            "status": "QUEUED",
+            "conclusion": null
+          },
+          {
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS"
+          }
+        ]
+      }
+    }
+  }
+]
+

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -800,7 +800,7 @@ describe('PRChecker', () => {
           ['No GitHub CI runs detected']
         ],
         info: [
-          ['Green GitHub Actions CI is sufficient']
+          ['Green GitHub CI is sufficient']
         ]
       };
 
@@ -839,10 +839,10 @@ describe('PRChecker', () => {
 
       const expectedLogs = {
         ok: [
-          ['Last GitHub Actions successful']
+          ['Last GitHub CI successful']
         ],
         info: [
-          ['Green GitHub Actions CI is sufficient']
+          ['Green GitHub CI is sufficient']
         ]
       };
 
@@ -883,10 +883,10 @@ describe('PRChecker', () => {
 
       const expectedLogs = {
         ok: [
-          ['Last GitHub Actions successful']
+          ['Last GitHub CI successful']
         ],
         info: [
-          ['Green GitHub Actions CI is sufficient']
+          ['Green GitHub CI is sufficient']
         ]
       };
 
@@ -1086,7 +1086,7 @@ describe('PRChecker', () => {
 
       const expectedLogs = {
         ok: [
-          ['Last GitHub Actions successful'],
+          ['Last GitHub CI successful'],
           ['Last Jenkins CI successful']
         ],
         error: [
@@ -1462,7 +1462,7 @@ describe('PRChecker', () => {
       const cli = new TestCLI();
 
       const expectedLogs = {
-        info: [
+        ok: [
           ['Last GitHub CI successful']
         ]
       };
@@ -1476,6 +1476,28 @@ describe('PRChecker', () => {
       assert(status);
       cli.assertCalledWith(expectedLogs);
     });
+
+    it(
+      'should succeed if status succeeded with queued Dependabot check',
+      async() => {
+        const cli = new TestCLI();
+
+        const expectedLogs = {
+          ok: [
+            ['Last GitHub CI successful']
+          ]
+        };
+
+        const commits = githubCI['success-dependabot-queued'];
+        const data = Object.assign({}, baseData, { commits });
+
+        const checker = new PRChecker(cli, data, {}, testArgv);
+
+        const status = await checker.checkCI();
+        assert(status);
+        cli.assertCalledWith(expectedLogs);
+      }
+    );
 
     it('should error if Check suite failed', async() => {
       const cli = new TestCLI();
@@ -1519,7 +1541,7 @@ describe('PRChecker', () => {
       const cli = new TestCLI();
 
       const expectedLogs = {
-        info: [
+        ok: [
           ['Last GitHub CI successful']
         ]
       };
@@ -1576,7 +1598,7 @@ describe('PRChecker', () => {
       const cli = new TestCLI();
 
       const expectedLogs = {
-        info: [
+        ok: [
           ['Last GitHub CI successful']
         ]
       };
@@ -1595,7 +1617,7 @@ describe('PRChecker', () => {
       const cli = new TestCLI();
 
       const expectedLogs = {
-        info: [
+        ok: [
           ['Last GitHub CI successful']
         ]
       };
@@ -1671,7 +1693,7 @@ describe('PRChecker', () => {
       const cli = new TestCLI();
 
       const expectedLogs = {
-        info: [
+        ok: [
           ['Last GitHub CI successful']
         ]
       };


### PR DESCRIPTION
```
fix: fetch first 100 check suites in PR checker

10 is not enough, as we have around 25 GitHub checks nowadays.
```

```
fix: allow pending dependabot checks in PR checker

GitHub support says that they are expected to show up by design.
This also removes some code duplication and normalizes log level and format.
```

