### PR TITLE
config: add file path to error message when parsing fails

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,13 @@ export function getMergedConfig(dir, home) {
 
 export function getConfig(configType, dir) {
   const configPath = getConfigPath(configType, dir);
-  return readJson(configPath);
+  try {
+    return readJson(configPath);
+  } catch (cause) {
+    const error = new Error('Unable to parse config file ' + configPath);
+    error.cause = cause;
+    throw error;
+  }
 };
 
 export function getConfigPath(configType, dir) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,9 +28,7 @@ export function getConfig(configType, dir) {
   try {
     return readJson(configPath);
   } catch (cause) {
-    const error = new Error('Unable to parse config file ' + configPath);
-    error.cause = cause;
-    throw error;
+    throw new Error('Unable to parse config file ' + configPath, { cause });
   }
 };
 


### PR DESCRIPTION
Before:

```
undefined:5
}
^

SyntaxError: Unexpected token } in JSON at position 138
    at JSON.parse (<anonymous>)
    at exports.readJson (…/lib/file.js:38:17)
    at Object.exports.getConfig (…/lib/config.js:34:10)
    at Object.exports.getMergedConfig (…/lib/config.js:26:32)
    at Object.<anonymous> (…/components/git/metadata.js:8:44)
    at Module._compile (node:internal/modules/cjs/loader:1097:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1151:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)

Node.js v17.6.0
```

After:
```
…/lib/config.js:39
    throw err
    ^

Error: Unable to parse config file /home/~/.ncurc
    at Object.exports.getConfig (…/lib/config.js:37:17)
    at Object.exports.getMergedConfig (…/lib/config.js:26:32)
    ... 5 lines matching cause stack trace ...
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at Object.require (node:internal/modules/cjs/helpers:102:18)
    at …/node_modules/require-directory/index.js:76:17 {
  cause: SyntaxError: Unexpected token } in JSON at position 138
      at JSON.parse (<anonymous>)
      at exports.readJson (…/lib/file.js:38:17)
      at Object.exports.getConfig (…/lib/config.js:35:12)
      at Object.exports.getMergedConfig (…/lib/config.js:26:32)
      at Object.<anonymous> (…/components/git/metadata.js:8:44)
      at Module._compile (node:internal/modules/cjs/loader:1097:14)
      at Object.Module._extensions..js (node:internal/modules/cjs/loader:1151:10)
      at Module.load (node:internal/modules/cjs/loader:975:32)
      at Function.Module._load (node:internal/modules/cjs/loader:822:12)
      at Module.require (node:internal/modules/cjs/loader:999:19)
}

Node.js v17.6.0
```