### PR TITLE
fix: comply with markdown style guidelines

### DIFF
--- a/lib/team_info.js
+++ b/lib/team_info.js
@@ -8,8 +8,8 @@ function byLogin(a, b) {
 }
 
 function getContact({ login, url, name, email }) {
-  if (!name) return `- [@${login}](${url})`;
-  return `- [@${login}](${url}) - ${name}`;
+  if (!name) return `* [@${login}](${url})`;
+  return `* [@${login}](${url}) - ${name}`;
 }
 
 function key(org, team) {

--- a/test/fixtures/ncu_team_sync_expected.md
+++ b/test/fixtures/ncu_team_sync_expected.md
@@ -2,9 +2,9 @@
 
 <!-- ncu-team-sync.team(nodejs/automation-collaborators) -->
 
-- [@Bar](https://github.com/Bar) - Bar Bar
-- [@foo](https://github.com/foo) - Mr. foo
-- [@quo](https://github.com/quo) - Ms. Quo
+* [@Bar](https://github.com/Bar) - Bar Bar
+* [@foo](https://github.com/foo) - Mr. foo
+* [@quo](https://github.com/quo) - Ms. Quo
 
 <!-- ncu-team-sync end -->
 
@@ -12,6 +12,6 @@
 
 <!-- ncu-team-sync.team(nodejs/bots) -->
 
-- [@nodejs-github-bot](https://github.com/nodejs-github-bot) - Node.js GitHub Bot
+* [@nodejs-github-bot](https://github.com/nodejs-github-bot) - Node.js GitHub Bot
 
 <!-- ncu-team-sync end -->

--- a/test/fixtures/ncu_team_sync_out.md
+++ b/test/fixtures/ncu_team_sync_out.md
@@ -2,9 +2,9 @@
 
 <!-- ncu-team-sync.team(nodejs/automation-collaborators) -->
 
-- [@Bar](https://github.com/Bar) - Bar Bar
-- [@foo](https://github.com/foo) - Mr. foo
-- [@quo](https://github.com/quo) - Ms. Quo
+* [@Bar](https://github.com/Bar) - Bar Bar
+* [@foo](https://github.com/foo) - Mr. foo
+* [@quo](https://github.com/quo) - Ms. Quo
 
 <!-- ncu-team-sync end -->
 
@@ -12,6 +12,6 @@
 
 <!-- ncu-team-sync.team(nodejs/bots) -->
 
-- [@nodejs-github-bot](https://github.com/nodejs-github-bot) - Node.js GitHub Bot
+* [@nodejs-github-bot](https://github.com/nodejs-github-bot) - Node.js GitHub Bot
 
 <!-- ncu-team-sync end -->

--- a/test/unit/team_info.test.js
+++ b/test/unit/team_info.test.js
@@ -7,9 +7,9 @@ import TeamInfo from '../../lib/team_info.js';
 import { readJSON, readFile, path as getPath } from '../fixtures/index.js';
 
 const collabList =
-`- [@Bar](https://github.com/Bar) - Bar Bar
-- [@foo](https://github.com/foo) - Mr. foo
-- [@quo](https://github.com/quo) - Ms. Quo`;
+`* [@Bar](https://github.com/Bar) - Bar Bar
+* [@foo](https://github.com/foo) - Mr. foo
+* [@quo](https://github.com/quo) - Ms. Quo`;
 
 describe('TeamInfo', function() {
   let request;


### PR DESCRIPTION
The markdown style linting for our repos requires `*` instead of `-` for
unordered lists. Because ncu-team uses `-`, it results in failing lints
in some repos, thus requiring manual changes to the output. Use `*`
instead so that becomes unnecessary.

I had this problem in https://github.com/nodejs/TSC/pull/1189.

Refs: https://github.com/nodejs/TSC/commit/3cbcd5a02c400d7c0886683166f9ff320c2c0f5c