### PR TITLE
fix: add trailing line feed to formatted JSON

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -20,7 +20,7 @@ export function writeFile(file, content) {
 };
 
 export function writeJson(file, obj) {
-  writeFile(file, JSON.stringify(obj, null, 2));
+  writeFile(file, `${JSON.stringify(obj, null, 2)}\n`);
 };
 
 export function readFile(file) {


### PR DESCRIPTION
Pretty-printed JSON files should end with `\n`.