### PR TITLE
fix: use res.arrayBuffer() instead of res.buffer()

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -37,7 +37,9 @@ export default class Request {
   }
 
   async buffer(url, options = {}) {
-    return this.fetch(url, options).then(res => res.buffer());
+    const res = await this.fetch(url, options);
+    const buffer = await res.arrayBuffer();
+    return Buffer.from(buffer);
   }
 
   async text(url, options = {}) {


### PR DESCRIPTION
Without this, when using `git node wpt`:

```console
tniessen@ubuntuserver:~/dev/node$ node ../node-core-utils/bin/git-node.js wpt wasm/webapi
   ⚠  Please create wasm/webapi.json in test/wpt/status
--------------------- Checking updates for wasm/webapi... ----------------------
Last local update for wasm/webapi is fd1b23eeaaf9
✔  wasm/webapi is up to date with upstream (fd1b23eeaaf9)
⠸ Updating license...(node:596531) [node-fetch#buffer] DeprecationWarning: Please use 'response.arrayBuffer()' instead of 'response.buffer()'
(Use `node --trace-deprecation ...` to show where the warning was created)
✔  Updated test/fixtures/wpt/LICENSE.md.
```

Tracing it:

```console
tniessen@ubuntuserver:~/dev/node$ node --trace-deprecation ../node-core-utils/bin/git-node.js wpt wasm/webapi
   ⚠  Please create wasm/webapi.json in test/wpt/status
--------------------- Checking updates for wasm/webapi... ----------------------
Last local update for wasm/webapi is fd1b23eeaaf9
✔  wasm/webapi is up to date with upstream (fd1b23eeaaf9)
⠙ Updating license...(node:597136) [node-fetch#buffer] DeprecationWarning: Please use 'response.arrayBuffer()' instead of 'response.buffer()'
    at file:///home/tniessen/dev/node-core-utils/lib/request.js:40:53
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async WPTUpdater.pullTextFile (file:///home/tniessen/dev/node-core-utils/lib/wpt/index.js:53:21)
    at async WPTUpdater.updateLicense (file:///home/tniessen/dev/node-core-utils/lib/wpt/index.js:123:5)
✔  Updated test/fixtures/wpt/LICENSE.md.
```

This PR modifies the relevant function to use the standard `res.arrayBuffer()` function instead of `res.buffer()`.