### PR TITLE
docs: clarify global gitignore and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To obtain the Jenkins API token
   token in the inbox that appears, and click `GENERATE`.
 4. Copy the generated token.
 5. Add it into your `ncurc` file (`~/.ncurc` or `$XDG_CONFIG_HOME/ncurc`)
-  with `jenkins_token` as key, like this
+  with `jenkins_token` as key, like this:
 
   ```json
   {
@@ -113,7 +113,8 @@ To obtain the Jenkins API token
 
 ### Make sure your credentials won't be committed
 
-Put the following entries into `~/.gitignore_global`
+Put the following entries into your global gitignore file
+(`$XDG_CONFIG_HOME/git/ignore` or a file specified by `core.excludesFile`):
 
 ```
 # node-core-utils configuration file

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ To obtain the Jenkins API token
 
 ### Make sure your credentials won't be committed
 
-Put the following entries into your global gitignore file
+Put the following entries into your
+[global `gitignore` file](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreexcludesFile)
 (`$XDG_CONFIG_HOME/git/ignore` or a file specified by `core.excludesFile`):
 
 ```

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Put the following entries into `~/.gitignore_global`
 .ncu
 ```
 
-Mind that`.ncu/land` could contain your access token since it contains the
+Mind that `.ncu/land` could contain your access token since it contains the
 serialized configurations.
 
 If you ever accidentally commit your access token on GitHub, you can simply

--- a/docs/ncu-ci.md
+++ b/docs/ncu-ci.md
@@ -111,7 +111,7 @@ and then cache the responses from Jenkins so that the next time the command
 is run, it picks up cached data written on disk for jobs whose results
 are known.
 
-Note: results are cached in `${ncu_intallation_path}/.ncu/cache`, so you
+Note: results are cached in `${ncu_installation_path}/.ncu/cache`, so you
 may want to clean it up from time to time.
 
 ```


### PR DESCRIPTION
The [Make sure your credentials won't be committed](https://github.com/nodejs/node-core-utils#make-sure-your-credentials-wont-be-committed) part of guide implies that `~/.gitignore_global` is a default path for global gitignore.

If anyone followed this part too literally, I'd recommend to doublecheck their setup with something like:
```bash
$ cat "$(git config --global core.excludesFile || echo ${XDG_CONFIG_HOME:-${HOME}/.config}/git/ignore)"
# should show the contents of global gitignore
```

This is applicable to Linux; I'm unsure about other platforms.
`git config --global core.excludesfile` should work everywhere, but note that setting it overrides file in default location (if any).