### PR TITLE
Update tested Node.js versions and mocha

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     "figures": "^4.0.1",
     "form-data": "^4.0.0",
     "ghauth": "^4.0.0",
-    "inquirer": "^8.2.2",
+    "inquirer": "^8.2.4",
     "listr2": "^4.0.5",
     "lodash": "^4.17.21",
     "log-symbols": "^5.1.0",
-    "node-fetch": "^3.2.3",
+    "node-fetch": "^3.2.4",
     "ora": "^6.1.0",
     "proxy-agent": "^5.0.0",
     "replace-in-file": "^6.3.2",
@@ -55,13 +55,13 @@
   },
   "devDependencies": {
     "c8": "^7.11.2",
-    "eslint": "^8.13.0",
+    "eslint": "^8.14.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^4.1.0",
-    "mocha": "^9.2.2",
+    "mocha": "^10.0.0",
     "sinon": "^13.0.2"
   }
 }


### PR DESCRIPTION
- chore(ci): test on supported Node.js versions

BREAKING CHANGE: Removed support for Node.js 12 and 17.

- chore: update some dependencies
