### PR TITLE
fix: add a specific error message for the commit queue

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -387,13 +387,13 @@ export default class LandingSession extends Session {
 
       if (!forceLand) {
         cli.info(
-          'GITHUB_ACTION' in process.env ?
-          
-          'Add `commit-queue-squash` label to land the PR as one commit, or ' +
-          '`commit-queue-rebase` to land as separate commits.' :
+          'GITHUB_ACTION' in process.env
 
-          'Use --fixupAll option, squash the PR manually or land the PR from ' +
-          'the command line.'
+            ? 'Add `commit-queue-squash` label to land the PR as one commit, ' +
+            'or `commit-queue-rebase` to land as separate commits.'
+
+            : 'Use --fixupAll option, squash the PR manually or land the PR ' +
+            'from the command line.'
         );
         process.exit(1);
       }

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -387,6 +387,11 @@ export default class LandingSession extends Session {
 
       if (!forceLand) {
         cli.info(
+          'GITHUB_ACTION' in process.env ?
+          
+          'Add `commit-queue-squash` label to land the PR as one commit, or ' +
+          '`commit-queue-rebase` to land as separate commits.' :
+
           'Use --fixupAll option, squash the PR manually or land the PR from ' +
           'the command line.'
         );


### PR DESCRIPTION
We can detect when we're running from a GitHub Actions runner, and output an error message specific to the CQ (as `Use --fixupAll` is not a very actionable workaround in the context of the CQ).