### PR TITLE
feat: add --since option to ncu-ci

### DIFF
--- a/bin/ncu-ci.js
+++ b/bin/ncu-ci.js
@@ -86,6 +86,18 @@ const args = yargs(hideBin(process.argv))
         .option('limit', {
           default: 99,
           describe: 'Maximum number of CIs to get data from'
+        })
+        .option('since <date>', {
+          type: 'string',
+          describe: 'Time since when the CI results should be queried'
+        }).check(argv => {
+          try {
+            new Date(argv.since);
+          } catch {
+            throw new Error('--since <date> should be string that can ' +
+                            'be parsed by new Date()');
+          }
+          return true;
         });
     },
     handler
@@ -421,7 +433,12 @@ class WalkCommand extends CICommand {
 
   async initialize() {
     const ciType = commandToType[this.argv.type];
-    const builds = await listBuilds(this.cli, this.request, ciType);
+    const since = this.argv.since ? new Date(this.argv.since) : undefined;
+    const builds = await listBuilds(this.cli, this.request, ciType, since);
+    if (builds.count === 0) {
+      this.cli.log('No applicable builds found.');
+      return;
+    }
     this.queue.push({ type: 'health', ciType, builds });
     for (const build of builds.failed.slice(0, this.argv.limit)) {
       this.queue.push(build);
@@ -430,6 +447,9 @@ class WalkCommand extends CICommand {
 
   async aggregate() {
     const { argv, cli } = this;
+    if (this.queue.length === 0) {
+      return;
+    }
     const aggregator = new FailureAggregator(cli, this.json);
     this.json = aggregator.aggregate();
     cli.log('');

--- a/bin/ncu-ci.js
+++ b/bin/ncu-ci.js
@@ -92,6 +92,7 @@ const args = yargs(hideBin(process.argv))
           describe: 'Time since when the CI results should be queried'
         }).check(argv => {
           try {
+            // eslint-disable-next-line no-new
             new Date(argv.since);
           } catch {
             throw new Error('--since <date> should be string that can ' +

--- a/lib/ci/ci_utils.js
+++ b/lib/ci/ci_utils.js
@@ -50,16 +50,19 @@ function filterBuild(builds, type) {
     .map(build => parseJobFromURL(build.url));
 }
 
-export async function listBuilds(cli, request, type) {
+export async function listBuilds(cli, request, type, since) {
   // assert(type === COMMIT || type === PR)
   const { jobName } = CI_TYPES.get(type);
-  const tree = 'builds[url,result]';
+  const tree = 'builds[url,result,timestamp]';
   const url = `https://${CI_DOMAIN}/job/${jobName}/api/json?tree=${qs.escape(tree)}`;
 
   cli.startSpinner(`Querying ${url}`);
 
   const result = await request.json(url);
-  const builds = result.builds;
+  let builds = result.builds;
+  if (since) {
+    builds = builds.filter(build => build.timestamp > since);
+  }
   const failed = filterBuild(builds, statusType.FAILURE);
   const aborted = filterBuild(builds, statusType.ABORTED);
   const pending = filterBuild(builds, null);


### PR DESCRIPTION
This excludes CI runs prior to a certain date, which can be useful when trying to know the status of the CI after a flake is fixed.