### PR TITLE
fix: only parse commit messages during git node backport analysis

### DIFF
--- a/lib/backport_session.js
+++ b/lib/backport_session.js
@@ -39,7 +39,7 @@ export default class BackportSession extends Session {
 
   getCommitMessage(rev) {
     return runSync('git',
-      ['show', '--format=%B', rev]
+      ['show', '--format=%B', '-s', rev]
     ).trim();
   }
 


### PR DESCRIPTION
Previously we parse the entire commit, including the diff, which can result in ENOBUFS errors. Adding `-s` option to the `git show` command would eliminate the commit body in the output, which we don't need, so the error can be less likely to happen during commit message analysis.