### PR TITLE
feat: add auto run v8 ci

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+auto-install-peers=true

--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -5,10 +5,15 @@ import {
   CI_TYPES,
   CI_TYPES_KEYS
 } from './ci_type_parser.js';
+import PRData from '../pr_data.js';
+import { debuglog } from '../verbosity.js';
 
 export const CI_CRUMB_URL = `https://${CI_DOMAIN}/crumbIssuer/api/json`;
 const CI_PR_NAME = CI_TYPES.get(CI_TYPES_KEYS.PR).jobName;
 export const CI_PR_URL = `https://${CI_DOMAIN}/job/${CI_PR_NAME}/build`;
+
+const CI_V8_NAME = CI_TYPES.get(CI_TYPES_KEYS.V8).jobName;
+export const CI_V8_URL = `https://${CI_DOMAIN}/job/${CI_V8_NAME}/build`;
 
 export class RunPRJob {
   constructor(cli, request, owner, repo, prid) {
@@ -17,6 +22,7 @@ export class RunPRJob {
     this.owner = owner;
     this.repo = repo;
     this.prid = prid;
+    this.prData = new PRData({ prid, owner, repo }, cli, request);
   }
 
   async getCrumb() {
@@ -38,6 +44,18 @@ export class RunPRJob {
         { name: 'PR_ID', value: this.prid },
         { name: 'REBASE_ONTO', value: '<pr base branch>' },
         { name: 'DESCRIPTION_SETTER_DESCRIPTION', value: '' }
+      ]
+    }));
+    return payload;
+  }
+
+  get v8Payload() {
+    const payload = new FormData();
+    payload.append('json', JSON.stringify({
+      parameter: [
+        { name: 'GITHUB_ORG', value: this.owner },
+        { name: 'REPO_NAME', value: this.repo },
+        { name: 'GIT_REMOTE_REF', value: `refs/pull/${this.prid}/head` }
       ]
     }));
     return payload;
@@ -71,7 +89,29 @@ export class RunPRJob {
         return false;
       }
       cli.stopSpinner('PR CI job successfully started');
+
+      // check if the job need a v8 build and trigger it
+      await this.prData.getPR();
+      const labels = this.prData.pr.labels;
+      if (labels.nodes.map(i => i.name).includes('v8 engine')) {
+        cli.startSpinner('Starting V8 CI job');
+        const response = await this.request.fetch(CI_V8_URL, {
+          method: 'POST',
+          headers: {
+            'Jenkins-Crumb': crumb
+          },
+          body: this.v8Payload
+        });
+        if (response.status !== 201) {
+          cli.stopSpinner(
+            `Failed to start V8 CI: ${response.status} ${response.statusText}`,
+            this.cli.SPINNER_STATUS.FAILED);
+          return false;
+        }
+        cli.stopSpinner('V8 CI job successfully started');
+      }
     } catch (err) {
+      debuglog(err);
       cli.stopSpinner('Failed to start CI', this.cli.SPINNER_STATUS.FAILED);
       return false;
     }

--- a/test/unit/ci_start.test.js
+++ b/test/unit/ci_start.test.js
@@ -67,6 +67,15 @@ describe('Jenkins', () => {
     const cli = new TestCLI();
 
     const request = {
+      gql: sinon.stub().returns({
+        repository: {
+          pullRequest: {
+            labels: {
+              nodes: []
+            }
+          }
+        }
+      }),
       fetch: sinon.stub()
         .callsFake((url, { method, headers, body }) => {
           assert.strictEqual(url, CI_PR_URL);


### PR DESCRIPTION
fix: https://github.com/nodejs/node-core-utils/issues/559
test pr: https://github.com/nodejs/node/pull/44986

Hopefully this will make us test v8 easier :)

local test
```
node bin/ncu-ci.js run 44986
```

currently I run into Jenkins credentials invalid. But I have used this credential before, and it worked.

cc @targos @richardlau @nodejs/v8-update 