### PR TITLE
doc: add startLTS usage examples

### DIFF
--- a/components/git/release.js
+++ b/components/git/release.js
@@ -36,7 +36,9 @@ export function builder(yargs) {
       describe: 'Version number of the release to be prepared or promoted'
     })
     .example('git node release --prepare 1.2.3',
-      'Prepare a new release of Node.js tagged v1.2.3');
+      'Prepare a release of Node.js tagged v1.2.3')
+    .example('git node --prepare --startLTS',
+      'Prepare the first LTS release');
 }
 
 export function handler(argv) {

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -233,6 +233,11 @@ git node release --prepare 1.2.3
 git node release --prepare
 ```
 
+```sh
+# Prepare the first LTS release for a given release line
+git node release --prepare --startLTS
+```
+
 ## `git node sync`
 
 Demo: https://asciinema.org/a/221230


### PR DESCRIPTION
I reach to `node-core-utils` for automating the LTS release commit but I couldn't get it to work due to the lack of a proper usage example.

I'm adding examples to both the markdown docs and the cli help output which are the places I would have loved to have found these.

## CLI help output

### Before

```
$ git node release --help
git-node release [newVersion|options]

Manage an in-progress release or start a new one.

Positionals:
  newVersion, options  Version number of the release to be prepared or promoted

Options:
  --version   Show version number                                      [boolean]
  --help      Show help                                                [boolean]
  --prepare   Prepare a new release of Node.js                         [boolean]
  --promote   Promote new release of Node.js                           [boolean]
  --security  Demarcate the new security release as a security release [boolean]
  --startLTS  Mark the release as the transition from Current to LTS   [boolean]

Examples:
  git node release --prepare 1.2.3  Prepare a new release of Node.js tagged v1.2
                                    .3
```

### After

```
$ git node release --help
git-node release [newVersion|options]

Manage an in-progress release or start a new one.

Positionals:
  newVersion, options  Version number of the release to be prepared or promoted

Options:
  --version   Show version number                                      [boolean]
  --help      Show help                                                [boolean]
  --prepare   Prepare a new release of Node.js                         [boolean]
  --promote   Promote new release of Node.js                           [boolean]
  --security  Demarcate the new security release as a security release [boolean]
  --startLTS  Mark the release as the transition from Current to LTS   [boolean]

Examples:
  git node release --prepare 1.2.3  Prepare a release of Node.js tagged v1.2.3
  git node --prepare --startLTS     Prepare the first LTS release
```

Signed-off-by: Ruy Adorno <ruyadorno@google.com>

cc @BethGriggs @richardlau @RafaelGSS