### PR TITLE
cli: handle spinning states

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,9 +26,10 @@ function head(text, length = 11) {
 }
 
 export default class CLI {
-  constructor(stream) {
+  constructor(stream, options = {}) {
+    const spinnerOptions = options.spinner ?? {};
     this.stream = stream || process.stderr;
-    this.spinner = ora({ stream: this.stream });
+    this.spinner = ora({ stream: this.stream, ...spinnerOptions });
     this.SPINNER_STATUS = SPINNER_STATUS;
     this.QUESTION_TYPE = QUESTION_TYPE;
     this.figureIndent = '   ';
@@ -67,7 +68,16 @@ export default class CLI {
         'defaultAnswer must be provided for non-confirmation prompts');
     }
 
+    const { isSpinning, text: spinningMessage } = this.spinner;
+
+    if (isSpinning) {
+      this.spinner.stop();
+    }
+
     if (this.assumeYes) {
+      if (isSpinning) {
+        this.spinner.start(spinningMessage);
+      }
       return defaultAnswer;
     }
 
@@ -77,6 +87,10 @@ export default class CLI {
       message: question,
       default: defaultAnswer
     }]);
+
+    if (isSpinning) {
+      this.spinner.start(spinningMessage);
+    }
 
     return answer;
   }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "test": "npm run test-unit && npm run lint",
-    "test-unit": "mocha --timeout 60000 test/unit/*.test.js",
-    "test-all": "mocha --timeout 60000 test/**/*.test.js",
+    "test-unit": "mocha --timeout 60000 test/unit/*.test.js --exit",
+    "test-all": "mocha --timeout 60000 test/**/*.test.js --exit",
     "coverage": "c8 --reporter=html --reporter=text --reporter=text-summary npm test",
     "coverage-all": "c8 --reporter=lcov --reporter=text --reporter=text-summary npm run test-all",
     "lint": "eslint . --cache",

--- a/test/unit/ci_start.test.js
+++ b/test/unit/ci_start.test.js
@@ -44,6 +44,7 @@ describe('Jenkins', () => {
   it('should fail if starting node-pull-request throws', async() => {
     const cli = new TestCLI();
     const request = {
+      fetch: sinon.stub().returns(Promise.resolve({ status: 400 })),
       text: sinon.stub().throws(),
       json: sinon.stub().withArgs(CI_CRUMB_URL)
         .returns(Promise.resolve({ crumb }))

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -165,6 +165,27 @@ describe('cli', () => {
     });
   });
 
+  describe('prompt cares about spinner', () => {
+    beforeEach(() => {
+      stream = new LogStream();
+      cli = new CLI(stream, {
+        spinner: { isEnabled: true }
+      });
+      cli.setAssumeYes();
+    });
+
+    it('pauses when prompt a question', async() => {
+      cli.startSpinner('foo');
+      assert.deepEqual(cli.spinner.text, 'foo');
+      assert.deepEqual(cli.spinner.isSpinning, true);
+      await cli.prompt('So you think darkness is your ally?', {
+        defaultAnswer: 'Yes, I was born in it. Molded by it.',
+        questionType: cli.QUESTION_TYPE.INPUT
+      });
+      assert.strictEqual(cli.spinner.isSpinning, true);
+    });
+  });
+
   describe('prompt assume yes', () => {
     beforeEach(() => {
       stream = new LogStream();


### PR DESCRIPTION
Fixes the annoying bug, when a question is asked through the client and a spinner is already taken place. This pull request, pauses and restarts the spinner after the answer.

Example:
![screen_shot_2022-10-22_at_6 58 55_pm_720](https://user-images.githubusercontent.com/1935246/204609825-4004054b-0274-4232-85e1-43b64f3d8fd9.png)


