### PR TITLE
fix: use case-insensitive string comparison for fast-track approvals

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -177,11 +177,11 @@ export default class PRChecker {
       }
       const [, requester] = comment.bodyText.match(FAST_TRACK_RE);
       const collaborators = Array.from(this.data.collaborators.values(),
-        (c) => c.login);
+        (c) => c.login.toLowerCase());
       const approvals = comment.reactions.nodes.filter((r) =>
         r.user.login !== requester &&
         r.user.login !== pr.author.login &&
-        collaborators.includes(r.user.login)).length;
+        collaborators.includes(r.user.login.toLowerCase())).length;
 
       if (requester === pr.author.login && approvals < 2) {
         cli.error('The fast-track request requires' +

--- a/test/fixtures/comments_with_two_fast_track_different_case.json
+++ b/test/fixtures/comments_with_two_fast_track_different_case.json
@@ -1,0 +1,16 @@
+[
+  {
+    "publishedAt": "2017-10-22T05:16:36.458Z",
+    "bodyText": "Fast-track has been requested by @bar. Please 👍 to approve.",
+    "author": {
+      "login": "github-actions"
+    },
+    "reactions": {
+      "nodes": [
+        { "user": { "login": "Bar" } },
+        { "user": { "login": "Foo" } },
+        { "user": { "login": "BAZ" } }
+      ]
+    }
+  }
+]

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -37,6 +37,8 @@ export const requestingChangesReviews =
 export const commentsWithFastTrack = readJSON('comments_with_fast_track.json');
 export const commentsWithTwoFastTrack =
   readJSON('comments_with_two_fast_track.json');
+export const commentsWithTwoFastTrackDifferentCase =
+  readJSON('comments_with_two_fast_track_different_case.json');
 export const commentsWithFastTrackInsuffientApprovals =
   readJSON('comments_with_fast_track_insufficient_approvals.json');
 export const commentsWithCI = readJSON('comments_with_ci.json');


### PR DESCRIPTION
I noticed today that a PR that had sufficient fast-track approvals was being rejected as needing one more approval. This is because one of the approvers' had a GitHub handle where the case in the README (`linkgoron`) did not match the case returned by GitHub (`Linkgoron`). Since GitHub handles are case-insensitive, this change makes the comparison case-insensitive.

One might be tempted to think that we need to do the same for the list of TSC members, but handles are never compared there so it is not necessary.