### PR TITLE
fix: switch to undici for requests to fix stream close errors

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 19.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 
 import { CI_DOMAIN } from './ci/ci_type_parser.js';
 import proxy from './proxy.js';

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     "listr2": "^4.0.5",
     "lodash": "^4.17.21",
     "log-symbols": "^5.1.0",
-    "node-fetch": "^3.2.4",
     "ora": "^6.1.0",
     "proxy-agent": "^5.0.0",
     "replace-in-file": "^6.3.2",
     "rimraf": "^3.0.2",
+    "undici": "^5.20.0",
     "which": "^2.0.2",
     "yargs": "^17.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.1.3",
   "description": "Utilities for Node.js core collaborators",
   "type": "module",
+  "engines": {
+    "node": ">=16.8.0"
+  },
   "bin": {
     "get-metadata": "./bin/get-metadata.js",
     "git-node": "./bin/git-node.js",


### PR DESCRIPTION
Fixes #626

When updating WPT resources, the `wpt` command would sometimes throw a `ERR_STREAM_PREMATURE_CLOSE` error. Switching to `undici` fixes this issue.

The `undici` `fetch` function is only supported on Node 16+. After discussing with the team, we agreed that dropping support for Node 14 in this tool was acceptable (https://github.com/nodejs/node-core-utils/issues/626#issuecomment-1433053922).

```
➜  node git:(main) ✗ ./node /Users/austinkelleher/Documents/open-source/node-core-utils/bin/git-node.js wpt resources
---------------------- Checking updates for resources... -----------------------
Last local update for resources is fbf1e7d24776
✔  Last update in upstream is 66933c819b6e
✔  Read asset list, 165 files in total.
Excluded 133 files, 32 files to write.
--------------- Writing assets to test/fixtures/wpt/resources... ---------------
✔  Downloaded 32 assets.
✔  Updated test/fixtures/wpt/versions.json
✔  Updated test/fixtures/wpt/README.md
✔  Updated test/fixtures/wpt/LICENSE.md.
```