### PR TITLE
docs: update Jenkins profile access

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ these commands.
 To obtain the Jenkins API token
 
 1. Open
-`https://ci.nodejs.org/user/<your-github-id>/configure` (replace
-\<your-github-id\> with your own GitHub ID)
+   `https://ci.nodejs.org/user/<your-github-username>/configure` (replace
+   \<your-github-username\> with your own GitHub username).
 2. Click on the `ADD NEW TOKEN` button in the `API Token` section.
 3. Enter an identifiable name (for example, `node-core-utils`) for this
   token in the inbox that appears, and click `GENERATE`.


### PR DESCRIPTION
The Node.js Jenkins server now only allows you to access your Jenkins profile with your GitHub username rather than your GitHub ID.