### PR TITLE
fix: do not run `git cherry-pick --abort` on failure

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -121,8 +121,6 @@ export default class LandingSession extends Session {
         ignoreFailure: false
       });
     } catch (ex) {
-      await forceRunAsync('git', ['cherry-pick', '--abort']);
-
       cli.error('Failed to apply patches');
       process.exit(1);
     }


### PR DESCRIPTION
I personally find it useful to keep the cherry-pick session as is to help with debugging what's going wrong.