### PR TITLE
chore(deps): do not use the deprecated Cheerio API

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 const FIXES_RE = /(Close[ds]?|Fix(e[ds])?|Resolve[sd]?)\s*:\s*(\S+)/mgi;
 const FIX_RE = /(Close[ds]?|Fix(e[ds])?|Resolve[sd]?)\s*:\s*(\S+)/i;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "branch-diff": "^2.1.0",
     "chalk": "^5.2.0",
     "changelog-maker": "^3.2.1",
-    "cheerio": "^1.0.0-rc.10",
+    "cheerio": "^1.0.0-rc.12",
     "clipboardy": "^3.0.0",
     "core-validate-commit": "^3.18.0",
     "enquirer": "^2.3.6",


### PR DESCRIPTION
Cheerio has deprecated the default export, instead we should be using the named ones.