### PR TITLE
fix: use correct V8 tag for major updates

### DIFF
--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -54,7 +54,7 @@ function checkoutBranch() {
           '--sort',
           'version:refname'
         );
-        const tags = res.stdout.split('\n');
+        const tags = res.stdout.split('\n').filter(tag => versionReg.test(tag));
         const lastTag = tags[tags.length - 1];
         if (lastTag) version = lastTag;
         if (version.split('.').length === 3) {


### PR DESCRIPTION
Sometimes there might be additional tags with suffix such as `-pgo`
