### PR TITLE
fix(wpt): remove stale fixtures before pulling fresh ones

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -37,3 +37,7 @@ export function readJson(file) {
   }
   return {};
 };
+
+export function removeDirectory(directory) {
+  return fs.promises.rm(directory, { recursive: true, force: true });
+}

--- a/lib/wpt/index.js
+++ b/lib/wpt/index.js
@@ -3,7 +3,9 @@ import path from 'node:path';
 import _ from 'lodash';
 
 import GitHubTree from '../github/tree.js';
-import { writeFile, readJson, writeJson, readFile } from '../file.js';
+import {
+  writeFile, readJson, writeJson, readFile, removeDirectory
+} from '../file.js';
 import {
   shortSha
 } from '../utils.js';
@@ -72,6 +74,9 @@ export class WPTUpdater {
     if (!assets) {
       assets = await this.getAssetList();
     }
+
+    this.cli.startSpinner('Removing stale assets...');
+    await removeDirectory(this.fixtures(this.path));
 
     this.cli.startSpinner('Pulling assets...');
     await Promise.all(assets.map(


### PR DESCRIPTION
Removes the updated directory before pulling fresh assets.

closes #678