### PR TITLE
feat: add support for PGP encrypted config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ After the token is generated, create an rc file with the following content:
 Note: you could use `ncu-config` to configure these variables, but it's not
 recommended to leave your tokens in your command line history.
 
+If you have `gpg` installed and setup on your local machine, it is recommended
+to store an encrypted version of this file:
+
+```console
+$ gpg --default-recipient-self --encrypt ~/.ncurc
+$ rm ~/.ncurc
+```
+
 ### Setting up Jenkins credentials
 
 The `git-node` and `ncu-ci` commands need to query the Node.js Jenkins API for
@@ -99,8 +107,9 @@ To obtain the Jenkins API token
 3. Enter an identifiable name (for example, `node-core-utils`) for this
    token in the inbox that appears, and click `GENERATE`.
 4. Copy the generated token.
-5. Add it into your `ncurc` file (`~/.ncurc` or `$XDG_CONFIG_HOME/ncurc`)
-   with `jenkins_token` as key, like this:
+5. Add it into your `ncurc` file (`~/.ncurc` or `$XDG_CONFIG_HOME/ncurc`, or
+   `~/.ncurc.gpg` or `$XDG_CONFIG_HOME/ncurc.gpg`) with `jenkins_token` as key,
+   like this:
 
    ```json
    {
@@ -120,6 +129,7 @@ Put the following entries into your
 ```
 # node-core-utils configuration file
 .ncurc
+.ncurc.gpg
 # node-core-utils working directory
 .ncu
 ```

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,8 @@ import path from 'node:path';
 import os from 'node:os';
 
 import { readJson, writeJson } from './file.js';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 
 export const GLOBAL_CONFIG = Symbol('globalConfig');
 export const PROJECT_CONFIG = Symbol('projectConfig');
@@ -25,6 +27,14 @@ export function getMergedConfig(dir, home) {
 
 export function getConfig(configType, dir) {
   const configPath = getConfigPath(configType, dir);
+  const encryptedConfigPath = configPath + '.gpg';
+  if (existsSync(encryptedConfigPath)) {
+    const { status, stdout } =
+      spawnSync('gpg', ['--decrypt', encryptedConfigPath]);
+    if (status === 0) {
+      return JSON.parse(stdout.toString('utf-8'));
+    }
+  }
   try {
     return readJson(configPath);
   } catch (cause) {


### PR DESCRIPTION
Rely on `gpg` being available on the path, but is opt-in so it shouldn't be a problem. Users can chose wether they want to use a  passphrase or their key pair, and that should be completely transparent for ncu.

Fixes: https://github.com/nodejs/node-core-utils/issues/615