### PR TITLE
fix(git-node): update README parser to account the recent TSC changes

### DIFF
--- a/lib/collaborators.js
+++ b/lib/collaborators.js
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 
-const TSC_TITLE = '### TSC (Technical Steering Committee)';
-const TSCE_TITLE = '### TSC Emeriti';
+const TSC_TITLE = '#### TSC voting members';
+const TSC_REGULAR_TITLE = '#### TSC regular members';
+const TSCE_TITLE = '#### TSC emeriti members';
 const CL_TITLE = '### Collaborators';
-const CLE_TITLE = '### Collaborator Emeriti';
+const CLE_TITLE = '### Collaborator emeriti';
 const CONTACT_RE = /\* +\[(.+?)\]\(.+?\) +-\s+\*\*([^*]+?)\*\* +(?:&lt;|\\<|<<)([^>]+?)(?:&gt;|>)/mg;
 
 const TSC = 'TSC';
@@ -73,12 +74,16 @@ function parseCollaborators(readme, cli) {
   let m;
 
   const tscIndex = readme.toUpperCase().indexOf(TSC_TITLE.toUpperCase());
+  const tscrIndex = readme.toUpperCase().indexOf(TSC_REGULAR_TITLE.toUpperCase());
   const tsceIndex = readme.toUpperCase().indexOf(TSCE_TITLE.toUpperCase());
   const clIndex = readme.toUpperCase().indexOf(CL_TITLE.toUpperCase());
   const cleIndex = readme.toUpperCase().indexOf(CLE_TITLE.toUpperCase());
 
   if (tscIndex === -1) {
     throw new Error(`Couldn't find ${TSC_TITLE} in the README`);
+  }
+  if (tscrIndex === -1) {
+    throw new Error(`Couldn't find ${TSC_REGULAR_TITLE} in the README`);
   }
   if (tsceIndex === -1) {
     throw new Error(`Couldn't find ${TSCE_TITLE} in the README`);
@@ -90,7 +95,8 @@ function parseCollaborators(readme, cli) {
     throw new Error(`Couldn't find ${CLE_TITLE} in the README`);
   }
 
-  if (!(tscIndex < tsceIndex &&
+  if (!(tscIndex < tscrIndex &&
+        tscrIndex < tsceIndex &&
         tsceIndex < clIndex &&
         clIndex < cleIndex)) {
     cli.warn('Contacts in the README is out of order, ' +
@@ -100,7 +106,7 @@ function parseCollaborators(readme, cli) {
   // We also assume that TSC & TSC Emeriti are also listed as collaborators
   CONTACT_RE.lastIndex = tscIndex;
   // eslint-disable-next-line no-cond-assign
-  while ((m = CONTACT_RE.exec(readme)) && CONTACT_RE.lastIndex < tsceIndex) {
+  while ((m = CONTACT_RE.exec(readme)) && CONTACT_RE.lastIndex < tscrIndex) {
     const login = m[1].toLowerCase();
     const user = new Collaborator(m[1], m[2], m[3], TSC);
     collaborators.set(login, user);

--- a/test/fixtures/README/README.md
+++ b/test/fixtures/README/README.md
@@ -234,13 +234,26 @@ For more information about the governance of the Node.js project, see
 
 ### TSC (Technical Steering Committee)
 
+#### TSC voting members
+
 * [bar](https://github.com/bar) -
   **Bar User** <<bar@example.com>> (she/her)
 
-### TSC emeriti
+#### TSC regular members
+
+* [Baz](https://github.com/Baz) -
+**Baz User** &lt;baz@example.com&gt; (he/him)
+
+<details>
+
+<summary>TSC emeriti members</summary>
+
+#### TSC emeriti members
 
 * [test](https://github.com/test) -
-**Test** &lt;test@example.com&gt;
+  **Test User** <<test@example.com>>
+
+</details>
 
 ### Collaborators
 
@@ -257,10 +270,16 @@ For more information about the governance of the Node.js project, see
 * [ExtraSpace](https://github.com/extraspace) -
 **Extra Space**  &lt;extraspace@example.com&gt; (he/him)
 
+<details>
+
+<summary>Emeriti</summary>
+
 ### Collaborator emeriti
 
 * [bee](https://github.com/bee) -
 **bee** &lt;bee@example.com&gt;
+
+</details>
 
 Collaborators follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.

--- a/test/fixtures/README/README_alternative.md
+++ b/test/fixtures/README/README_alternative.md
@@ -234,10 +234,20 @@ For more information about the governance of the Node.js project, see
 
 ### TSC (Technical Steering Committee)
 
+#### TSC voting members
+
 * [bar](https://github.com/bar) -
 **Bar User (张三)** &lt;bar@example.com&gt; (she/her)
 
-### TSC Emeriti
+#### TSC regular members
+
+<details>
+
+<summary>TSC emeriti members</summary>
+
+#### TSC emeriti members
+
+</details>
 
 ### Collaborators
 
@@ -246,7 +256,13 @@ For more information about the governance of the Node.js project, see
 * [Baz](https://github.com/Baz) -
 **Baz User** &lt;baz@example.com&gt; (he/him)
 
-### Collaborator Emeriti
+<details>
+
+<summary>Emeriti</summary>
+
+### Collaborator emeriti
+
+</details>
 
 Collaborators follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.

--- a/test/fixtures/README/README_no_TSC.md
+++ b/test/fixtures/README/README_no_TSC.md
@@ -231,10 +231,18 @@ that forms the _Technical Steering Committee_ (TSC) which governs the project.
 For more information about the governance of the Node.js project, see
 [GOVERNANCE.md](./GOVERNANCE.md).
 
-### TSC Emeriti
+### TSC (Technical Steering Committee)
+
+<details>
+
+<summary>TSC emeriti members</summary>
+
+#### TSC emeriti members
 
 * [test](https://github.com/test) -
 **Test** &lt;test@example.com&gt;
+
+</details>
 
 ### Collaborators
 
@@ -247,10 +255,16 @@ For more information about the governance of the Node.js project, see
 * [Quo](https://github.com/quo) -
 **Quo User** &lt;quo@example.com&gt; (she/her)
 
-### Collaborator Emeriti
+<details>
+
+<summary>Emeriti</summary>
+
+### Collaborator emeriti
 
 * [bee](https://github.com/bee) -
 **bee** &lt;bee@example.com&gt;
+
+</details>
 
 Collaborators follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.

--- a/test/fixtures/README/README_no_TSCE.md
+++ b/test/fixtures/README/README_no_TSCE.md
@@ -234,6 +234,8 @@ For more information about the governance of the Node.js project, see
 
 ### TSC (Technical Steering Committee)
 
+#### TSC voting members
+
 * [bar](https://github.com/bar) -
 **Bar User** &lt;bar@example.com&gt; (she/her)
 
@@ -248,10 +250,16 @@ For more information about the governance of the Node.js project, see
 * [Quo](https://github.com/quo) -
 **Quo User** &lt;quo@example.com&gt; (she/her)
 
-### Collaborator Emeriti
+<details>
+
+<summary>Emeriti</summary>
+
+### Collaborator emeriti
 
 * [bee](https://github.com/bee) -
 **bee** &lt;bee@example.com&gt;
+
+</details>
 
 Collaborators follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.

--- a/test/fixtures/README/README_no_collaboratorE.md
+++ b/test/fixtures/README/README_no_collaboratorE.md
@@ -234,13 +234,23 @@ For more information about the governance of the Node.js project, see
 
 ### TSC (Technical Steering Committee)
 
+#### TSC voting members
+
 * [bar](https://github.com/bar) -
 **Bar User** &lt;bar@example.com&gt; (she/her)
 
-### TSC Emeriti
+#### TSC regular members
+
+<details>
+
+<summary>TSC emeriti members</summary>
+
+#### TSC emeriti members
 
 * [test](https://github.com/test) -
 **Test** &lt;test@example.com&gt;
+
+</details>
 
 ### Collaborators
 

--- a/test/fixtures/README/README_no_collaborators.md
+++ b/test/fixtures/README/README_no_collaborators.md
@@ -233,18 +233,34 @@ For more information about the governance of the Node.js project, see
 
 ### TSC (Technical Steering Committee)
 
+#### TSC voting members
+
 * [bar](https://github.com/bar) -
 **Bar User** &lt;bar@example.com&gt; (she/her)
 
-### TSC Emeriti
+#### TSC regular members
+
+<details>
+
+<summary>TSC emeriti members</summary>
+
+#### TSC emeriti members
 
 * [test](https://github.com/test) -
 **Test** &lt;test@example.com&gt;
 
-### Collaborator Emeriti
+</details>
+
+<details>
+
+<summary>Emeriti</summary>
+
+### Collaborator emeriti
 
 * [bee](https://github.com/bee) -
 **bee** &lt;bee@example.com&gt;
+
+</details>
 
 Collaborators follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.

--- a/test/fixtures/README/README_unordered.md
+++ b/test/fixtures/README/README_unordered.md
@@ -232,10 +232,16 @@ that forms the _Technical Steering Committee_ (TSC) which governs the project.
 For more information about the governance of the Node.js project, see
 [GOVERNANCE.md](./GOVERNANCE.md).
 
-### Collaborator Emeriti
+<details>
+
+<summary>Emeriti</summary>
+
+### Collaborator emeriti
 
 * [bee](https://github.com/bee) -
 **bee** &lt;bee@example.com&gt;
+
+</details>
 
 Collaborators follow the [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md) in
 maintaining the Node.js project.
@@ -251,12 +257,22 @@ maintaining the Node.js project.
 * [Quo](https://github.com/quo) -
 **Quo User** &lt;quo@example.com&gt; (she/her)
 
-### TSC Emeriti
+### TSC (Technical Steering Committee)
+
+<details>
+
+<summary>Emeriti</summary>
+
+#### TSC emeriti members
 
 * [test](https://github.com/test) -
 **Test** &lt;test@example.com&gt;
 
-### TSC (Technical Steering Committee)
+</details>
+
+#### TSC regular members
+
+#### TSC voting members
 
 * [bar](https://github.com/bar) -
 **Bar User** &lt;bar@example.com&gt; (she/her)

--- a/test/unit/collaborators.test.js
+++ b/test/unit/collaborators.test.js
@@ -132,13 +132,13 @@ describe('collaborators', function() {
       });
 
     it(
-      'should throw error if there is no TSC Emeriti section in the README',
+      'should throw error if there is no TSC Regular Members section in the README',
       async() => {
         const argv = { owner: 'nodejs', repo: 'node' };
         const request = mockRequest(readmeNoTscE, argv);
         await assertThrowsAsync(
           async() => getCollaborators(cli, request, argv),
-          /Error: Couldn't find ### TSC Emeriti in the README/);
+          /Error: Couldn't find #### TSC regular members in the README/);
       });
 
     it('should throw error if there is no Collaborators section in the README',
@@ -158,7 +158,7 @@ describe('collaborators', function() {
         const request = mockRequest(readmeNoCollaboratorE, argv);
         await assertThrowsAsync(
           async() => getCollaborators(cli, request, argv),
-          /Error: Couldn't find ### Collaborator Emeriti in the README/);
+          /Error: Couldn't find ### Collaborator emeriti in the README/);
       });
 
     it(


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/47126
Refs: https://github.com/nodejs/TSC/pull/1350

BREAKING CHANGE: Old README format is no longer supported