### PR TITLE
fix: accurately define ncu-ci report condition

### DIFF
--- a/lib/ci/failure_aggregator.js
+++ b/lib/ci/failure_aggregator.js
@@ -72,7 +72,7 @@ export class FailureAggregator {
     let output = 'Failures in ';
     output += `[${jobName}/${first.jobid}](${first.link}) to `;
     output += `[${jobName}/${last.jobid}](${last.link}) `;
-    output += 'that failed more than 2 PRs\n';
+    output += 'that failed 2 or more PRs\n';
     output += '(Generated with `ncu-ci ';
     output += `${process.argv.slice(2).join(' ')}\`)\n\n`;
 


### PR DESCRIPTION
Problems are ignored if they occurred in less than two PRs. Thus, they are reported if they failed in two or more PRs.

https://github.com/nodejs/node-core-utils/blob/ecb1b7d0b86ab2afb581046220e3cfcc6254255a/lib/ci/failure_aggregator.js#L88-L89