### PR TITLE
docs: update maintaining-dependencies.md on major v8 update

### DIFF
--- a/lib/update-v8/index.js
+++ b/lib/update-v8/index.js
@@ -6,11 +6,18 @@ import updateVersionNumbers from './updateVersionNumbers.js';
 import commitUpdate from './commitUpdate.js';
 import majorUpdate from './majorUpdate.js';
 import minorUpdate from './minorUpdate.js';
+import updateMaintainingDependencies from './updateMaintainingDependencies.js';
 import updateV8Clone from './updateV8Clone.js';
 
 export function major(options) {
   const tasks = new Listr(
-    [updateV8Clone(), majorUpdate(), commitUpdate(), updateVersionNumbers()],
+    [
+      updateV8Clone(),
+      majorUpdate(),
+      updateMaintainingDependencies(),
+      commitUpdate(),
+      updateVersionNumbers()
+    ],
     getOptions(options)
   );
   return tasks.run(options);

--- a/lib/update-v8/updateMaintainingDependencies.js
+++ b/lib/update-v8/updateMaintainingDependencies.js
@@ -1,0 +1,34 @@
+import { promises as fs } from 'node:fs';
+import { getNodeV8Version } from './util.js';
+
+export default function updateMaintainingDependencies() {
+  return {
+    title: 'Update V8 version in maintaining-dependencies.md',
+    task: async(ctx) => {
+      const path = `${ctx.nodeDir}/doc/contributing/maintaining/maintaining-dependencies.md`;
+      let maintainingDependenciesMd = await fs.readFile(path, 'utf8');
+      const v8Version = (await getNodeV8Version(ctx.nodeDir)).toString();
+      const v8VersionNoDots = v8Version.replaceAll('.', '');
+      // V8 itemlist link
+      maintainingDependenciesMd = maintainingDependenciesMd.replace(
+        /\* \[V8.*/,
+        `* [V8 ${v8Version}][]`
+      );
+      // V8 link to section
+      maintainingDependenciesMd = maintainingDependenciesMd.replace(
+        /\[v8.*\]: #v8.*/,
+        `[v8 ${v8Version}]: #v8-${v8VersionNoDots}`
+      );
+      // V8 section title
+      maintainingDependenciesMd = maintainingDependenciesMd.replace(
+        /### V8.*/,
+        `### V8 ${v8Version}`
+      );
+      await fs.writeFile(path, maintainingDependenciesMd);
+      await ctx.execGitNode(
+        'add',
+        ['doc/contributing/maintaining/maintaining-dependencies.md']
+      );
+    }
+  };
+};

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -29,10 +29,15 @@ function bumpNodeModule() {
         v8Version,
         ctx.nodeMajorVersion
       );
+      await updateMaintainingDependenciesMd(ctx.nodeDir, v8Version);
       await updateModuleVersion(ctx.nodeDir, newModuleVersion);
       await ctx.execGitNode(
         'add',
-        ['doc/abi_version_registry.json', 'src/node_version.h']
+        [
+          'doc/abi_version_registry.json',
+          'doc/contributing/maintaining/maintaining-dependencies.md',
+          'src/node_version.h'
+        ]
       );
       await ctx.execGitNode(
         'commit',
@@ -78,6 +83,29 @@ async function updateModuleVersion(nodeDir, newVersion) {
     `NODE_MODULE_VERSION ${newVersion}`
   );
   await fs.writeFile(path, nodeVersionH);
+}
+
+async function updateMaintainingDependenciesMd(nodeDir, v8Version) {
+  const path = `${nodeDir}/doc/contributing/maintaining/maintaining-dependencies.md`;
+  let maintainingDependenciesMd = await fs.readFile(path, 'utf8');
+  const version = v8Version.toString();
+  const versionNoDots = version.replaceAll('.', '');
+  // V8 itemlist link
+  maintainingDependenciesMd = maintainingDependenciesMd.replace(
+    /\* \[V8.*/,
+    `* [V8 ${version}][]`
+  );
+  // V8 link to section
+  maintainingDependenciesMd = maintainingDependenciesMd.replace(
+    /\[v8.*\]: #v8.*/,
+    `[v8 ${version}]: #v8-${versionNoDots}`
+  );
+  // V8 section title
+  maintainingDependenciesMd = maintainingDependenciesMd.replace(
+    /### V8.*/,
+    `### V8 ${version}`
+  );
+  await fs.writeFile(path, maintainingDependenciesMd);
 }
 
 function getCommitTitle(moduleVersion) {

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -29,15 +29,10 @@ function bumpNodeModule() {
         v8Version,
         ctx.nodeMajorVersion
       );
-      await updateMaintainingDependenciesMd(ctx.nodeDir, v8Version);
       await updateModuleVersion(ctx.nodeDir, newModuleVersion);
       await ctx.execGitNode(
         'add',
-        [
-          'doc/abi_version_registry.json',
-          'doc/contributing/maintaining/maintaining-dependencies.md',
-          'src/node_version.h'
-        ]
+        ['doc/abi_version_registry.json', 'src/node_version.h']
       );
       await ctx.execGitNode(
         'commit',
@@ -83,29 +78,6 @@ async function updateModuleVersion(nodeDir, newVersion) {
     `NODE_MODULE_VERSION ${newVersion}`
   );
   await fs.writeFile(path, nodeVersionH);
-}
-
-async function updateMaintainingDependenciesMd(nodeDir, v8Version) {
-  const path = `${nodeDir}/doc/contributing/maintaining/maintaining-dependencies.md`;
-  let maintainingDependenciesMd = await fs.readFile(path, 'utf8');
-  const version = v8Version.toString();
-  const versionNoDots = version.replaceAll('.', '');
-  // V8 itemlist link
-  maintainingDependenciesMd = maintainingDependenciesMd.replace(
-    /\* \[V8.*/,
-    `* [V8 ${version}][]`
-  );
-  // V8 link to section
-  maintainingDependenciesMd = maintainingDependenciesMd.replace(
-    /\[v8.*\]: #v8.*/,
-    `[v8 ${version}]: #v8-${versionNoDots}`
-  );
-  // V8 section title
-  maintainingDependenciesMd = maintainingDependenciesMd.replace(
-    /### V8.*/,
-    `### V8 ${version}`
-  );
-  await fs.writeFile(path, maintainingDependenciesMd);
 }
 
 function getCommitTitle(moduleVersion) {


### PR DESCRIPTION
Update `doc/contributing/maintaining/maintaining-dependencies.md` on major V8 updates. Marked as draft in order to wait for https://github.com/nodejs/node/pull/48081 to land