### PR TITLE
chore!: switch to `@node-core` scope

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
         id: release
         with:
           release-type: node
-          package-name: node-core-utils
+          package-name: '@node-core/utils'
   npm-publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
@@ -26,6 +26,6 @@ jobs:
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ CLI tools for Node.js Core collaborators.
 ### Install
 
 ```
-npm install -g node-core-utils
+npm install -g @node-core/utils
 ```
 
 If you would prefer to build from the source, install and link:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-core-utils",
+  "name": "@node-core/utils",
   "version": "3.5.0",
   "description": "Utilities for Node.js core collaborators",
   "type": "module",


### PR DESCRIPTION
Not sure this is ready yet, we may need a new NPM_TOKEN on the repo secret.

Refs: https://github.com/nodejs/TSC/issues/1178