### PR TITLE
fix: properly terminate pr landing sessions

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -62,8 +62,8 @@ export default class LandingSession extends Session {
     const shouldContinue = await cli.prompt(
       `This PR ${status} to land, do you want to continue?`, { defaultAnswer });
     if (!shouldContinue) {
-      cli.setExitCode(1);
-      return this.abort(false);
+      await this.abort(false);
+      return process.exit(1);
     }
 
     this.saveMetadata(metadata);


### PR DESCRIPTION
This pull request properly terminates the CLI issue, but does not fix the unnecessary `Querying for API...` log.

Example output

```
? This PR is not ready to land, do you want to continue? No
⠋ Querying API for job/node-test-pull-request/52248/   ✔  Aborted `git node land` session in /Users/yagiz/Developer/node/.ncu
```

Reference: https://github.com/nodejs/node-core-utils/issues/707