### PR TITLE
feat(git-node): add support for `amend!` commits

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -119,10 +119,9 @@ export default class LandingSession extends Session {
     const commitInfo = { base, head, shas: commitShas };
     this.saveCommitInfo(commitInfo);
 
-    const allowEmptyCommits = this.fixupAll ? ['--allow-empty'] : [];
     try {
       await forceRunAsync('git',
-        ['cherry-pick', ...allowEmptyCommits, ...this.gpgSign, `${base}..${head}`],
+        ['cherry-pick', '--allow-empty', ...this.gpgSign, `${base}..${head}`],
         { ignoreFailure: false });
     } catch (ex) {
       cli.error('Failed to apply patches');
@@ -152,11 +151,11 @@ export default class LandingSession extends Session {
 
   getRebaseSuggestion(subjects) {
     const { upstream, branch } = this;
-    let command = `git rebase ${upstream}/${branch} -i`;
+    let command = `git rebase ${upstream}/${branch} --no-keep-empty -i`;
     command += ' -x "git node land --amend"';
 
     const squashes = subjects.filter(
-      line => line.includes('fixup!') || line.includes('squash!'));
+      line => line.includes('fixup!') || line.includes('squash!') || line.includes('amend!'));
 
     if (squashes.length !== 0) {
       command += ' --autosquash';
@@ -233,7 +232,8 @@ export default class LandingSession extends Session {
       const msgAmend = `-x "git node land --amend ${assumeYes}"`;
       try {
         await forceRunAsync('git',
-          ['rebase', ...this.gpgSign, `${upstream}/${branch}`, '-i', '--autosquash', msgAmend],
+          ['rebase', ...this.gpgSign, `${upstream}/${branch}`,
+            '--no-keep-empty', '-i', '--autosquash', msgAmend],
           {
             ignoreFailure: false,
             spawnArgs: {


### PR DESCRIPTION
Commits made using `git commit --fixup=reword:HEAD` are empty commits that lets the user change the commit message without needing to force-push the PR branch. With this commit, those are still ignored when using `--fixupAll` CLI flag.

Another change with this PR is that ncu will no longer reject PRs with empty commits, but will drop them from the rebase. Previously, empty commits were allowed only when using `--fixupAll`.

Tested locally with https://github.com/nodejs/node/pull/48513.