### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "branch-diff": "^2.1.3",
+    "branch-diff": "^2.1.4",
     "chalk": "^5.3.0",
     "changelog-maker": "^3.2.4",
     "cheerio": "^1.0.0-rc.12",
     "clipboardy": "^3.0.0",
     "core-validate-commit": "^4.0.0",
     "enquirer": "^2.4.1",
-    "execa": "^7.2.0",
+    "execa": "^8.0.1",
     "figures": "^5.0.0",
     "ghauth": "^5.0.1",
     "inquirer": "^9.2.10",
@@ -59,8 +59,8 @@
     "c8": "^8.0.1",
     "eslint": "^8.47.0",
     "eslint-config-standard": "^17.1.0",
-    "eslint-plugin-import": "^2.28.0",
-    "eslint-plugin-n": "^16.0.1",
+    "eslint-plugin-import": "^2.28.1",
+    "eslint-plugin-n": "^16.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "sinon": "^15.2.0"
   }


### PR DESCRIPTION
- Update the `execa` dependency to its new major version.
- Update the other dependencies and developer dependencies to their latest versions.