### PR TITLE
chore: remove `execa` dependency

### DIFF
--- a/components/git/v8.js
+++ b/components/git/v8.js
@@ -1,11 +1,11 @@
 import path from 'node:path';
 
-import { execa } from 'execa';
 import logSymbols from 'log-symbols';
 
 import { minor, major, backport } from '../../lib/update-v8/index.js';
 import { defaultBaseDir } from '../../lib/update-v8/constants.js';
 import { checkCwd } from '../../lib/update-v8/common.js';
+import { runAsync } from '../../lib/run.js';
 
 export const command = 'v8 [major|minor|backport]';
 export const describe = 'Update or patch the V8 engine';
@@ -80,14 +80,16 @@ export function handler(argv) {
 
   options.execGitNode = function execGitNode(cmd, args, input) {
     args.unshift(cmd);
-    return execa('git', args, {
-      cwd: options.nodeDir,
-      ...input && { input }
+    return runAsync('git', args, {
+      spawnArgs: {
+        cwd: options.nodeDir,
+        ...input && { input }
+      }
     });
   };
 
   options.execGitV8 = function execGitV8(...args) {
-    return execa('git', args, { cwd: options.v8Dir });
+    return runAsync('git', args, { captureStdout: true, spawnArgs: { cwd: options.v8Dir } });
   };
 
   Promise.resolve()

--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -135,7 +135,7 @@ function generatePatches() {
       try {
         const fullShas = await Promise.all(
           shas.map(async(sha) => {
-            const { stdout } = await ctx.execGitV8('rev-parse', sha);
+            const stdout = await ctx.execGitV8('rev-parse', sha);
             return stdout;
           })
         );
@@ -146,8 +146,8 @@ function generatePatches() {
           ]);
           return {
             sha,
-            data: patch.stdout,
-            message: message.stdout
+            data: patch,
+            message
           };
         }));
       } catch (e) {

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
 import Enquirer from 'enquirer';
-import { execa } from 'execa';
 import { Listr } from 'listr2';
 
 import { getCurrentV8Version } from './common.js';
@@ -16,6 +15,7 @@ import {
 } from './util.js';
 import applyNodeChanges from './applyNodeChanges.js';
 import { chromiumGit, v8Deps } from './constants.js';
+import { runAsync } from '../run.js';
 
 export default function majorUpdate() {
   return {
@@ -54,7 +54,7 @@ function checkoutBranch() {
           '--sort',
           'version:refname'
         );
-        const tags = res.stdout.split('\n').filter(isVersionString);
+        const tags = res.split('\n').filter(isVersionString);
         const lastTag = tags[tags.length - 1];
         if (lastTag) version = lastTag;
         if (version.split('.').length === 3) {
@@ -88,8 +88,8 @@ function cloneLocalV8() {
   return {
     title: 'Clone branch to deps/v8',
     task: (ctx) =>
-      execa('git', ['clone', '-b', ctx.branch, ctx.v8Dir, 'deps/v8'], {
-        cwd: ctx.nodeDir
+      runAsync('git', ['clone', '-b', ctx.branch, ctx.v8Dir, 'deps/v8'], {
+        spawnArgs: { cwd: ctx.nodeDir }
       })
   };
 }
@@ -106,8 +106,8 @@ function addDepsV8() {
     title: 'Track all files in deps/v8',
     // Add all V8 files with --force before updating DEPS. We have to do this
     // because some files are checked in by V8 despite .gitignore rules.
-    task: (ctx) => execa('git', ['add', '--force', 'deps/v8'], {
-      cwd: ctx.nodeDir
+    task: (ctx) => runAsync('git', ['add', '--force', 'deps/v8'], {
+      spawnArgs: { cwd: ctx.nodeDir }
     })
   };
 }
@@ -166,6 +166,6 @@ async function fetchFromGit(cwd, repo, commit) {
   await removeDirectory(path.join(cwd, '.git'));
 
   function exec(...options) {
-    return execa('git', options, { cwd });
+    return runAsync('git', options, { spawnArgs: { cwd } });
   }
 }

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -2,11 +2,11 @@ import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
 import Enquirer from 'enquirer';
-import { execa } from 'execa';
 import { Listr } from 'listr2';
 
 import { getCurrentV8Version } from './common.js';
 import { isVersionString } from './util.js';
+import { runAsync } from '../run.js';
 
 export default function minorUpdate() {
   return {
@@ -31,11 +31,14 @@ function getLatestV8Version() {
     task: async(ctx) => {
       const version = ctx.currentVersion;
       const currentV8Tag = `${version.major}.${version.minor}.${version.build}`;
-      const result = await execa('git', ['tag', '-l', `${currentV8Tag}.*`], {
-        cwd: ctx.v8Dir,
-        encoding: 'utf8'
+      const result = await runAsync('git', ['tag', '-l', `${currentV8Tag}.*`], {
+        captureStdout: true,
+        spawnArgs: {
+          cwd: ctx.v8Dir,
+          encoding: 'utf8'
+        }
       });
-      const tags = filterAndSortTags(result.stdout);
+      const tags = filterAndSortTags(result);
       ctx.latestVersion = tags[0];
     }
   };
@@ -63,15 +66,17 @@ function doMinorUpdate() {
 }
 
 async function applyPatch(ctx, latestStr) {
-  const { stdout: diff } = await execa(
+  const diff = await runAsync(
     'git',
     ['format-patch', '--stdout', `${ctx.currentVersion}...${latestStr}`],
-    { cwd: ctx.v8Dir, encoding: 'utf8' }
+    { captureStdout: true, spawnArgs: { cwd: ctx.v8Dir, encoding: 'utf8' } }
   );
   try {
-    await execa('git', ['apply', '--directory', 'deps/v8'], {
-      cwd: ctx.nodeDir,
-      input: diff
+    await runAsync('git', ['apply', '--directory', 'deps/v8'], {
+      spawnArgs: {
+        cwd: ctx.nodeDir,
+        input: diff
+      }
     });
   } catch (e) {
     const file = path.join(ctx.nodeDir, `${latestStr}.diff`);

--- a/lib/update-v8/updateV8Clone.js
+++ b/lib/update-v8/updateV8Clone.js
@@ -1,10 +1,10 @@
 import { promises as fs } from 'node:fs';
 
 import Enquirer from 'enquirer';
-import { execa } from 'execa';
 import { Listr } from 'listr2';
 
 import { v8Git } from './constants.js';
+import { runAsync } from '../run.js';
 
 export default function updateV8Clone() {
   return {
@@ -24,7 +24,7 @@ function fetchOrigin() {
     title: 'Fetch V8',
     task: async(ctx, task) => {
       try {
-        await execa('git', ['fetch', 'origin'], { cwd: ctx.v8Dir });
+        await runAsync('git', ['fetch', 'origin'], { spawnArgs: { cwd: ctx.v8Dir } });
       } catch (e) {
         if (e.code === 'ENOENT') {
           ctx.shouldClone = true;
@@ -42,7 +42,7 @@ function createClone() {
     title: 'Clone V8',
     task: async(ctx) => {
       await fs.mkdir(ctx.baseDir, { recursive: true });
-      await execa('git', ['clone', v8Git], { cwd: ctx.baseDir });
+      await runAsync('git', ['clone', v8Git], { spawnArgs: { cwd: ctx.baseDir } });
     },
     enabled: (ctx) => ctx.shouldClone
   };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "clipboardy": "^3.0.0",
     "core-validate-commit": "^4.0.0",
     "enquirer": "^2.4.1",
-    "execa": "^8.0.1",
     "figures": "^5.0.0",
     "ghauth": "^5.0.1",
     "inquirer": "^9.2.10",


### PR DESCRIPTION
The less dependencies we have, the better.