### PR TITLE
feat(release): add skipBranchDiff option

### DIFF
--- a/components/git/release.js
+++ b/components/git/release.js
@@ -25,6 +25,10 @@ const releaseOptions = {
     describe: 'Labels separated by "," to filter security PRs',
     type: 'string'
   },
+  skipBranchDiff: {
+    describe: 'Skips the initial branch-diff check when preparing releases',
+    type: 'boolean'
+  },
   startLTS: {
     describe: 'Mark the release as the transition from Current to LTS',
     type: 'boolean'

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -247,6 +247,11 @@ git node release --prepare --startLTS
 git node release --prepare --security --filterLabel 18.x 18.20.1
 ```
 
+```
+# Skip the branch-diff initial check (useful when updating ongoing proposals)
+git node release --prepare 1.2.3 --skipBranchDiff
+```
+
 ## `git node sync`
 
 Demo: https://asciinema.org/a/221230
@@ -330,7 +335,7 @@ ncu-config set waitTimeMultiApproval 48
 
 ## `git node v8`
 
-Update or patch the V8 engine.  
+Update or patch the V8 engine.
 This tool will maintain a clone of the V8 repository in `~/.update-v8/v8`
 if it's used without `--v8-dir`.
 
@@ -367,7 +372,7 @@ Options:
 ### `git node v8 minor`
 
 Compare current V8 version with latest upstream of the same major. Applies a
-patch if necessary.  
+patch if necessary.
 If the `git apply` command fails, a patch file will be written in the Node.js
 clone directory.
 

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -335,7 +335,7 @@ ncu-config set waitTimeMultiApproval 48
 
 ## `git node v8`
 
-Update or patch the V8 engine.
+Update or patch the V8 engine.  
 This tool will maintain a clone of the V8 repository in `~/.update-v8/v8`
 if it's used without `--v8-dir`.
 
@@ -372,7 +372,7 @@ Options:
 ### `git node v8 minor`
 
 Compare current V8 version with latest upstream of the same major. Applies a
-patch if necessary.
+patch if necessary.  
 If the `git apply` command fails, a patch file will be written in the Node.js
 clone directory.
 

--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -29,6 +29,7 @@ export default class ReleasePreparation {
     this.isSecurityRelease = argv.security;
     this.isLTS = false;
     this.isLTSTransition = argv.startLTS;
+    this.runBranchDiff = !argv.skipBranchDiff;
     this.ltsCodename = '';
     this.date = '';
     this.config = getMergedConfig(this.dir);
@@ -202,31 +203,34 @@ export default class ReleasePreparation {
       this.config.repo = 'node-private';
       return this.prepareSecurity();
     }
-    // TODO: UPDATE re-use
-    // Check the branch diff to determine if the releaser
-    // wants to backport any more commits before proceeding.
-    cli.startSpinner('Fetching branch-diff');
-    const raw = this.getBranchDiff({
-      onlyNotableChanges: false,
-      comparisonBranch: newVersion
-    });
 
-    const diff = raw.split('*');
-    cli.stopSpinner('Got branch diff');
+    if (this.runBranchDiff) {
+      // TODO: UPDATE re-use
+      // Check the branch diff to determine if the releaser
+      // wants to backport any more commits before proceeding.
+      cli.startSpinner('Fetching branch-diff');
+      const raw = this.getBranchDiff({
+        onlyNotableChanges: false,
+        comparisonBranch: newVersion
+      });
 
-    const outstandingCommits = diff.length - 1;
-    if (outstandingCommits !== 0) {
-      const staging = `v${semver.major(newVersion)}.x-staging`;
-      const proceed = await cli.prompt(
-        `There are ${outstandingCommits} commits that may be ` +
-        `backported to ${staging} - do you still want to proceed?`,
-        { defaultAnswer: false });
+      const diff = raw.split('*');
+      cli.stopSpinner('Got branch diff');
 
-      if (!proceed) {
-        const seeDiff = await cli.prompt(
-          'Do you want to see the branch diff?');
-        if (seeDiff) cli.log(raw);
-        return;
+      const outstandingCommits = diff.length - 1;
+      if (outstandingCommits !== 0) {
+        const staging = `v${semver.major(newVersion)}.x-staging`;
+        const proceed = await cli.prompt(
+          `There are ${outstandingCommits} commits that may be ` +
+          `backported to ${staging} - do you still want to proceed?`,
+          { defaultAnswer: false });
+
+        if (!proceed) {
+          const seeDiff = await cli.prompt(
+            'Do you want to see the branch diff?');
+          if (seeDiff) cli.log(raw);
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
Adds an option that allows skipping the initial `branch-diff` check step in the release command. This should be very convenient for releasers that are updating a current work in progress proposal, particularly helping avoid hitting GitHub API rate limits.