### PR TITLE
add --skip-more-than to ncu-ci and show console URL for "Appeared on"

### DIFF
--- a/bin/ncu-ci.js
+++ b/bin/ncu-ci.js
@@ -215,6 +215,11 @@ const args = yargs(hideBin(process.argv))
     default: false,
     type: 'boolean'
   })
+  .option('skip-more-than', {
+    describe: 'Skip jobs that fail more than <limit> builds, when --stat is true, default to 10.',
+    type: 'number',
+    default: Infinity
+  })
   .option('nobuild', {
     describe: 'If running cigtm, whether or not jobid is citgm-nobuild.',
     type: 'boolean',
@@ -325,15 +330,19 @@ class CICommand {
       cli.separator('');
 
       let build;
+      let { skipMoreThan } = argv;
+      if (argv.stats && argv.skipMoreThan === Infinity) {
+        skipMoreThan = 10;
+      }
       switch (job.type) {
         case 'health':
           build = new HealthBuild(cli, request, job.ciType, job.builds);
           break;
         case PR:
-          build = new PRBuild(cli, request, job.jobid);
+          build = new PRBuild(cli, request, job.jobid, skipMoreThan);
           break;
         case COMMIT:
-          build = new CommitBuild(cli, request, job.jobid);
+          build = new CommitBuild(cli, request, job.jobid, skipMoreThan);
           break;
         case CITGM:
         case CITGM_NOBUILD:

--- a/lib/ci/build-types/commit_build.js
+++ b/lib/ci/build-types/commit_build.js
@@ -20,10 +20,11 @@ const {
 } = CIFailureParser;
 
 export class CommitBuild extends TestBuild {
-  constructor(cli, request, id) {
+  constructor(cli, request, id, skipMoreThan) {
     const path = `job/node-test-commit/${id}/`;
     const tree = COMMIT_TREE;
     super(cli, request, path, tree);
+    this.skipMoreThan = skipMoreThan;
   }
 
   getBuilds({ result, subBuilds }) {
@@ -87,6 +88,11 @@ export class CommitBuild extends TestBuild {
     if (!builds.failed.length) {
       const failures = await this.parseConsoleText();
       return { result, builds, failures };
+    }
+
+    if (builds.failed.length > this.skipMoreThan) {
+      cli.log(`Failed ${builds.failed.length} builds (> ${this.skipMoreThan}), skipping`);
+      return { result, builds, failures: [] };
     }
 
     cli.startSpinner(`Querying failures of ${path}`);

--- a/lib/ci/build-types/pr_build.js
+++ b/lib/ci/build-types/pr_build.js
@@ -15,11 +15,11 @@ const {
 } = CIFailureParser;
 
 export class PRBuild extends TestBuild {
-  constructor(cli, request, id) {
+  constructor(cli, request, id, skipMoreThan) {
     const path = `job/node-test-pull-request/${id}/`;
     const tree = PR_TREE;
     super(cli, request, path, tree);
-
+    this.skipMoreThan = skipMoreThan;
     this.commitBuild = null;
   }
 
@@ -78,7 +78,7 @@ export class PRBuild extends TestBuild {
       result, subBuilds: allBuilds, changeSet, actions, timestamp
     };
     const commitBuildId = commitBuild.buildNumber;
-    this.commitBuild = new CommitBuild(cli, request, commitBuildId);
+    this.commitBuild = new CommitBuild(cli, request, commitBuildId, this.skipMoreThan);
     const { builds, failures } = await this.commitBuild.getResults(buildData);
 
     // Set up aliases for display

--- a/lib/ci/failure_aggregator.js
+++ b/lib/ci/failure_aggregator.js
@@ -43,7 +43,9 @@ export class FailureAggregator {
         .sortBy((f) => parseJobFromURL(f.upstream).jobid)
         .map((item) => ({ source: item.source, upstream: item.upstream }))
         .value();
-      const machines = _.uniq(failures.map(f => f.builtOn));
+      const machines = _.uniqBy(
+        failures.map(f => ({ hostname: f.builtOn, url: f.url })),
+        'hostname');
       data.push({
         reason, type: failures[0].type, failures, prs, machines
       });
@@ -91,7 +93,7 @@ export class FailureAggregator {
         output += markdownRow('Reason', `<code>${reason}</code>`);
         output += markdownRow('-', ':-');
         output += markdownRow('Type', type);
-        const source = prs.map(f => f.source);
+        const source = prs.map(f => `[${f.source}](${f.upstream})`);
         output += markdownRow(
           'Failed PR', `${source.length} (${source.join(', ')})`
         );
@@ -137,7 +139,7 @@ export class FailureAggregator {
             return parsed ? `#${parsed.prid}` : f.source;
           });
         cli.table('Failed PR', `${source.length} (${source.join(', ')})`);
-        cli.table('Appeared', machines.join(', '));
+        cli.table('Appeared', machines.map(m => m.hostname).join(', '));
         if (prs.length > 1) {
           cli.table('First CI', `${prs[0].upstream}`);
         }

--- a/lib/links.js
+++ b/lib/links.js
@@ -106,8 +106,8 @@ export function getPrURL({ owner, repo, prid }) {
   return `https://github.com/${owner}/${repo}/pull/${prid}`;
 };
 
-export function getMachineUrl(name) {
-  return `[${name}](https://ci.nodejs.org/computer/${name}/)`;
+export function getMachineUrl(machine) {
+  return `[${machine.hostname}](${machine.url})`;
 };
 
 const PR_URL_RE = /PR-URL: https:\/\/github.com\/.+/;


### PR DESCRIPTION
### feat: add --skip-more-than to ncu-ci to skip real test failures

### fix: link to failure console for "Appeared on" in ncu-ci

Because it's more useful than the computer URL.
Also use CI URL for PRs instead of the PR URLs themselves.