### PR TITLE
[WIP] feat: mark and skip flaky test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp-*
 .eslintcache
 .ncu
 package-lock.json
+.vscode

--- a/docs/ncu-ci.md
+++ b/docs/ncu-ci.md
@@ -32,6 +32,8 @@ Options:
                                                       [boolean] [default: false]
   --json <path>      Write the results as json to <path>                [string]
   --markdown <path>  Write the results as markdown to <path>            [string]
+  --mark-flaky       If running walk, whether or not mark tests as flaky.
+                                                      [boolean] [default: false]
   --help             Show help                                         [boolean]
 ```
 

--- a/lib/ci/ci_mark_flaky.js
+++ b/lib/ci/ci_mark_flaky.js
@@ -4,6 +4,9 @@ import { appendFile, open, rename } from 'node:fs/promises';
 import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
+// assume 3 is the number of pr in which a test has failed to consider it flaky
+const FLAKY_TEST_PR_THRESHOLD = 3;
+
 export async function markFlakyTests(aggregation) {
   try {
     const tests = getFlakyTests(aggregation);
@@ -23,8 +26,12 @@ export function getFlakyTests(aggregation) {
   const { JS_TEST_FAILURE } = aggregation;
 
   for (const failedTest of JS_TEST_FAILURE) {
-    const { failures } = failedTest;
+    const { failures, prs } = failedTest;
+
     if (!failures) continue;
+    // if test has failed in less than x pr do not consider it flaky
+    if (prs.length < FLAKY_TEST_PR_THRESHOLD) continue;
+
     for (const failure of failures) {
       const { builtOn, file } = failure;
       if (!builtOn) continue;
@@ -111,7 +118,8 @@ function parseSystemArchitecture(builtOn) {
 
 async function editStatusFile(type, failedTests) {
   try {
-    const groupedByHeaders = _.groupBy(failedTests, (f) => createHeader(f.system, f.architecture));
+    const groupedByHeaders = _.groupBy(failedTests,
+      (f) => `[$system==${f.system} && $arch==${f.architecture}]`);
     // assume the .status file exists
     const fileName = `./test/${type}/${type}.status`;
     const tmpFile = `${fileName}.tmp`;
@@ -131,10 +139,6 @@ async function editStatusFile(type, failedTests) {
     // file might not exist or error was not parsable
     console.error(error);
   }
-}
-
-function createHeader(system, architecture) {
-  return `[$system==${system} && $arch==${architecture}]`;
 }
 
 function generateSkipFileLine(file) {

--- a/lib/ci/ci_mark_flaky.js
+++ b/lib/ci/ci_mark_flaky.js
@@ -28,9 +28,8 @@ export function getFlakyTests(aggregation) {
   for (const failedTest of JS_TEST_FAILURE) {
     const { failures, prs } = failedTest;
 
-    if (!failures) continue;
     // if test has failed in less than x pr do not consider it flaky
-    if (prs.length < FLAKY_TEST_PR_THRESHOLD) continue;
+    if (!failures || prs.length < FLAKY_TEST_PR_THRESHOLD) continue;
 
     for (const failure of failures) {
       const { builtOn, file } = failure;

--- a/lib/ci/ci_mark_flaky.js
+++ b/lib/ci/ci_mark_flaky.js
@@ -5,7 +5,7 @@ import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 // assume 3 is the number of pr in which a test has failed to consider it flaky
-const FLAKY_TEST_PR_THRESHOLD = 3;
+const FLAKY_TEST_PR_THRESHOLD = 5;
 
 export async function markFlakyTests(aggregation) {
   try {
@@ -117,7 +117,7 @@ function parseSystemArchitecture(builtOn) {
 
 async function editStatusFile(type, failedTests) {
   try {
-    const groupedByHeaders = _.groupBy(failedTests,
+    const testsGroupedByHeader = _.groupBy(failedTests,
       (f) => `[$system==${f.system} && $arch==${f.architecture}]`);
     // assume the .status file exists
     const fileName = `./test/${type}/${type}.status`;
@@ -126,13 +126,14 @@ async function editStatusFile(type, failedTests) {
 
     await pipeline(
       file.readLines(),
-      new FlakyTestTransfrom(groupedByHeaders),
+      new FlakyTestTransfrom(testsGroupedByHeader),
       createWriteStream(tmpFile) // write output on a temp file
     );
 
     // if the header was not present we append it at the end of the file
-    await appendTestsWithNewHeader(tmpFile, groupedByHeaders);
+    await appendTestsWithNewHeader(tmpFile, testsGroupedByHeader);
 
+    // replace original file with tmp
     await rename(tmpFile, fileName);
   } catch (error) {
     // file might not exist or error was not parsable
@@ -146,15 +147,15 @@ function generateSkipFileLine(file) {
   return `${filename}: PASS, FLAKY`;
 }
 
-function appendTestsWithNewHeader(tmpFile, groupedByHeaders) {
+function appendTestsWithNewHeader(tmpFile, testsGroupedByHeader) {
   const text = [];
 
-  for (const [header, failedTests] of Object.entries(groupedByHeaders)) {
+  for (const [header, failedTests] of Object.entries(testsGroupedByHeader)) {
     // skip if there isnt at least one failedTest with written false or no failedTests
     if (!failedTests?.length || !failedTests.some(f => f.written === false)) continue;
 
     // add space on top of header
-    text.push('\n' + header);
+    text.push(header);
 
     // add test lines in a set to avoid duplicates
     const newLines = new Set();
@@ -170,56 +171,59 @@ function appendTestsWithNewHeader(tmpFile, groupedByHeaders) {
 }
 
 class FlakyTestTransfrom extends Transform {
-  constructor(groupedByHeaders) {
+  constructor(testsGroupedByHeader) {
     super();
-    this.groupedByHeaders = groupedByHeaders;
+    this.testsGroupedByHeader = testsGroupedByHeader;
     this.bufferedLines = [];
-    this.uniqueTests = new Set();
   }
 
   _transform(chunk, _encoding, callback) {
     const chunkStringified = chunk.toString();
 
-    // keys of groupedByHeaders are [$system==win32 && $arch==arm64]
-    const failedTests = this.groupedByHeaders[chunkStringified];
+    const isHeader = chunkStringified.startsWith('[');
 
-    if (failedTests?.length) {
-      // when we hit a new header, push bufferedLines
-      this.push(this.bufferedLinesToString());
+    if (
+      // if its an empty line, passthrough
+      chunkStringified === '' ||
+      // if its not a header and we are not buffering, passthrough
+      (!isHeader && !this.bufferedLines.length) ||
+      // if its a header and not mapped, passthrough
+      (isHeader && !(chunkStringified in this.testsGroupedByHeader))
+    ) {
+      callback(null, chunkStringified + '\n');
+      return;
+      ;
+    }
 
-      // reset
-      this.bufferedLines = [];
-      this.uniqueTests = new Set();
+    // not a header but a line (ex: test-tls-client-mindhsize: PASS, FLAKY)
+    if (!isHeader) {
+      this.bufferedLines.push(chunkStringified + '\n');
+      callback();
+      return;
+    }
 
-      // header first
-      this.bufferedLines.push(chunkStringified);
+    // when we hit a new header, flush bufferedLines and reset
+    this.push(this.bufferedLinesToString());
+    this.bufferedLines = [];
 
-      for (const failedTest of failedTests) {
-        // set written to true because there was an existing header
-        failedTest.written = true;
-        const skipFileLine = generateSkipFileLine(failedTest.file);
-        this.bufferedLines.push(skipFileLine);
-        this.uniqueTests.add(skipFileLine);
-      }
-      // this is a non header line
-      // we check if its a test we have added already
-    } else if (!this.uniqueTests.has(chunkStringified)) {
-      this.bufferedLines.push(chunkStringified);
+    this.bufferedLines.push(chunkStringified + '\n');
+
+    for (const failedTest of this.testsGroupedByHeader[chunkStringified]) {
+      // set written to true because we are buffering it
+      failedTest.written = true;
+      const skipFileLine = generateSkipFileLine(failedTest.file);
+      this.bufferedLines.push(skipFileLine + '\n');
     }
 
     callback();
   }
 
   bufferedLinesToString() {
-    if (this.bufferedLines.length > 0) {
-      return this.bufferedLines.join('\n') + '\n';
-    }
-    return '\n';
+    return _.uniq(this.bufferedLines).join('');
   }
 
   _flush(callback) {
-    // Push any remaining buffered lines
-    this.push(this.bufferedLinesToString());
-    callback();
+    // Flush any remaining buffered lines
+    callback(null, this.bufferedLinesToString());
   }
 }

--- a/lib/ci/ci_mark_flaky.js
+++ b/lib/ci/ci_mark_flaky.js
@@ -1,0 +1,222 @@
+import _ from 'lodash';
+import { createWriteStream } from 'node:fs';
+import { appendFile, open, rename } from 'node:fs/promises';
+import { Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+export async function markFlakyTests(aggregation) {
+  try {
+    const tests = getFlakyTests(aggregation);
+    // group tests by type (ex: parallel, pummel)
+    const groupedByType = _.groupBy(tests, ({ file }) => file.split('/', 1));
+
+    for (const [type, failedTests] of Object.entries(groupedByType)) {
+      await editStatusFile(type, failedTests);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export function getFlakyTests(aggregation) {
+  const failedRuns = [];
+  const { JS_TEST_FAILURE } = aggregation;
+
+  for (const failedTest of JS_TEST_FAILURE) {
+    const { failures } = failedTest;
+    if (!failures) continue;
+    for (const failure of failures) {
+      const { builtOn, file } = failure;
+      if (!builtOn) continue;
+      const { system, architecture } = parseSystemArchitecture(builtOn);
+      failedRuns.push({
+        builtOn,
+        file,
+        system,
+        architecture,
+        written: false
+      });
+    }
+  }
+
+  return failedRuns;
+}
+
+function matchSystem(rawSystem) {
+  let system;
+  switch (true) {
+    case rawSystem.includes('container'):
+      system = 'docker';
+      break;
+    case rawSystem.includes('win'):
+      system = 'win32';
+      break;
+    case rawSystem.includes('fedora'):
+    case rawSystem.includes('ubuntu'):
+    case rawSystem.includes('rhel'):
+    case rawSystem.includes('debian'):
+      system = 'linux';
+      break;
+    case rawSystem.includes('macos'):
+      system = 'macos';
+      break;
+    case rawSystem.includes('solaris'):
+    case rawSystem.includes('smartos'):
+      system = 'solaris';
+      break;
+    case rawSystem.includes('freebsd'):
+      system = 'freebsd';
+      break;
+    case rawSystem.includes('aix72'):
+      system = 'aix';
+      break;
+    default:
+      system = rawSystem;
+      break;
+  }
+
+  return system;
+}
+
+function matchArchitecture(rawArchitecture) {
+  let architecture;
+  switch (true) {
+    case rawArchitecture.includes('arm64'):
+      architecture = 'arm64';
+      break;
+    case rawArchitecture.includes('arm'):
+      architecture = 'arm';
+      break;
+    case rawArchitecture.includes('s390x'):
+    case rawArchitecture.includes('ppc64'):
+      architecture = 'ibm';
+      break;
+    default:
+      architecture = rawArchitecture;
+      break;
+  }
+  return architecture;
+}
+
+function parseSystemArchitecture(builtOn) {
+  const buildInfos = builtOn.split('-');
+  const rawArchitecture = buildInfos[buildInfos.length - 2]; // second last element is architecture
+  const rawSystem = buildInfos[buildInfos.length - 3]; // third last element is os
+
+  return {
+    architecture: matchArchitecture(rawArchitecture),
+    system: matchSystem(rawSystem)
+  };
+}
+
+async function editStatusFile(type, failedTests) {
+  try {
+    const groupedByHeaders = _.groupBy(failedTests, (f) => createHeader(f.system, f.architecture));
+    // assume the .status file exists
+    const fileName = `./test/${type}/${type}.status`;
+    const tmpFile = `${fileName}.tmp`;
+    const file = await open(fileName);
+
+    await pipeline(
+      file.readLines(),
+      new FlakyTestTransfrom(groupedByHeaders),
+      createWriteStream(tmpFile) // write output on a temp file
+    );
+
+    // if the header was not present we append it at the end of the file
+    await appendTestsWithNewHeader(tmpFile, groupedByHeaders);
+
+    await rename(tmpFile, fileName);
+  } catch (error) {
+    // file might not exist or error was not parsable
+    console.error(error);
+  }
+}
+
+function createHeader(system, architecture) {
+  return `[$system==${system} && $arch==${architecture}]`;
+}
+
+function generateSkipFileLine(file) {
+  // take only filename without ex: /parallel/
+  const filename = file.split('/')[1];
+  return `${filename}: PASS, FLAKY`;
+}
+
+function appendTestsWithNewHeader(tmpFile, groupedByHeaders) {
+  const text = [];
+
+  for (const [header, failedTests] of Object.entries(groupedByHeaders)) {
+    // skip if there isnt at least one failedTest with written false or no failedTests
+    if (!failedTests?.length || !failedTests.some(f => f.written === false)) continue;
+
+    // add space on top of header
+    text.push('\n' + header);
+
+    // add test lines in a set to avoid duplicates
+    const newLines = new Set();
+    for (const failedTest of failedTests) {
+      // skip tests we have already been written because we found the header
+      if (failedTest.written) continue;
+      newLines.add(generateSkipFileLine(failedTest.file));
+    }
+    text.push(...newLines);
+  }
+
+  return appendFile(tmpFile, text.join('\n'));
+}
+
+class FlakyTestTransfrom extends Transform {
+  constructor(groupedByHeaders) {
+    super();
+    this.groupedByHeaders = groupedByHeaders;
+    this.bufferedLines = [];
+    this.uniqueTests = new Set();
+  }
+
+  _transform(chunk, _encoding, callback) {
+    const chunkStringified = chunk.toString();
+
+    // keys of groupedByHeaders are [$system==win32 && $arch==arm64]
+    const failedTests = this.groupedByHeaders[chunkStringified];
+
+    if (failedTests?.length) {
+      // when we hit a new header, push bufferedLines
+      this.push(this.bufferedLinesToString());
+
+      // reset
+      this.bufferedLines = [];
+      this.uniqueTests = new Set();
+
+      // header first
+      this.bufferedLines.push(chunkStringified);
+
+      for (const failedTest of failedTests) {
+        // set written to true because there was an existing header
+        failedTest.written = true;
+        const skipFileLine = generateSkipFileLine(failedTest.file);
+        this.bufferedLines.push(skipFileLine);
+        this.uniqueTests.add(skipFileLine);
+      }
+      // this is a non header line
+      // we check if its a test we have added already
+    } else if (!this.uniqueTests.has(chunkStringified)) {
+      this.bufferedLines.push(chunkStringified);
+    }
+
+    callback();
+  }
+
+  bufferedLinesToString() {
+    if (this.bufferedLines.length > 0) {
+      return this.bufferedLines.join('\n') + '\n';
+    }
+    return '\n';
+  }
+
+  _flush(callback) {
+    // Push any remaining buffered lines
+    this.push(this.bufferedLinesToString());
+    callback();
+  }
+}


### PR DESCRIPTION
Draft implementation to add flaky tests automatically to the `.status` file.
Missing:
- ~~rules to determine which tests we consider flaky~~
- tests
- proper matching for OS and architecture

I'm assuming that if the failed test shows up in at least 5 pr is flaky (debatable) and can be skipped, I'd increase this number to make sure no false positive
