### PR TITLE
fix(v8): clone V8 repository when it's not present

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -36,6 +36,7 @@ function runAsyncBase(cmd, args, {
       child.stdout.setEncoding('utf8');
       child.stdout.on('data', (chunk) => { stdout += chunk; });
     }
+    child.on('error', reject);
     child.on('close', (code) => {
       if (code !== 0) {
         if (ignoreFailure) {

--- a/lib/update-v8/updateV8Clone.js
+++ b/lib/update-v8/updateV8Clone.js
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs';
 import { Listr } from 'listr2';
 
 import { v8Git } from './constants.js';
-import { runAsync } from '../run.js';
+import { forceRunAsync } from '../run.js';
 
 export default function updateV8Clone() {
   return {
@@ -19,7 +19,7 @@ function fetchOrigin() {
     title: 'Fetch V8',
     task: async(ctx, task) => {
       try {
-        await runAsync('git', ['fetch', 'origin'], {
+        await forceRunAsync('git', ['fetch', 'origin'], {
           spawnArgs: { cwd: ctx.v8Dir, stdio: 'ignore' }
         });
       } catch (e) {
@@ -39,8 +39,8 @@ function createClone() {
     title: 'Clone V8',
     task: async(ctx) => {
       await fs.mkdir(ctx.baseDir, { recursive: true });
-      await runAsync('git', ['clone', v8Git], {
-        spawnArgs: { cwd: ctx.baseDir, stdio: 'ignore' }
+      await forceRunAsync('git', ['clone', v8Git, ctx.v8Dir], {
+        spawnArgs: { stdio: 'ignore' }
       });
     },
     enabled: (ctx) => ctx.shouldClone


### PR DESCRIPTION
Previously, when the V8 repository was not present, it would emit an `'error'` event instead of rejecting the promise, causing the process to crash instead of running the fallback.

Fixes: https://github.com/nodejs/node-core-utils/issues/743