### PR TITLE
Feat: validate gpg releasers signatures

### DIFF
--- a/bin/ncu-team.js
+++ b/bin/ncu-team.js
@@ -45,6 +45,25 @@ yargs(hideBin(process.argv))
     },
     handler
   })
+  .command({
+    command: 'check-gpg',
+    desc: 'Check that all the team members have a valid GPG key',
+    builder: (yargs) => {
+      yargs
+        .option('org', {
+          describe: 'Name of the organization',
+          type: 'string',
+          default: 'nodejs'
+        });
+      yargs
+        .option('team', {
+          describe: 'Name of the team',
+          type: 'string',
+          default: 'releasers'
+        });
+    },
+    handler
+  })
   .demandCommand(1, 'must provide a valid command')
   .help()
   .parse();
@@ -69,6 +88,10 @@ async function main(argv) {
     }
     case 'sync':
       await TeamInfo.syncFile(cli, request, argv.file);
+      break;
+    case 'check-gpg':
+      const info = new TeamInfo(cli, request, argv.org, argv.team);
+      await info.checkTeamPGPKeys();
       break;
     default:
       throw new Error(`Unknown command ${command}`);

--- a/docs/ncu-team.md
+++ b/docs/ncu-team.md
@@ -71,3 +71,9 @@ will update the file with text like this:
 
 <!-- ncu-team-sync end -->
 ```
+
+### Check GPG Releasers Signature
+
+```
+$ ncu-team check-gpg
+```

--- a/lib/team_info.js
+++ b/lib/team_info.js
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from './file.js';
-import { ascending } from './utils.js';
+import { ascending, extractReleasersFromReadme, checkReleaserDiscrepancies } from './utils.js';
 
 const TEAM_QUERY = 'Team';
 
@@ -37,6 +37,13 @@ export default class TeamInfo {
     return sorted;
   }
 
+  async getGpgPublicKey(login) {
+    const { request } = this;
+    const url = `https://api.github.com/users/${login}/gpg_keys`;
+    const result = await request.json(url);
+    return result;
+  }
+
   async getMemberContacts() {
     const members = await this.getMembers();
     return members.map(getContact).join('\n');
@@ -45,6 +52,39 @@ export default class TeamInfo {
   async listMembers() {
     const contacts = await this.getMemberContacts();
     this.cli.log(contacts);
+  }
+
+  async checkTeamPGPKeys() {
+    const { cli } = this;
+    cli.startSpinner(`Collecting Members details of ${this.org}/${this.team}`);
+    const members = await this.getMembers();
+    cli.stopSpinner(`Collecting Members details of ${this.org}/${this.team}`);
+
+    cli.startSpinner(`Collecting PGP keys of ${this.org}/${this.team}`);
+    const keys = await Promise.all(members.map(member => this.getGpgPublicKey(member.login)));
+    // Add keys to members
+    members.forEach((member, index) => {
+      member.keys = keys[index];
+    });
+    cli.stopSpinner(`Collecting PGP keys of ${this.org}/${this.team}`);
+
+    cli.startSpinner('Collecting Release members from Readme.md');
+    const readmeTxt = await this.request.text('https://raw.githubusercontent.com/nodejs/node/main/README.md');
+    const extractedMembers = extractReleasersFromReadme(readmeTxt);
+    cli.stopSpinner('Collecting Release members from Readme.md');
+
+    // Checks per member
+    cli.startSpinner('Checking discrepancies between members and readme.md');
+
+    for (const member of members) {
+      if (!member.keys || !member.keys.length) {
+        console.error(`The releaser ${member.name} (${member.login}) has no keys associated with their account`);
+      }
+      checkReleaserDiscrepancies(member, extractedMembers);
+      // @TODO: Check if the GPG key is available in https://keys.openpgp.org/
+    }
+
+    cli.stopSpinner('Checking discrepancies between members and readme.md');
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,3 +64,64 @@ export async function getEditor(options = {}) {
 
   return process.env.VISUAL || process.env.EDITOR || null;
 };
+
+/**
+ * Extracts the releasers' information from the provided markdown txt.
+ * Each releaser's information includes their name, email, and GPG key.
+ *
+ * @param {string} txt - The README content.
+ * @returns {Array<Array<string>>} An array of releaser information arrays.
+ *                                 Each sub-array contains the name, email,
+ *                                 and GPG key of a releaser.
+ */
+export function extractReleasersFromReadme(txt) {
+  const regex = /\* \*\*(.*)\*\*.*<<(.*)>>\n.*`(.*)`/gm;
+  let match;
+  const result = [];
+  while ((match = regex.exec(txt)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (match.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+    const [, name, email, key] = match;
+    result.push([name, email, key]);
+  }
+  return result;
+}
+
+export function checkReleaserDiscrepancies(member, extractedMembers) {
+  let releaseKey, extractedMember;
+  member.keys.forEach(key => {
+    extractedMembers.filter(eMember => {
+      if (eMember[2].includes(key.key_id)) {
+        extractedMember = eMember;
+        releaseKey = key;
+      }
+    });
+  });
+
+  if (!extractedMember || !releaseKey) {
+    console.error(`The releaser ${member.name} (${member.login}) is not listed or any of the current profile GPG keys are listed in README.md`);
+    return;
+  }
+
+  if (!releaseKey.emails.some(({ email }) => email === extractedMember[1])) {
+    console.error(`The releaser ${member.name} (${member.login}) has a key (${releaseKey.key_id}) that is not associated with their email address ${extractedMember[1]} in the README.md`);
+  }
+
+  if (!releaseKey.can_sign) {
+    console.error(`The releaser ${member.name} (${member.login}) has a key (${releaseKey.key_id}) that cannot sign`);
+  }
+
+  if (!releaseKey.can_certify) {
+    console.error(`The releaser ${member.name} (${member.login}) has a key (${releaseKey.key_id}) that cannot certify`);
+  }
+
+  if (!releaseKey.expires_at) {
+    console.error(`The releaser ${member.name} (${member.login}) has a key (${releaseKey.key_id}) that cannot expire`);
+  }
+
+  if (releaseKey.revoked) {
+    console.error(`The releaser ${member.name} (${member.login}) has a key (${releaseKey.key_id}) that has been revoked`);
+  }
+}


### PR DESCRIPTION
### Notes

This is currently under a draft version. They main objetive is to collect early feedback before creating the final PR (proper linting, tests, etc...)

This is my first time doing changes on NCU so I might be using wrongly the API or breaking any expected convention, please let me know 👍 


### What is this feature about?

While working on https://github.com/nodejs/Release/pull/966, @RafaelGSS suggested to extend the NCU to review the signatures.

This PR introduce a new command `ncu-team check-gpg`. This command will check the current releasers team members and the available information in the [README.md](https://github.com/nodejs/node#release-keys) and make some checks on the status of the individuals keys and if the keys/releasers are properly listed on the `README.md`

**Currently checks included**
- If the Releaser is not included in the `README.md`
- If the Releaser key listed in the README is not included in their profile
- The Release key status:
  - Was revoked?
  - Has expiration date?
  - Is the email different from the README.md?
  - Can sign commits?

**Potential additional checks**
- Is the key expired?
- Is the key is available in `hkps://keys.openpgp.org` as [expected](https://github.com/nodejs/node#release-keys)?







