### PR TITLE
chore: upgrade `ghauth` to 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "clipboardy": "^4.0.0",
     "core-validate-commit": "^4.0.0",
     "figures": "^6.0.1",
-    "ghauth": "^5.0.1",
+    "ghauth": "^6.0.0",
     "inquirer": "^9.2.11",
     "js-yaml": "^4.1.0",
     "listr2": "^7.0.2",


### PR DESCRIPTION
The only change is regarding which versions of Node.js are supported.

Fixes: https://github.com/nodejs/node-core-utils/issues/750