### PR TITLE
fix: update npm shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Node.js Core Utilities
-[![npm](https://img.shields.io/npm/v/node-core-utils.svg?style=flat-square)](https://npmjs.org/package/node-core-utils)
+[![npm](https://img.shields.io/npm/v/@node-core/utils.svg?style=flat-square)](https://npmjs.org/package/@node-core/utils)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/nodejs/node-core-utils/nodejs.yml?branch=main&style=flat-square)](https://github.com/nodejs/node-core-utils/workflows/Node.js%20CI/badge.svg?branch=main)
 [![codecov](https://img.shields.io/codecov/c/github/nodejs/node-core-utils.svg?style=flat-square)](https://codecov.io/gh/nodejs/node-core-utils)
 [![Known Vulnerabilities](https://snyk.io/test/github/nodejs/node-core-utils/badge.svg?style=flat-square)](https://snyk.io/test/github/nodejs/node-core-utils)


### PR DESCRIPTION
Update the npm shield in the README to point to the new scoped `@node-core/utils` package instead of `node-core-utils`.