### PR TITLE
feat: automate security release issue creation

### DIFF
--- a/lib/github/templates/next-security-release.md
+++ b/lib/github/templates/next-security-release.md
@@ -3,7 +3,7 @@
 * [X] Open an [issue](https://github.com/nodejs-private/node-private) titled
   `Next Security Release`, and put this checklist in the description.
 
-* [ ] Get agreement on the list of vulnerabilities to be addressed.
+* [ ] Get agreement on the [list of vulnerabilities](%VULNERABILITIES_PR_URL%) to be addressed.
 
 * [ ] PR release announcements in [private](https://github.com/nodejs-private/nodejs.org-private):
   * [ ] pre-release: %PRE_RELEASE_PRIV%

--- a/lib/github/templates/next-security-release.md
+++ b/lib/github/templates/next-security-release.md
@@ -1,10 +1,11 @@
+# Security Release Checklist
+
 ## Planning
 
 * [X] Open an [issue](https://github.com/nodejs-private/node-private) titled
   `Next Security Release`, and put this checklist in the description.
 
-* [ ] Get agreement on the list of vulnerabilities to be addressed:
-%REPORTS%
+* [ ] Get agreement on the list of vulnerabilities to be addressed.
 
 * [ ] PR release announcements in [private](https://github.com/nodejs-private/nodejs.org-private):
   * [ ] pre-release: %PRE_RELEASE_PRIV%

--- a/lib/github/templates/next-security-release.md
+++ b/lib/github/templates/next-security-release.md
@@ -1,5 +1,3 @@
-# Security Release Checklist
-
 ## Planning
 
 * [X] Open an [issue](https://github.com/nodejs-private/node-private) titled

--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -7,6 +7,7 @@ import path from 'node:path';
 
 export const PLACEHOLDERS = {
   releaseDate: '%RELEASE_DATE%',
+  vulnerabilitiesPRURL: '%VULNERABILITIES_PR_URL%',
   preReleasePrivate: '%PRE_RELEASE_PRIV%',
   postReleasePrivate: '%POS_RELEASE_PRIV%',
   affectedLines: '%AFFECTED_LINES%'
@@ -27,61 +28,98 @@ export default class SecurityReleaseSteward {
     const req = new Request(credentials);
     const release = new PrepareSecurityRelease(req);
     const releaseDate = await release.promptReleaseDate(cli);
-    const createIssue = await cli.prompt(
-      'Create the Next Security Release issue?',
-      { defaultAnswer: true });
-    if (createIssue) {
-      // prepare the security release issue content and release date
-      const { content } = await release.buildIssue(releaseDate);
+    let securityReleasePRUrl = PLACEHOLDERS.vulnerabilitiesPRURL;
 
-      // create the security release issue
+    const createVulnerabilitiesJSON = await release.promptVulnerabilitiesJSON(cli);
+    if (createVulnerabilitiesJSON) {
+      securityReleasePRUrl = await this.createVulnerabilitiesJSON(req, release, { cli });
+    }
+
+    const createIssue = await release.promptCreateRelaseIssue(cli);
+
+    if (createIssue) {
+      const { content } = release.buildIssue(releaseDate, securityReleasePRUrl);
       await release.createIssue(content, { cli });
     };
 
-    const createVulnerabilitiesJSON = await cli.prompt(
-      'Create the vulnerabilities.json?',
-      { defaultAnswer: true });
-
-    if (createVulnerabilitiesJSON) {
-      // choose the reports to include in the security release
-      const reports = await release.chooseReports(cli);
-
-      // create the vulnerabilities.json file in the security-release repo
-      const filePath = await release.createVulnerabilitiesJSON(reports, { cli });
-
-      const review = await cli.prompt(
-        'Please review vulnerabilities.json and press enter to proceed.',
-        { defaultAnswer: true });
-
-      if (!review) return;
-
-      runSync('git', ['add', filePath]);
-
-      const commitMessage = 'chore: create vulnerabilities.json for next security release';
-      runSync('git', ['commit', '-m', commitMessage]);
-      runSync('git', ['push', '-u', 'origin', 'next-security-release']);
-      cli.ok(`Pushed commit: ${commitMessage}`);
-
-      const createPr = await cli.prompt(
-        'Create the Next Security Release PR?',
-        { defaultAnswer: true });
-
-      if (!createPr) return;
-
-      await release.createPullRequest(req, { cli });
-    }
     cli.ok('Done!');
+  }
+
+  async createVulnerabilitiesJSON(req, release, { cli }) {
+    // checkout on the next-security-release branch
+    release.checkoutOnSecurityReleaseBranch(cli);
+
+    // choose the reports to include in the security release
+    const reports = await release.chooseReports(cli);
+
+    // create the vulnerabilities.json file in the security-release repo
+    const filePath = await release.createVulnerabilitiesJSON(reports, { cli });
+
+    // review the vulnerabilities.json file
+    const review = await release.promptReviewVulnerabilitiesJSON(cli);
+
+    if (!review) {
+      cli.info(`To push the vulnerabilities.json file run:
+        - git add ${filePath}
+        - git commit -m "chore: create vulnerabilities.json for next security release"
+        - git push -u origin next-security-release
+        - open a PR on ${release.repository.owner}/${release.repository.repo}`);
+      return;
+    };
+
+    // commit and push the vulnerabilities.json file
+    release.commitAndPushVulnerabilitiesJSON(filePath, cli);
+
+    const createPr = await release.promptCreatePR(cli);
+
+    if (!createPr) return;
+
+    // create pr on the security-release repo
+    return release.createPullRequest(req, { cli });
   }
 }
 
 class PrepareSecurityRelease {
-  constructor(req) {
-    this.repository = {
-      owner: 'nodejs-private',
-      repo: 'security-release'
-    };
+  repository = {
+    owner: 'nodejs-private',
+    repo: 'security-release'
+  };
+
+  title = 'Next Security Release';
+  nextSecurityReleaseBranch = 'next-security-release';
+
+  constructor(req, repository) {
     this.req = req;
-    this.title = 'Next Security Release';
+    if (repository) {
+      this.repository = repository;
+    }
+  }
+
+  promptCreatePR(cli) {
+    return cli.prompt(
+      'Create the Next Security Release PR?',
+      { defaultAnswer: true });
+  }
+
+  checkRemote(cli) {
+    const remote = runSync('git', ['ls-remote', '--get-url', 'origin']).trim();
+    const { owner, repo } = this.repository;
+    const securityReleaseOrigin = `https://github.com/${owner}/${repo}.git`;
+
+    if (remote !== securityReleaseOrigin) {
+      cli.error(`Wrong repository! It should be ${securityReleaseOrigin}`);
+      process.exit(1);
+    }
+  }
+
+  commitAndPushVulnerabilitiesJSON(filePath, cli) {
+    this.checkRemote(cli);
+
+    runSync('git', ['add', filePath]);
+    const commitMessage = 'chore: create vulnerabilities.json for next security release';
+    runSync('git', ['commit', '-m', commitMessage]);
+    runSync('git', ['push', '-u', 'origin', 'next-security-release']);
+    cli.ok(`Pushed commit: ${commitMessage} to ${this.nextSecurityReleaseBranch}`);
   }
 
   getSecurityIssueTemplate() {
@@ -101,10 +139,29 @@ class PrepareSecurityRelease {
     });
   }
 
-  async buildIssue(releaseDate) {
+  async promptVulnerabilitiesJSON(cli) {
+    return cli.prompt(
+      'Create the vulnerabilities.json?',
+      { defaultAnswer: true });
+  }
+
+  async promptCreateRelaseIssue(cli) {
+    return cli.prompt(
+      'Create the Next Security Release issue?',
+      { defaultAnswer: true });
+  }
+
+  async promptReviewVulnerabilitiesJSON(cli) {
+    return cli.prompt(
+      'Please review vulnerabilities.json and press enter to proceed.',
+      { defaultAnswer: true });
+  }
+
+  buildIssue(releaseDate, securityReleasePRUrl) {
     const template = this.getSecurityIssueTemplate();
-    const content = template.replace(PLACEHOLDERS.releaseDate, releaseDate);
-    return { releaseDate, content };
+    const content = template.replace(PLACEHOLDERS.releaseDate, releaseDate)
+      .replace(PLACEHOLDERS.vulnerabilitiesPRURL, securityReleasePRUrl);
+    return { releaseDate, content, securityReleasePRUrl };
   }
 
   async createIssue(content, { cli }) {
@@ -164,32 +221,22 @@ class PrepareSecurityRelease {
     return summaries?.[0].attributes?.content;
   }
 
-  async createVulnerabilitiesJSON(reports, { cli }) {
-    cli.separator('Creating vulnerabilities.json...');
-    const remote = runSync('git', ['ls-remote', '--get-url', 'origin']).trim();
-    const { owner, repo } = this.repository;
-    const securityReleaseOrigin = `https://github.com/${owner}/${repo}.git`;
-
-    if (remote !== securityReleaseOrigin) {
-      cli.error(`Wrong repository! It should be ${securityReleaseOrigin}`);
-      process.exit(1);
-    }
-    const now = new Date().toISOString();
-    const file = JSON.stringify({
-      created: now,
-      updated: now,
-      reports
-    }, null, 2);
-
+  checkoutOnSecurityReleaseBranch(cli) {
+    this.checkRemote(cli);
     const currentBranch = runSync('git', ['branch', '--show-current']).trim();
     cli.info(`Current branch: ${currentBranch} `);
 
-    const nextSecurityReleaseBranch = 'next-security-release';
-
-    if (currentBranch !== nextSecurityReleaseBranch) {
-      runSync('git', ['checkout', '-B', nextSecurityReleaseBranch]);
-      cli.ok(`Checkout on branch: ${nextSecurityReleaseBranch} `);
+    if (currentBranch !== this.nextSecurityReleaseBranch) {
+      runSync('git', ['checkout', '-B', this.nextSecurityReleaseBranch]);
+      cli.ok(`Checkout on branch: ${this.nextSecurityReleaseBranch} `);
     };
+  }
+
+  async createVulnerabilitiesJSON(reports, { cli }) {
+    cli.separator('Creating vulnerabilities.json...');
+    const file = JSON.stringify({
+      reports
+    }, null, 2);
 
     const folderPath = path.join(process.cwd(), 'security-release', 'next-security-release');
     try {
@@ -218,8 +265,10 @@ class PrepareSecurityRelease {
       }
 
     );
-    if (response?.html_url) {
-      cli.ok('Created: ' + response.html_url);
+    const url = response?.html_url;
+    if (url) {
+      cli.ok('Created: ' + url);
+      return url;
     } else {
       if (response?.errors) {
         for (const error of response.errors) {

--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -3,7 +3,7 @@ import auth from './auth.js';
 import Request from './request.js';
 import fs from 'node:fs';
 import { runSync } from './run.js';
-import path from 'path';
+import path from 'node:path';
 
 export const PLACEHOLDERS = {
   releaseDate: '%RELEASE_DATE%',
@@ -47,7 +47,7 @@ export default class SecurityReleaseSteward {
       const reports = await release.chooseReports(cli);
 
       // create the vulnerabilities.json file in the security-release repo
-      const filePath = await release.createVulnerabilitiesJSON(reports, releaseDate, { cli });
+      const filePath = await release.createVulnerabilitiesJSON(reports, { cli });
 
       const review = await cli.prompt(
         'Please review vulnerabilities.json and press enter to proceed.',
@@ -164,7 +164,7 @@ class PrepareSecurityRelease {
     return summaries?.[0].attributes?.content;
   }
 
-  async createVulnerabilitiesJSON(reports, releaseDate, { cli }) {
+  async createVulnerabilitiesJSON(reports, { cli }) {
     cli.separator('Creating vulnerabilities.json...');
     const remote = runSync('git', ['ls-remote', '--get-url', 'origin']).trim();
     const { owner, repo } = this.repository;
@@ -178,7 +178,6 @@ class PrepareSecurityRelease {
     const file = JSON.stringify({
       created: now,
       updated: now,
-      releaseDate,
       reports
     }, null, 2);
 

--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -2,6 +2,15 @@ import nv from '@pkgjs/nv';
 import auth from './auth.js';
 import Request from './request.js';
 import fs from 'node:fs';
+import { runSync } from './run.js';
+import path from 'path';
+
+export const PLACEHOLDERS = {
+  releaseDate: '%RELEASE_DATE%',
+  preReleasePrivate: '%PRE_RELEASE_PRIV%',
+  postReleasePrivate: '%POS_RELEASE_PRIV%',
+  affectedLines: '%AFFECTED_LINES%'
+};
 
 export default class SecurityReleaseSteward {
   constructor(cli) {
@@ -16,31 +25,63 @@ export default class SecurityReleaseSteward {
     });
 
     const req = new Request(credentials);
-    const create = await cli.prompt(
+    const release = new PrepareSecurityRelease(req);
+    const releaseDate = await release.promptReleaseDate(cli);
+    const createIssue = await cli.prompt(
       'Create the Next Security Release issue?',
       { defaultAnswer: true });
-    if (create) {
-      const issue = new SecurityReleaseIssue(req);
-      const content = await issue.buildIssue(cli);
-      const data = await req.createIssue('Next Security Release', content, {
-        owner: 'nodejs-private',
-        repo: 'node-private'
-      });
-      if (data.html_url) {
-        cli.ok('Created: ' + data.html_url);
-      } else {
-        cli.error(data);
-      }
+    if (createIssue) {
+      // prepare the security release issue content and release date
+      const { content } = await release.buildIssue(releaseDate);
+
+      // create the security release issue
+      await release.createIssue(content, { cli });
+    };
+
+    const createVulnerabilitiesJSON = await cli.prompt(
+      'Create the vulnerabilities.json?',
+      { defaultAnswer: true });
+
+    if (createVulnerabilitiesJSON) {
+      // choose the reports to include in the security release
+      const reports = await release.chooseReports(cli);
+
+      // create the vulnerabilities.json file in the security-release repo
+      const filePath = await release.createVulnerabilitiesJSON(reports, releaseDate, { cli });
+
+      const review = await cli.prompt(
+        'Please review vulnerabilities.json and press enter to proceed.',
+        { defaultAnswer: true });
+
+      if (!review) return;
+
+      runSync('git', ['add', filePath]);
+
+      const commitMessage = 'chore: create vulnerabilities.json for next security release';
+      runSync('git', ['commit', '-m', commitMessage]);
+      runSync('git', ['push', '-u', 'origin', 'next-security-release']);
+      cli.ok(`Pushed commit: ${commitMessage}`);
+
+      const createPr = await cli.prompt(
+        'Create the Next Security Release PR?',
+        { defaultAnswer: true });
+
+      if (!createPr) return;
+
+      await release.createPullRequest(req, { cli });
     }
+    cli.ok('Done!');
   }
 }
 
-class SecurityReleaseIssue {
+class PrepareSecurityRelease {
   constructor(req) {
+    this.repository = {
+      owner: 'nodejs-private',
+      repo: 'security-release'
+    };
     this.req = req;
-    this.content = '';
     this.title = 'Next Security Release';
-    this.affectedLines = {};
   }
 
   getSecurityIssueTemplate() {
@@ -53,31 +94,39 @@ class SecurityReleaseIssue {
     );
   }
 
-  async buildIssue(cli) {
-    this.content = this.getSecurityIssueTemplate();
-    cli.info('Getting triaged H1 reports...');
-    const reports = await this.req.getTriagedReports();
-    await this.fillReports(cli, reports);
-
-    this.fillAffectedLines(Object.keys(this.affectedLines));
-
-    const target = await cli.prompt('Enter target date in YYYY-MM-DD format:', {
+  async promptReleaseDate(cli) {
+    return cli.prompt('Enter target release date in YYYY-MM-DD format:', {
       questionType: 'input',
       defaultAnswer: 'TBD'
     });
-    this.fillTargetDate(target);
-
-    return this.content;
   }
 
-  async fillReports(cli, reports) {
+  async buildIssue(releaseDate) {
+    const template = this.getSecurityIssueTemplate();
+    const content = template.replace(PLACEHOLDERS.releaseDate, releaseDate);
+    return { releaseDate, content };
+  }
+
+  async createIssue(content, { cli }) {
+    const data = await this.req.createIssue(this.title, content, this.repository);
+    if (data.html_url) {
+      cli.ok('Created: ' + data.html_url);
+    } else {
+      cli.error(data);
+      process.exit(1);
+    }
+  }
+
+  async chooseReports(cli) {
+    cli.info('Getting triaged H1 reports...');
+    const reports = await this.req.getTriagedReports();
     const supportedVersions = (await nv('supported'))
       .map((v) => v.versionName + '.x')
       .join(',');
+    const selectedReports = [];
 
-    let reportsContent = '';
     for (const report of reports.data) {
-      const { id, attributes: { title }, relationships: { severity } } = report;
+      const { id, attributes: { title, cve_ids }, relationships: { severity } } = report;
       const reportLevel = severity ? severity.data.attributes.rating : 'TBD';
       cli.separator();
       cli.info(`Report: ${id} - ${title} (${reportLevel})`);
@@ -88,30 +137,99 @@ class SecurityReleaseIssue {
         continue;
       }
 
-      reportsContent +=
-        `  * **[${id}](https://hackerone.com/bugs?subject=nodejs&report_id=${id}) - ${title} (TBD) - (${reportLevel})**\n`;
       const versions = await cli.prompt('Which active release lines this report affects?', {
         questionType: 'input',
         defaultAnswer: supportedVersions
       });
-      for (const v of versions.split(',')) {
-        if (!this.affectedLines[v]) this.affectedLines[v] = true;
-        reportsContent += `    * ${v} - TBD\n`;
+      const summaryContent = await this.getSummary(id);
+
+      selectedReports.push({
+        id,
+        title,
+        cve_ids,
+        severity: reportLevel,
+        summary: summaryContent ?? '',
+        affectedVersions: versions.split(',').map((v) => v.replace('v', '').trim())
+      });
+    }
+    return selectedReports;
+  }
+
+  async getSummary(reportId) {
+    const { data } = await this.req.getReport(reportId);
+    const summaryList = data?.relationships?.summaries?.data;
+    if (!summaryList?.length) return;
+    const summaries = summaryList.filter((summary) => summary?.attributes?.category === 'team');
+    if (!summaries?.length) return;
+    return summaries?.[0].attributes?.content;
+  }
+
+  async createVulnerabilitiesJSON(reports, releaseDate, { cli }) {
+    cli.separator('Creating vulnerabilities.json...');
+    const remote = runSync('git', ['ls-remote', '--get-url', 'origin']).trim();
+    const { owner, repo } = this.repository;
+    const securityReleaseOrigin = `https://github.com/${owner}/${repo}.git`;
+
+    if (remote !== securityReleaseOrigin) {
+      cli.error(`Wrong repository! It should be ${securityReleaseOrigin}`);
+      process.exit(1);
+    }
+    const now = new Date().toISOString();
+    const file = JSON.stringify({
+      created: now,
+      updated: now,
+      releaseDate,
+      reports
+    }, null, 2);
+
+    const currentBranch = runSync('git', ['branch', '--show-current']).trim();
+    cli.info(`Current branch: ${currentBranch} `);
+
+    const nextSecurityReleaseBranch = 'next-security-release';
+
+    if (currentBranch !== nextSecurityReleaseBranch) {
+      runSync('git', ['checkout', '-B', nextSecurityReleaseBranch]);
+      cli.ok(`Checkout on branch: ${nextSecurityReleaseBranch} `);
+    };
+
+    const folderPath = path.join(process.cwd(), 'security-release', 'next-security-release');
+    try {
+      await fs.accessSync(folderPath);
+    } catch (error) {
+      await fs.mkdirSync(folderPath, { recursive: true });
+    }
+
+    const fullPath = path.join(folderPath, 'vulnerabilities.json');
+    fs.writeFileSync(fullPath, file);
+    cli.ok(`Created ${fullPath} `);
+
+    return fullPath;
+  }
+
+  async createPullRequest(req, { cli }) {
+    const { owner, repo } = this.repository;
+    const response = await req.createPullRequest(
+      this.title,
+      'List of vulnerabilities to be included in the next security release',
+      {
+        owner,
+        repo,
+        base: 'main',
+        head: 'next-security-release'
       }
-    }
-    this.content = this.content.replace('%REPORTS%', reportsContent);
-  }
 
-  fillAffectedLines(affectedLines) {
-    let affected = '';
-    for (const line of affectedLines) {
-      affected += `  * ${line} - TBD\n`;
+    );
+    if (response?.html_url) {
+      cli.ok('Created: ' + response.html_url);
+    } else {
+      if (response?.errors) {
+        for (const error of response.errors) {
+          cli.error(error.message);
+        }
+      } else {
+        cli.error(response);
+      }
+      process.exit(1);
     }
-    this.content =
-      this.content.replace('%AFFECTED_LINES%', affected);
-  }
-
-  fillTargetDate(date) {
-    this.content = this.content.replace('%RELEASE_DATE%', date);
   }
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -77,6 +77,25 @@ export default class Request {
     return this.json(url, options);
   }
 
+  async createPullRequest(title, body, { owner, repo, head, base }) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/pulls`;
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${this.credentials.github}`,
+        'User-Agent': 'node-core-utils',
+        Accept: 'application/vnd.github+json'
+      },
+      body: JSON.stringify({
+        title,
+        body,
+        head,
+        base
+      })
+    };
+    return this.json(url, options);
+  }
+
   async gql(name, variables, path) {
     const query = this.loadQuery(name);
     if (path) {
@@ -102,6 +121,19 @@ export default class Request {
 
   async getTriagedReports() {
     const url = 'https://api.hackerone.com/v1/reports?filter[program][]=nodejs&filter[state][]=triaged';
+    const options = {
+      method: 'GET',
+      headers: {
+        Authorization: `Basic ${this.credentials.h1}`,
+        'User-Agent': 'node-core-utils',
+        Accept: 'application/json'
+      }
+    };
+    return this.json(url, options);
+  }
+
+  async getReport(reportId) {
+    const url = `https://api.hackerone.com/v1/reports/${reportId}`;
     const options = {
       method: 'GET',
       headers: {


### PR DESCRIPTION
This PR automates the first step of the security release: `security --start`.
The `Next Security Release` issue will not contain the list of reports but they will be stored in the new repository `security-release` in a json format.
This way it will be much easier to automate and manipulate json rather than markdown strings.
@RafaelGSS 