### PR TITLE
feat(ncu-ci): check for `request-ci` label

### DIFF
--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -27,7 +27,7 @@ export class RunPRJob {
     this.certifySafe =
       certifySafe ||
       Promise.all([this.prData.getReviews(), this.prData.getPR()]).then(() =>
-        new PRChecker(cli, this.prData, request, {}).checkCommitsAfterReview()
+        new PRChecker(cli, this.prData, request, {}).checkCommitsAfterReviewOrLabel()
       );
   }
 

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -526,14 +526,14 @@ export default class PRChecker {
   async checkCommitsAfterReviewOrLabel() {
     if (this.checkCommitsAfterReview()) return true;
 
-    await Promise.all([this.data.getLabels(), this.data.getCollaborators()]);
+    await Promise.all([this.data.getLabeledEvents(), this.data.getCollaborators()]);
 
     const {
       cli, data, pr
     } = this;
 
     const { updatedAt } = pr.timelineItems;
-    const requestCiLabels = data.labels.findLast(
+    const requestCiLabels = data.labeledEvents.findLast(
       ({ createdAt, label: { name } }) => name === 'request-ci' && createdAt > updatedAt
     );
     if (requestCiLabels == null) return false;

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -523,6 +523,28 @@ export default class PRChecker {
     return true;
   }
 
+  async checkCommitsAfterReviewOrLabel() {
+    if (this.checkCommitsAfterReview()) return true;
+
+    await Promise.all([this.data.getLabels(), this.data.getCollaborators()]);
+
+    const {
+      cli, data, pr
+    } = this;
+    const { updatedAt } = pr.timelineItems;
+    const { actor: { login } } = data.labels.findLast(
+      ({ createdAt, label: { name } }) => name === 'request-ci' && createdAt > updatedAt
+    );
+    const collaborators = Array.from(data.collaborators.values(),
+      (c) => c.login.toLowerCase());
+    if (collaborators.includes(login.toLowerCase())) {
+      cli.info('request-ci label was added by a Collaborator after the last push event.');
+      return true;
+    }
+
+    return false;
+  }
+
   checkCommitsAfterReview() {
     const {
       commits, reviews, cli, argv

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -531,10 +531,14 @@ export default class PRChecker {
     const {
       cli, data, pr
     } = this;
+
     const { updatedAt } = pr.timelineItems;
-    const { actor: { login } } = data.labels.findLast(
+    const requestCiLabels = data.labels.findLast(
       ({ createdAt, label: { name } }) => name === 'request-ci' && createdAt > updatedAt
     );
+    if (requestCiLabels == null) return false;
+
+    const { actor: { login } } = requestCiLabels;
     const collaborators = Array.from(data.collaborators.values(),
       (c) => c.login.toLowerCase());
     if (collaborators.includes(login.toLowerCase())) {

--- a/lib/pr_data.js
+++ b/lib/pr_data.js
@@ -5,7 +5,7 @@ import {
 } from './user_status.js';
 
 // lib/queries/*.gql file names
-const LABELS_QUERY = 'PRLabels';
+const LABELED_EVENTS_QUERY = 'PRLabeledEvents';
 const PR_QUERY = 'PR';
 const REVIEWS_QUERY = 'Reviews';
 const COMMENTS_QUERY = 'PRComments';
@@ -34,6 +34,7 @@ export default class PRData {
     this.comments = [];
     this.commits = [];
     this.reviewers = [];
+    this.labeledEvents = [];
   }
 
   getThread() {
@@ -91,11 +92,11 @@ export default class PRData {
     ]);
   }
 
-  async getLabels() {
+  async getLabeledEvents() {
     const { prid, owner, repo, cli, request, prStr } = this;
     const vars = { prid, owner, repo };
     cli.updateSpinner(`Getting labels from ${prStr}`);
-    this.labels = (await request.gql(LABELS_QUERY, vars))
+    this.labeledEvents = (await request.gql(LABELED_EVENTS_QUERY, vars))
       .repository.pullRequest.timelineItems.nodes;
   }
 

--- a/lib/pr_data.js
+++ b/lib/pr_data.js
@@ -5,6 +5,7 @@ import {
 } from './user_status.js';
 
 // lib/queries/*.gql file names
+const LABELS_QUERY = 'PRLabels';
 const PR_QUERY = 'PR';
 const REVIEWS_QUERY = 'Reviews';
 const COMMENTS_QUERY = 'PRComments';
@@ -88,6 +89,14 @@ export default class PRData {
     this.reviews = await request.gql(REVIEWS_QUERY, vars, [
       'repository', 'pullRequest', 'reviews'
     ]);
+  }
+
+  async getLabels() {
+    const { prid, owner, repo, cli, request, prStr } = this;
+    const vars = { prid, owner, repo };
+    cli.updateSpinner(`Getting labels from ${prStr}`);
+    this.labels = (await request.gql(LABELS_QUERY, vars))
+      .repository.pullRequest.timelineItems.nodes;
   }
 
   async getComments() {

--- a/lib/queries/PRLabeledEvents.gql
+++ b/lib/queries/PRLabeledEvents.gql
@@ -1,4 +1,4 @@
-query PRLabels($prid: Int!, $owner: String!, $repo: String!, $after: String) {
+query PRLabeledEvents($prid: Int!, $owner: String!, $repo: String!, $after: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prid) {
       timelineItems(itemTypes: LABELED_EVENT, after: $after, last: 100) {

--- a/lib/queries/PRLabels.gql
+++ b/lib/queries/PRLabels.gql
@@ -1,0 +1,19 @@
+query PRLabels($prid: Int!, $owner: String!, $repo: String!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prid) {
+      timelineItems(itemTypes: LABELED_EVENT, after: $after, last: 100) {
+        nodes { 
+          ... on LabeledEvent {
+            actor {
+              login
+            }
+            label {
+              name
+            }
+            createdAt
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -134,3 +134,12 @@ for (const subdir of readdirSync(path('./jenkins'))) {
       readJSON(`./jenkins/${subdir}/${item}`);
   }
 };
+
+export const labeledEvents = {};
+
+for (const item of readdirSync(path('./labeled_events'))) {
+  if (!item.endsWith('.json')) {
+    continue;
+  }
+  labeledEvents[basename(item, '.json')] = readJSON(`./labeled_events/${item}`);
+}

--- a/test/fixtures/first_timer_pr.json
+++ b/test/fixtures/first_timer_pr.json
@@ -22,6 +22,7 @@
       }
     ]
   },
+  "timelineItems": { "updatedAt": "2017-10-24T11:13:43Z" },
   "title": "test: awesome changes",
   "baseRefName": "main",
   "headRefName": "awesome-changes"

--- a/test/fixtures/labeled_events/no-request-ci.json
+++ b/test/fixtures/labeled_events/no-request-ci.json
@@ -1,0 +1,12 @@
+[
+  {
+    "actor": { "login": "nodejs-github-bot" },
+    "label": { "name": "doc" },
+    "createdAt": "2024-05-13T15:57:10Z"
+  },
+  {
+    "actor": { "login": "nodejs-github-bot" },
+    "label": { "name": "test_runner" },
+    "createdAt": "2024-05-13T15:57:10Z"
+  }
+]

--- a/test/fixtures/labeled_events/old-request-ci-collaborator.json
+++ b/test/fixtures/labeled_events/old-request-ci-collaborator.json
@@ -1,0 +1,12 @@
+[
+  {
+    "actor": { "login": "nodejs-github-bot" },
+    "label": { "name": "doc" },
+    "createdAt": "2024-05-13T15:57:10Z"
+  },
+  {
+    "actor": { "login": "foo" },
+    "label": { "name": "request-ci" },
+    "createdAt": "1999-10-24T11:13:43Z"
+  }
+]

--- a/test/fixtures/labeled_events/recent-request-ci-collaborator.json
+++ b/test/fixtures/labeled_events/recent-request-ci-collaborator.json
@@ -1,0 +1,12 @@
+[
+  {
+    "actor": { "login": "nodejs-github-bot" },
+    "label": { "name": "doc" },
+    "createdAt": "2024-05-13T15:57:10Z"
+  },
+  {
+    "actor": { "login": "foo" },
+    "label": { "name": "request-ci" },
+    "createdAt": "2024-05-13T15:57:10Z"
+  }
+]

--- a/test/fixtures/labeled_events/recent-request-ci-non-collaborator.json
+++ b/test/fixtures/labeled_events/recent-request-ci-non-collaborator.json
@@ -1,0 +1,12 @@
+[
+  {
+    "actor": { "login": "nodejs-github-bot" },
+    "label": { "name": "doc" },
+    "createdAt": "2024-05-13T15:57:10Z"
+  },
+  {
+    "actor": { "login": "random-person" },
+    "label": { "name": "request-ci" },
+    "createdAt": "2024-05-13T15:57:10Z"
+  }
+]

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -40,9 +40,9 @@ import {
   semverMajorPR,
   conflictingPR,
   closedPR,
+  labeledEvents,
   mergedPR,
-  pullRequests,
-  labeledEvents
+  pullRequests
 } from '../fixtures/data.js';
 
 jobCache.disable();


### PR DESCRIPTION
When commits were pushed to a PR since the last approving review, check if the last time a `request-ci` label was added, it was done by a Collaborator and after the last push event on the PR.

I don't really like the fact `"request-ci"` is hard-coded, and also it might make sense to enable this check only in the GHA workflow (as the code doesn't search for `'unlabeled'` events, so if someone adds the label and removes it, it would still still count), so if you have suggestions regarding that, I'd be interested.

Fixes: https://github.com/nodejs/node-core-utils/issues/801