### PR TITLE
fix(v8): remove trace_event starting with 12.6

### DIFF
--- a/lib/update-v8/constants.js
+++ b/lib/update-v8/constants.js
@@ -46,7 +46,8 @@ export const v8Deps = [
       match: '/base\n',
       replace: ''
     },
-    since: 55
+    since: 55,
+    until: 125
   },
   {
     name: 'gtest',

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -146,6 +146,9 @@ async function readDeps(nodeDir, depName) {
   let deps;
   eval(depsDeclaration); // eslint-disable-line no-eval
   const dep = deps[depName];
+  if (!dep) {
+    throw new Error(`V8 dep "${depName}" not found in DEPS file`);
+  }
   if (typeof dep === 'object') {
     return dep.url.split('@');
   }


### PR DESCRIPTION
Also add a custom error message when a dependency disappears to avoid
the unhelpful `Cannot read properties of undefined (reading 'split')`.

Refs: https://github.com/v8/v8/commit/f8fa22073a0db4a62775efba87ddee5f949a2095
