### PR TITLE
fix(v8): do not ignore failures when running git

### DIFF
--- a/components/git/v8.js
+++ b/components/git/v8.js
@@ -81,6 +81,7 @@ export function handler(argv) {
   options.execGitNode = function execGitNode(cmd, args, input) {
     args.unshift(cmd);
     return forceRunAsync('git', args, {
+      ignoreFailure: false,
       input,
       spawnArgs: {
         cwd: options.nodeDir,
@@ -91,6 +92,7 @@ export function handler(argv) {
 
   options.execGitV8 = function execGitV8(...args) {
     return forceRunAsync('git', args, {
+      ignoreFailure: false,
       captureStdout: true,
       spawnArgs: { cwd: options.v8Dir, stdio: ['ignore', 'pipe', 'ignore'] }
     });

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -14,7 +14,7 @@ import {
 } from './util.js';
 import applyNodeChanges from './applyNodeChanges.js';
 import { chromiumGit, v8Deps } from './constants.js';
-import { runAsync } from '../run.js';
+import { forceRunAsync } from '../run.js';
 
 export default function majorUpdate() {
   return {
@@ -83,7 +83,8 @@ function cloneLocalV8() {
   return {
     title: 'Clone branch to deps/v8',
     task: (ctx) =>
-      runAsync('git', ['clone', '-b', ctx.branch, ctx.v8Dir, 'deps/v8'], {
+      forceRunAsync('git', ['clone', '-b', ctx.branch, ctx.v8Dir, 'deps/v8'], {
+        ignoreFailure: false,
         spawnArgs: { cwd: ctx.nodeDir, stdio: 'ignore' }
       })
   };
@@ -101,7 +102,8 @@ function addDepsV8() {
     title: 'Track all files in deps/v8',
     // Add all V8 files with --force before updating DEPS. We have to do this
     // because some files are checked in by V8 despite .gitignore rules.
-    task: (ctx) => runAsync('git', ['add', '--force', 'deps/v8'], {
+    task: (ctx) => forceRunAsync('git', ['add', '--force', 'deps/v8'], {
+      ignoreFailure: false,
       spawnArgs: { cwd: ctx.nodeDir, stdio: 'ignore' }
     })
   };
@@ -164,6 +166,9 @@ async function fetchFromGit(cwd, repo, commit) {
   await removeDirectory(path.join(cwd, '.git'));
 
   function exec(...options) {
-    return runAsync('git', options, { spawnArgs: { cwd, stdio: 'ignore' } });
+    return forceRunAsync('git', options, {
+      ignoreFailure: false,
+      spawnArgs: { cwd, stdio: 'ignore' }
+    });
   }
 }

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -6,7 +6,7 @@ import { Listr } from 'listr2';
 
 import { getCurrentV8Version } from './common.js';
 import { isVersionString } from './util.js';
-import { runAsync } from '../run.js';
+import { forceRunAsync } from '../run.js';
 
 export default function minorUpdate() {
   return {
@@ -27,7 +27,8 @@ function getLatestV8Version() {
     task: async(ctx) => {
       const version = ctx.currentVersion;
       const currentV8Tag = `${version.major}.${version.minor}.${version.build}`;
-      const result = await runAsync('git', ['tag', '-l', `${currentV8Tag}.*`], {
+      const result = await forceRunAsync('git', ['tag', '-l', `${currentV8Tag}.*`], {
+        ignoreFailure: false,
         captureStdout: true,
         spawnArgs: {
           cwd: ctx.v8Dir,
@@ -68,7 +69,8 @@ async function applyPatch(ctx, latestStr) {
     { cwd: ctx.v8Dir, stdio: ['ignore', 'pipe', 'ignore'] }
   );
   try {
-    await runAsync('git', ['apply', '--directory', 'deps/v8'], {
+    await forceRunAsync('git', ['apply', '--directory', 'deps/v8'], {
+      ignoreFailure: false,
       spawnArgs: {
         cwd: ctx.nodeDir,
         stdio: [diff.stdout, 'ignore', 'ignore']

--- a/lib/update-v8/updateV8Clone.js
+++ b/lib/update-v8/updateV8Clone.js
@@ -20,6 +20,7 @@ function fetchOrigin() {
     task: async(ctx, task) => {
       try {
         await forceRunAsync('git', ['fetch', 'origin'], {
+          ignoreFailure: false,
           spawnArgs: { cwd: ctx.v8Dir, stdio: 'ignore' }
         });
       } catch (e) {
@@ -40,6 +41,7 @@ function createClone() {
     task: async(ctx) => {
       await fs.mkdir(ctx.baseDir, { recursive: true });
       await forceRunAsync('git', ['clone', v8Git, ctx.v8Dir], {
+        ignoreFailure: false,
         spawnArgs: { stdio: 'ignore' }
       });
     },


### PR DESCRIPTION
Also always use `forceRunAsync` because `runAsync` exits the process on error.
