### PR TITLE
fix(vote): improve UX when posting comment fails

### DIFF
--- a/lib/voting_session.js
+++ b/lib/voting_session.js
@@ -114,7 +114,7 @@ export default class VotingSession extends Session {
     const body = 'I would like to close this vote, and for this effect, I\'m revealing my ' +
                  `key part:\n\n${'```'}\n${keyPart}\n${'```'}\n`;
     if (this.postComment) {
-      const { html_url } = await this.req.json(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${this.prid}/comments`, {
+      const { message, html_url } = await this.req.json(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${this.prid}/comments`, {
         agent: this.req.proxyAgent,
         method: 'POST',
         headers: {
@@ -124,13 +124,23 @@ export default class VotingSession extends Session {
         },
         body: JSON.stringify({ body })
       });
-      this.cli.log('Comment posted at:', html_url);
-    } else if (isGhAvailable()) {
+      if (html_url) {
+        this.cli.log(`Comment posted at: ${html_url}`);
+        return;
+      } else {
+        this.cli.error('Failed to post comment');
+        this.cli.info(message);
+      }
+    }
+    if (isGhAvailable()) {
       this.cli.log('\nRun the following command to post the comment:\n');
       this.cli.log(
         `gh pr comment ${this.prid} --repo ${this.owner}/${this.repo} ` +
         `--body-file - <<'EOF'\n${body}\nEOF`
       );
+    } else {
+      this.cli.log('\nPost the following comment on the PR thread:\n');
+      this.cli.log(body);
     }
   }
 }

--- a/lib/voting_session.js
+++ b/lib/voting_session.js
@@ -128,8 +128,8 @@ export default class VotingSession extends Session {
         this.cli.log(`Comment posted at: ${html_url}`);
         return;
       } else {
+        this.cli.warn(message);
         this.cli.error('Failed to post comment');
-        this.cli.info(message);
       }
     }
     if (isGhAvailable()) {


### PR DESCRIPTION
When the token doesn't have the permission to post the comment directly, we can fallback to showing the user the error message and what command they should type.