### PR TITLE
fix: remove post-release checks

### DIFF
--- a/lib/security_blog.js
+++ b/lib/security_blog.js
@@ -8,7 +8,6 @@ import {
   checkoutOnSecurityReleaseBranch,
   NEXT_SECURITY_RELEASE_REPOSITORY,
   validateDate,
-  getSummary,
   commitAndPushVulnerabilitiesJSON,
   NEXT_SECURITY_RELEASE_FOLDER
 } from './security-release/security-release.js';

--- a/lib/security_blog.js
+++ b/lib/security_blog.js
@@ -208,12 +208,13 @@ export default class SecurityBlog {
     for (const report of reports) {
       const cveId = report.cveIds?.join(', ');
       if (!cveId) {
-        this.cli.error(`CVE ID for vulnerability https://hackerone.com/reports/${report.id} not found`);
+        this.cli.error(`CVE ID for vulnerability ${report.link} ${report.title} not found`);
         process.exit(1);
       }
       template += `## ${report.title} (${cveId}) - (${report.severity.rating})\n\n`;
       if (!report.summary) {
-        this.cli.error(`Summary missing for vulnerability https://hackerone.com/reports/${report.id} ${report.title}. Please create it before continuing.`);
+        this.cli.error(`Summary missing for vulnerability ${report.link} ` +
+        `${report.title}. Please create it before continuing.`);
         process.exit(1);
       }
 
@@ -222,7 +223,7 @@ export default class SecurityBlog {
       template += `Impact:\n\n- This vulnerability affects all users\
  in active release lines: ${releaseLines}\n\n`;
       if (!report.patchAuthors) {
-        this.cli.error(`Missing patch author for vulnerability https://hackerone.com/reports/${report.id} ${report.title}`);
+        this.cli.error(`Missing patch author for vulnerability ${report.link} ${report.title}`);
         process.exit(1);
       }
       template += `Thank you, to ${report.reporter} for reporting this vulnerability\

--- a/lib/security_blog.js
+++ b/lib/security_blog.js
@@ -84,6 +84,7 @@ export default class SecurityBlog {
     const releaseDate = new Date(content.releaseDate);
     const template = this.getSecurityPostReleaseTemplate();
     const data = {
+      // TODO: read from pre-sec-release
       annoucementDate: await this.getAnnouncementDate(cli),
       releaseDate: this.formatReleaseDate(releaseDate),
       affectedVersions: this.getAffectedVersions(content),
@@ -205,46 +206,24 @@ export default class SecurityBlog {
     const reports = content.reports;
     let template = '';
     for (const report of reports) {
-      let cveId = report.cve_ids?.join(', ');
+      const cveId = report.cveIds?.join(', ');
       if (!cveId) {
-        // ask for the CVE ID
-        // it should have been created with the step `--request-cve`
-        cveId = await this.cli.prompt(`What is the CVE ID for vulnerability https://hackerone.com/reports/${report.id} ${report.title}?`, {
-          questionType: 'input',
-          defaultAnswer: 'TBD'
-        });
-        report.cve_ids = [cveId];
-        content[kChanged] = true;
+        this.cli.error(`CVE ID for vulnerability https://hackerone.com/reports/${report.id} not found`);
+        process.exit(1);
       }
       template += `## ${report.title} (${cveId}) - (${report.severity.rating})\n\n`;
       if (!report.summary) {
-        const fetchIt = await this.cli.prompt(`Summary missing for vulnerability https://hackerone.com/reports/${report.id} ${report.title}.\
- Do you want to try fetch it from HackerOne??`, {
-          questionType: 'confirm',
-          defaultAnswer: true
-        });
-
-        if (fetchIt) {
-          report.summary = await getSummary(report.id, this.req);
-          content[kChanged] = true;
-        }
-
-        if (!report.summary) {
-          this.cli.error(`Summary missing for vulnerability https://hackerone.com/reports/${report.id} ${report.title}. Please create it before continuing.`);
-          process.exit(1);
-        }
+        this.cli.error(`Summary missing for vulnerability https://hackerone.com/reports/${report.id} ${report.title}. Please create it before continuing.`);
+        process.exit(1);
       }
+
       template += `${report.summary}\n\n`;
       const releaseLines = report.affectedVersions.join(', ');
       template += `Impact:\n\n- This vulnerability affects all users\
  in active release lines: ${releaseLines}\n\n`;
       if (!report.patchAuthors) {
-        const author = await this.cli.prompt(`Who fixed vulnerability https://hackerone.com/reports/${report.id} ${report.title}? If multiple use & as separator`, {
-          questionType: 'input',
-          defaultAnswer: 'TBD'
-        });
-        report.patchAuthors = author.split('&').map((p) => p.trim());
-        content[kChanged] = true;
+        this.cli.error(`Missing patch author for vulnerability https://hackerone.com/reports/${report.id} ${report.title}`);
+        process.exit(1);
       }
       template += `Thank you, to ${report.reporter} for reporting this vulnerability\
  and thank you ${report.patchAuthors.join(' and ')} for fixing it.\n\n`;


### PR DESCRIPTION
We have a CI to check all missing fields before running post-release

Refs: https://github.com/nodejs/security-wg/issues/860