### PR TITLE
fix: handle dependencies empty on sec release blog

### DIFF
--- a/lib/security_blog.js
+++ b/lib/security_blog.js
@@ -253,9 +253,10 @@ export default class SecurityBlog {
   }
 
   getDependencyUpdatesTemplate(dependencyUpdates) {
-    if (!dependencyUpdates) return '';
-    let template = 'This security release includes the following dependency' +
-      ' updates to address public vulnerabilities:\n\n';
+    if (typeof dependencyUpdates !== 'object') return '';
+    if (Object.keys(dependencyUpdates).length === 0) return '';
+    let template = '\nThis security release includes the following dependency' +
+      ' updates to address public vulnerabilities:\n';
     for (const dependencyUpdate of Object.values(dependencyUpdates)) {
       for (const dependency of dependencyUpdate) {
         const title = dependency.title.substring(dependency.title.indexOf(':') + ':'.length).trim();


### PR DESCRIPTION
Refs: https://github.com/nodejs/security-wg/issues/860