### PR TITLE
feat: use sec release template in PR description

### DIFF
--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -37,22 +37,15 @@ export default class PrepareSecurityRelease {
     const createVulnerabilitiesJSON = await this.promptVulnerabilitiesJSON();
 
     let securityReleasePRUrl;
+    const content = await this.buildDescription(releaseDate, securityReleasePRUrl);
     if (createVulnerabilitiesJSON) {
-      securityReleasePRUrl = await this.startVulnerabilitiesJSONCreation(releaseDate);
+      securityReleasePRUrl = await this.startVulnerabilitiesJSONCreation(releaseDate, content);
     }
-
-    const createIssue = await this.promptCreateRelaseIssue();
-
-    if (createIssue) {
-      const content = await this.buildIssue(releaseDate, securityReleasePRUrl);
-      await createIssue(
-        this.title, content, this.repository, { cli: this.cli, repository: this.repository });
-    };
 
     this.cli.ok('Done!');
   }
 
-  async startVulnerabilitiesJSONCreation(releaseDate) {
+  async startVulnerabilitiesJSONCreation(releaseDate, content) {
     // checkout on the next-security-release branch
     checkoutOnSecurityReleaseBranch(this.cli, this.repository);
 
@@ -87,7 +80,7 @@ export default class PrepareSecurityRelease {
     if (!createPr) return;
 
     // create pr on the security-release repo
-    return this.createPullRequest();
+    return this.createPullRequest(content);
   }
 
   promptCreatePR() {
@@ -143,11 +136,9 @@ export default class PrepareSecurityRelease {
       { defaultAnswer: true });
   }
 
-  async buildIssue(releaseDate, securityReleasePRUrl = PLACEHOLDERS.vulnerabilitiesPRURL) {
+  async buildDescription() {
     const template = await this.getSecurityIssueTemplate();
-    const content = template.replace(PLACEHOLDERS.releaseDate, releaseDate)
-      .replace(PLACEHOLDERS.vulnerabilitiesPRURL, securityReleasePRUrl);
-    return content;
+    return template;
   }
 
   async chooseReports() {
@@ -185,11 +176,11 @@ export default class PrepareSecurityRelease {
     return fullPath;
   }
 
-  async createPullRequest() {
+  async createPullRequest(content) {
     const { owner, repo } = this.repository;
     const response = await this.req.createPullRequest(
       this.title,
-      'List of vulnerabilities to be included in the next security release',
+      content ?? 'List of vulnerabilities to be included in the next security release',
       {
         owner,
         repo,

--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -6,7 +6,6 @@ import {
   NEXT_SECURITY_RELEASE_BRANCH,
   NEXT_SECURITY_RELEASE_FOLDER,
   NEXT_SECURITY_RELEASE_REPOSITORY,
-  PLACEHOLDERS,
   checkoutOnSecurityReleaseBranch,
   commitAndPushVulnerabilitiesJSON,
   validateDate,


### PR DESCRIPTION
Refs: https://github.com/nodejs-private/security-release/issues/35

I have also removed the need to create the Next Security Release issue. We'll use only the PR as tracking.

The https://github.com/nodejs/node/pull/53877 needs to land first.