### PR TITLE
fix: listr overriding parent task

### DIFF
--- a/lib/update-v8/applyNodeChanges.js
+++ b/lib/update-v8/applyNodeChanges.js
@@ -1,7 +1,5 @@
 import path from 'node:path';
 
-import { Listr } from 'listr2';
-
 import {
   getNodeV8Version,
   filterForVersion,
@@ -19,10 +17,10 @@ const nodeChanges = [
 export default function applyNodeChanges() {
   return {
     title: 'Apply Node-specific changes',
-    task: async(ctx) => {
+    task: async(ctx, task) => {
       const v8Version = await getNodeV8Version(ctx.nodeDir);
       const list = filterForVersion(nodeChanges, v8Version);
-      return new Listr(list.map((change) => change.task()));
+      return task.newListr(list.map((change) => change.task()));
     }
   };
 }

--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -4,7 +4,6 @@ import {
 } from 'node:fs';
 
 import inquirer from 'inquirer';
-import { Listr } from 'listr2';
 import { ListrEnquirerPromptAdapter } from '@listr2/prompt-adapter-enquirer';
 
 import { shortSha } from '../utils.js';
@@ -50,8 +49,8 @@ export function doBackport(options) {
 
   return {
     title: 'V8 commit backport',
-    task: () => {
-      return new Listr(todo);
+    task: (ctx, task) => {
+      return task.newListr(todo);
     }
   };
 };
@@ -164,8 +163,8 @@ function applyPatches() {
 function applyAndCommitPatches() {
   return {
     title: 'Apply and commit patches to deps/v8',
-    task: (ctx) => {
-      return new Listr(ctx.patches.map(applyPatchTask));
+    task: (ctx, task) => {
+      return task.newListr(ctx.patches.map(applyPatchTask));
     }
   };
 }
@@ -173,7 +172,7 @@ function applyAndCommitPatches() {
 function applyPatchTask(patch) {
   return {
     title: `Commit ${shortSha(patch.sha)}`,
-    task: (ctx) => {
+    task: (ctx, task) => {
       const todo = [
         {
           title: 'Apply patch',
@@ -188,7 +187,7 @@ function applyPatchTask(patch) {
         }
       }
       todo.push(commitPatch(patch));
-      return new Listr(todo);
+      return task.newListr(todo);
     }
   };
 }

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -1,8 +1,6 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
-import { Listr } from 'listr2';
-
 import { getCurrentV8Version } from './common.js';
 import {
   getNodeV8Version,
@@ -19,8 +17,8 @@ import { forceRunAsync } from '../run.js';
 export default function majorUpdate() {
   return {
     title: 'Major V8 update',
-    task: () => {
-      return new Listr([
+    task: (ctx, task) => {
+      return task.newListr([
         getCurrentV8Version(),
         checkoutBranch(),
         removeDepsV8(),

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -2,8 +2,6 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
-import { Listr } from 'listr2';
-
 import { getCurrentV8Version } from './common.js';
 import { isVersionString } from './util.js';
 import { forceRunAsync } from '../run.js';
@@ -11,8 +9,8 @@ import { forceRunAsync } from '../run.js';
 export default function minorUpdate() {
   return {
     title: 'Minor V8 update',
-    task: () => {
-      return new Listr([
+    task: (ctx, task) => {
+      return task.newListr([
         getCurrentV8Version(),
         getLatestV8Version(),
         doMinorUpdate()

--- a/lib/update-v8/updateV8Clone.js
+++ b/lib/update-v8/updateV8Clone.js
@@ -1,15 +1,13 @@
 import { promises as fs } from 'node:fs';
 
-import { Listr } from 'listr2';
-
 import { v8Git } from './constants.js';
 import { forceRunAsync } from '../run.js';
 
 export default function updateV8Clone() {
   return {
     title: 'Update local V8 clone',
-    task: () => {
-      return new Listr([fetchOrigin(), createClone()]);
+    task: (ctx, task) => {
+      return task.newListr([fetchOrigin(), createClone()]);
     }
   };
 };

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -1,15 +1,13 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
-import { Listr } from 'listr2';
-
 import { getNodeV8Version } from './util.js';
 
 export default function updateVersionNumbers() {
   return {
     title: 'Update version numbers',
-    task: () => {
-      return new Listr([resetEmbedderString(), bumpNodeModule()]);
+    task: (ctx, task) => {
+      return task.newListr([resetEmbedderString(), bumpNodeModule()]);
     }
   };
 };


### PR DESCRIPTION
Whenever there was a conflict, it was not pausing the previous operation. 

Example repro is

```
git node v8 backport 46ebf52481965305f82a4b75e724282c2ab26a17
```