### PR TITLE
fix(ncu-ci): use correct Jenkins URL to start builds

### DIFF
--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -11,10 +11,10 @@ import PRChecker from '../pr_checker.js';
 
 export const CI_CRUMB_URL = `https://${CI_DOMAIN}/crumbIssuer/api/json`;
 const CI_PR_NAME = CI_TYPES.get(CI_TYPES_KEYS.PR).jobName;
-export const CI_PR_URL = `https://${CI_DOMAIN}/job/${CI_PR_NAME}/build`;
+export const CI_PR_URL = `https://${CI_DOMAIN}/job/${CI_PR_NAME}/buildWithParameters`;
 
 const CI_V8_NAME = CI_TYPES.get(CI_TYPES_KEYS.V8).jobName;
-export const CI_V8_URL = `https://${CI_DOMAIN}/job/${CI_V8_NAME}/build`;
+export const CI_V8_URL = `https://${CI_DOMAIN}/job/${CI_V8_NAME}/buildWithParameters`;
 
 export class RunPRJob {
   constructor(cli, request, owner, repo, prid, certifySafe) {


### PR DESCRIPTION
I found the solution on https://stackoverflow.com/questions/55533294/getting-400-this-page-expects-a-form-submission-when-making-a-rest-call-to-tri

I don't know how it has worked before nor why it suddenly started to fail.