### PR TITLE
feat: add warning when fail on all platforms

### DIFF
--- a/lib/ci/build-types/citgm_comparison_build.js
+++ b/lib/ci/build-types/citgm_comparison_build.js
@@ -44,6 +44,7 @@ export class CITGMComparisonBuild {
     const { failures: comparisonFailures } = comparisonBuild.results;
 
     const failures = {};
+    let allPlatformFailures;
     for (const platform in comparisonFailures) {
       // Account for no failure on this platform, or different platform.
       if (!Object.prototype.hasOwnProperty.call(baseFailures, platform)) {
@@ -66,11 +67,18 @@ export class CITGMComparisonBuild {
       if (newFailures.length !== 0) {
         result = statusType.FAILURE;
       }
-
+      if (allPlatformFailures === undefined) {
+        allPlatformFailures = newFailures;
+      } else if (allPlatformFailures.length > 0) {
+        allPlatformFailures = allPlatformFailures.filter(f => {
+          return newFailures.includes(f);
+        });
+      }
       failures[platform] = newFailures;
     }
 
     this.results.failures = failures;
+    this.results.allPlatformFailures = allPlatformFailures;
     this.result = result;
 
     return result;
@@ -124,6 +132,12 @@ export class CITGMComparisonBuild {
     const str = `${totalFailures} failures in ${cID} not present in ${bID}`;
     cli.log(`${statusType.FAILURE}: ${str}\n\n`);
     console.table(output);
+    if (
+      results.allPlatformFailures &&
+      results.allPlatformFailures.length) {
+      const failures = results.allPlatformFailures.join(', ');
+      console.warn(`These modules failed in all platforms: ${failures}`);
+    }
   }
 
   formatAsJson() {


### PR DESCRIPTION
Motived by the recent regression on Node.js 22.7.0. Apparently, the CITGM did catch the potential regression on `throughv` package. But, due to the number of failures on CITGM, I somehow missed this module in my analysis: https://github.com/nodejs/node/pull/54452#issuecomment-2302202292.

So, this PR makes sure to include a warning whenever a module fails in **all platforms**. So, the previous CITGM comparison would tell the following:

```
➜  node-core-utils (improve-citgm-summary) ./bin/ncu-ci.js citgm 3468 3471                                                                                                                                                                                ✭ ✱
--------------------------------------------------------------------------------
[1/1] Running CITGM: 3468
--------------------------------------------------------------------------------
✔  Summary data downloaded
✔  Results data downloaded
✔  Summary data downloaded
✔  Results data downloaded
----------------------------------- Summary ------------------------------------
Result     FAILURE
URL        https://ci.nodejs.org/job/citgm-smoker/3468/
Source     https://github.com/nodejs/node/pull/54123/
Commit     [b096e41b48ef] 2024-08-06, Version 22.6.0 (Current)
Date       2024-08-05 14:23:50 -0300
Author     Rafael Gonzaga <rafael.nunu@hotmail.com>
----------------------------------- Summary ------------------------------------
Result     FAILURE
URL        https://ci.nodejs.org/job/citgm-smoker/3471/
Source     https://github.com/nodejs/node/pull/54452/
Commit     [56a56628ea55] 2024-08-20, Version 22.7.0 (Current)
Date       2024-08-19 23:43:40 -0300
Author     Rafael Gonzaga <rafael.nunu@hotmail.com>
----------------------------------- Results ------------------------------------



FAILURE: 84 failures in 3471 not present in 3468


┌────────────────────────┬────────────────────────────────┬────────────────────────────────┬──────────────────────────┬─────────────────────┬────────────────────────────────┬──────────────────────────┬─────────────────────────────┬─────────────────────┬──────────────────────────┬───────────────────┬─────────────────────┬──────────────────────┬───────────────────┬──────────────────┐
│ (index)                │ 0                              │ 1                              │ 2                        │ 3                   │ 4                              │ 5                        │ 6                           │ 7                   │ 8                        │ 9                 │ 10                  │ 11                   │ 12                │ 13               │
├────────────────────────┼────────────────────────────────┼────────────────────────────────┼──────────────────────────┼─────────────────────┼────────────────────────────────┼──────────────────────────┼─────────────────────────────┼─────────────────────┼──────────────────────────┼───────────────────┼─────────────────────┼──────────────────────┼───────────────────┼──────────────────┤
│ alpine-latest-x64      │ '@babel/core-v7.25.2'          │ '@yarnpkg/cli'                 │ 'cheerio-v1.0.0'         │ 'fastify-v4.28.0'   │ 'import-in-the-middle-v1.11.0' │ 'is-core-module-v2.15.0' │ 'jest-v0.0.0'               │ 'lru-cache-v11.0.0' │ 'serialport-v12.0.0'     │ 'throughv-v1.0.4' │ 'undici-v6.19.8'    │                      │                   │                  │
│ debian11-x64           │ '@babel/core-v7.25.2'          │ 'cheerio-v1.0.0'               │ 'is-core-module-v2.15.0' │ 'jest-v0.0.0'       │ 'lru-cache-v11.0.0'            │ 'serialport-v12.0.0'     │ 'throughv-v1.0.4'           │ 'undici-v6.19.8'    │                          │                   │                     │                      │                   │                  │
│ aix72-ppc64            │ 'import-in-the-middle-v1.11.0' │ 'is-core-module-v2.15.0'       │ 'throughv-v1.0.4'        │ 'undici-v6.19.8'    │                                │                          │                             │                     │                          │                   │                     │                      │                   │                  │
│ rhel8-ppc64le          │ 'cheerio-v1.0.0'               │ 'import-in-the-middle-v1.11.0' │ 'is-core-module-v2.15.0' │ 'lru-cache-v11.0.0' │ 'path-to-regexp-v7.1.0'        │ 'sax-v1.4.1'             │ 'throughv-v1.0.4'           │ 'undici-v6.19.8'    │                          │                   │                     │                      │                   │                  │
│ rhel8-x64              │ '@babel/core-v7.25.2'          │ 'cheerio-v1.0.0'               │ 'is-core-module-v2.15.0' │ 'jest-v0.0.0'       │ 'lru-cache-v11.0.0'            │ 'serialport-v12.0.0'     │ 'throughv-v1.0.4'           │ 'undici-v6.19.8'    │                          │                   │                     │                      │                   │                  │
│ osx11-x64              │ '@babel/core-v7.25.2'          │ 'cheerio-v1.0.0'               │ 'is-core-module-v2.15.0' │ 'lru-cache-v11.0.0' │ 'serialport-v12.0.0'           │ 'throughv-v1.0.4'        │ 'undici-v6.19.8'            │                     │                          │                   │                     │                      │                   │                  │
│ fedora-last-latest-x64 │ '@babel/core-v7.25.2'          │ 'cheerio-v1.0.0'               │ 'is-core-module-v2.15.0' │ 'jest-v0.0.0'       │ 'lru-cache-v11.0.0'            │ 'serialport-v12.0.0'     │ 'throughv-v1.0.4'           │ 'undici-v6.19.8'    │                          │                   │                     │                      │                   │                  │
│ rhel8-s390x            │ 'cheerio-v1.0.0'               │ 'import-in-the-middle-v1.11.0' │ 'is-core-module-v2.15.0' │ 'lru-cache-v11.0.0' │ 'path-to-regexp-v7.1.0'        │ 'throughv-v1.0.4'        │ 'underscore-v1.13.7'        │ 'undici-v6.19.8'    │                          │                   │                     │                      │                   │                  │
│ fedora-latest-x64      │ '@babel/core-v7.25.2'          │ '@hapi/shot-v6.0.1'            │ '@yarnpkg/cli-v4.4.0'    │ 'cheerio-v1.0.0'    │ 'crc32-stream-v6.0.0'          │ 'csv-parser-v3.0.0'      │ 'flush-write-stream-v2.0.0' │ 'from2-v2.3.0'      │ 'is-core-module-v2.15.0' │ 'jest-v0.0.0'     │ 'lru-cache-v11.0.0' │ 'serialport-v12.0.0' │ 'throughv-v1.0.4' │ 'undici-v6.19.8' │
│ debian12-x64           │ '@babel/core-v7.25.2'          │ 'cheerio-v1.0.0'               │ 'is-core-module-v2.15.0' │ 'jest-v0.0.0'       │ 'lru-cache-v11.0.0'            │ 'serialport-v12.0.0'     │ 'throughv-v1.0.4'           │ 'undici-v6.19.8'    │                          │                   │                     │                      │                   │                  │
└────────────────────────┴────────────────────────────────┴────────────────────────────────┴──────────────────────────┴─────────────────────┴────────────────────────────────┴──────────────────────────┴─────────────────────────────┴─────────────────────┴──────────────────────────┴───────────────────┴─────────────────────┴──────────────────────┴───────────────────┴──────────────────┘
These modules failed in all platforms: is-core-module-v2.15.0,throughv-v1.0.4,undici-v6.19.8
```

@nodejs/releasers 

