### PR TITLE
fix(actions): add appropriate permissions for release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As it currently stands, this workflow is failing due to lack of permissions. This PR remedies that by given the workflow the permissions required to update releases.