### PR TITLE
fix(ncu-ci): fix cache and stats option, and use tmpdir for cache

### DIFF
--- a/bin/ncu-ci.js
+++ b/bin/ncu-ci.js
@@ -77,12 +77,13 @@ const args = yargs(hideBin(process.argv))
         })
         .option('stats', {
           default: false,
+          type: 'boolean',
           describe: 'Aggregate the results'
         })
         .option('cache', {
           default: false,
-          describe: 'Cache the responses from Jenkins in .ncu/cache/ under' +
-                    ' the node-core-utils installation directory'
+          type: 'boolean',
+          describe: 'Cache the responses from Jenkins in $tmpdir/ncu/cache for testing'
         })
         .option('limit', {
           default: 99,
@@ -199,13 +200,14 @@ const args = yargs(hideBin(process.argv))
     builder: (yargs) => {
       yargs
         .option('stats', {
+          type: 'boolean',
           default: false,
           describe: 'Aggregate the results'
         })
         .option('cache', {
+          type: 'boolean',
           default: false,
-          describe: 'Cache the responses from Jenkins in .ncu/cache/ under' +
-                    ' the node-core-utils installation directory'
+          describe: 'Cache the responses from Jenkins in $tmpdir/ncu/cache for testing'
         })
         .option('limit', {
           default: 15,

--- a/docs/ncu-ci.md
+++ b/docs/ncu-ci.md
@@ -111,7 +111,7 @@ Possible use cases:
    is run, it picks up cached data written on disk for jobs whose results
    are known.
 
-   Note: results are cached in `${ncu_installation_path}/.ncu/cache`, so you
+   Note: results are cached in `$tmpdir/ncu/cache`, so you
    may want to clean it up from time to time.
 
    ```

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import os from 'node:os';
 
 import { writeJson, readJson, writeFile, readFile } from './file.js';
 
@@ -8,17 +8,15 @@ function isAsync(fn) {
   return fn[Symbol.toStringTag] === 'AsyncFunction';
 }
 
-const parentDir = fileURLToPath(new URL('..', import.meta.url));
-
 export default class Cache {
   constructor(dir) {
-    this.dir = dir || this.computeCacheDir(parentDir);
+    this.dir = dir || this.computeCacheDir(os.tmpdir());
     this.originals = {};
     this.disabled = true;
   }
 
   computeCacheDir(base) {
-    return path.join(base, '.ncu', 'cache');
+    return path.join(base, 'ncu', 'cache');
   }
 
   disable() {


### PR DESCRIPTION
Previously --cache and --stats were broken (by probably one of the yargs updates) and forced users to use `--stats=true` etc.

Also change the cache location to tmpdir.