### PR TITLE
fix(v8): handle error in git apply

### DIFF
--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
@@ -61,29 +60,21 @@ function doMinorUpdate() {
 }
 
 async function applyPatch(ctx, latestStr) {
-  const diff = spawn(
+  const diff = await forceRunAsync(
     'git',
     ['format-patch', '--stdout', `${ctx.currentVersion}...${latestStr}`],
-    { cwd: ctx.v8Dir, stdio: ['ignore', 'pipe', 'ignore'] }
+    { captureStdout: true, ignoreFailure: false, spawnArgs: { cwd: ctx.v8Dir } }
   );
   try {
     await forceRunAsync('git', ['apply', '--directory', 'deps/v8'], {
+      input: diff,
       ignoreFailure: false,
-      spawnArgs: {
-        cwd: ctx.nodeDir,
-        stdio: [diff.stdout, 'ignore', 'ignore']
-      }
+      spawnArgs: { cwd: ctx.nodeDir }
     });
   } catch (e) {
     const file = path.join(ctx.nodeDir, `${latestStr}.diff`);
     await fs.writeFile(file, diff);
     throw new Error(`Could not apply patch.\n${e}\nDiff was stored in ${file}`);
-  }
-  if (diff.exitCode !== 0) {
-    const err = new Error(`git format-patch failed: ${diff.exitCode}`);
-    err.code = diff.exitCode;
-    err.messageOnly = true;
-    throw err;
   }
 }
 


### PR DESCRIPTION
Capture stdout so it can be used in the catch block when there is a conflict.

Fixes: https://github.com/nodejs/node-core-utils/issues/850
