### PR TITLE
fix(git-node): ignore all non-gha nodes when checking for GitHub CI

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -374,7 +374,7 @@ export default class PRChecker {
     // GitHub new Check API
     for (const { status, conclusion, app } of checkSuites.nodes) {
       if (app.slug !== 'github-actions') {
-        // Ignore Dependabot and Codecov check suites.
+        // Ignore all non-github check suites, such as Dependabot and Codecov.
         // They are expected to show up on PRs whose head branch is not on a
         // fork and never complete.
         continue;

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -29,7 +29,6 @@ const GITHUB_SUCCESS_CONCLUSIONS = ['SUCCESS', 'NEUTRAL', 'SKIPPED'];
 const FAST_TRACK_RE = /^Fast-track has been requested by @(.+?)\. Please 👍 to approve\.$/;
 const FAST_TRACK_MIN_APPROVALS = 2;
 const GIT_CONFIG_GUIDE_URL = 'https://github.com/nodejs/node/blob/99b1ada/doc/guides/contributing/pull-requests.md#step-1-fork';
-const IGNORED_CHECK_SLUGS = ['dependabot', 'codecov'];
 
 // eslint-disable-next-line no-extend-native
 Array.prototype.findLastIndex ??= function findLastIndex(fn) {
@@ -374,9 +373,10 @@ export default class PRChecker {
 
     // GitHub new Check API
     for (const { status, conclusion, app } of checkSuites.nodes) {
-      if (app && IGNORED_CHECK_SLUGS.includes(app.slug)) {
+      if (app.slug !== 'github-actions') {
         // Ignore Dependabot and Codecov check suites.
-        // They are expected to show up sometimes and never complete.
+        // They are expected to show up on PRs whose head branch is not on a
+        // fork and never complete.
         continue;
       }
 

--- a/test/fixtures/github-ci/both-apis-failure.json
+++ b/test/fixtures/github-ci/both-apis-failure.json
@@ -13,6 +13,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "FAILURE"
           }

--- a/test/fixtures/github-ci/both-apis-success.json
+++ b/test/fixtures/github-ci/both-apis-success.json
@@ -13,6 +13,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "SUCCESS"
           }

--- a/test/fixtures/github-ci/check-suite-failure.json
+++ b/test/fixtures/github-ci/check-suite-failure.json
@@ -10,6 +10,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "FAILURE"
           }

--- a/test/fixtures/github-ci/check-suite-pending.json
+++ b/test/fixtures/github-ci/check-suite-pending.json
@@ -10,6 +10,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "IN_PROGRESS"
           }
         ]

--- a/test/fixtures/github-ci/check-suite-skipped.json
+++ b/test/fixtures/github-ci/check-suite-skipped.json
@@ -10,6 +10,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "SKIPPED"
           }

--- a/test/fixtures/github-ci/check-suite-success.json
+++ b/test/fixtures/github-ci/check-suite-success.json
@@ -10,6 +10,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "SUCCESS"
           }

--- a/test/fixtures/github-ci/status-failure-check-suite-succeed.json
+++ b/test/fixtures/github-ci/status-failure-check-suite-succeed.json
@@ -13,6 +13,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "SUCCESS"
           }

--- a/test/fixtures/github-ci/status-succeed-check-suite-failure.json
+++ b/test/fixtures/github-ci/status-succeed-check-suite-failure.json
@@ -13,6 +13,7 @@
       "checkSuites": {
         "nodes": [
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "FAILURE"
           }

--- a/test/fixtures/github-ci/success-dependabot-queued.json
+++ b/test/fixtures/github-ci/success-dependabot-queued.json
@@ -17,6 +17,7 @@
             "conclusion": null
           },
           {
+            "app": { "slug": "github-actions" },
             "status": "COMPLETED",
             "conclusion": "SUCCESS"
           }


### PR DESCRIPTION
Implements https://github.com/nodejs/node-core-utils/pull/838#discussion_r1706574660. The problem has come back now that we have a new `jenkins-node-js-ci` (see https://github.com/nodejs/admin/issues/916), and IMO it only makes sense to check for GHA-related jobs only when checking the state of the GitHub CI.