### PR TITLE
fix(git-node): do not assume release commit will conflict

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -147,23 +147,31 @@ export default class ReleasePromotion extends Session {
       cli.warn(`Aborting release promotion for version ${version}`);
       throw new Error('Aborted');
     }
-    await this.cherryPickToDefaultBranch();
+    const appliedCleanly = await this.cherryPickToDefaultBranch();
 
-    // Update `node_version.h`
-    await forceRunAsync('git', ['checkout', 'HEAD', '--', 'src/node_version.h'],
+    // Ensure `node_version.h`'s `NODE_VERSION_IS_RELEASE` bit is not updated
+    await forceRunAsync('git',
+      ['checkout', appliedCleanly ? 'HEAD^' : 'HEAD', '--', 'src/node_version.h'],
       { ignoreFailure: false });
 
-    // There will be remaining cherry-pick conflicts the Releaser will
-    // need to resolve, so confirm they've been resolved before
-    // proceeding with next steps.
-    cli.separator();
-    cli.info('Resolve the conflicts and commit the result');
-    cli.separator();
-    const didResolveConflicts = await cli.prompt(
-      'Finished resolving cherry-pick conflicts?', { defaultAnswer: true });
-    if (!didResolveConflicts) {
-      cli.warn(`Aborting release promotion for version ${version}`);
-      throw new Error('Aborted');
+    if (appliedCleanly) {
+      // There were no conflicts, we have to amend the commit to revert the
+      // `node_version.h` changes.
+      await forceRunAsync('git', ['commit', ...this.gpgSign, '--amend', '--no-edit', '-n'],
+        { ignoreFailure: false });
+    } else {
+      // There will be remaining cherry-pick conflicts the Releaser will
+      // need to resolve, so confirm they've been resolved before
+      // proceeding with next steps.
+      cli.separator();
+      cli.info('Resolve the conflicts and commit the result');
+      cli.separator();
+      const didResolveConflicts = await cli.prompt(
+        'Finished resolving cherry-pick conflicts?', { defaultAnswer: true });
+      if (!didResolveConflicts) {
+        cli.warn(`Aborting release promotion for version ${version}`);
+        throw new Error('Aborted');
+      }
     }
 
     if (existsSync('.git/CHERRY_PICK_HEAD')) {
@@ -488,8 +496,14 @@ export default class ReleasePromotion extends Session {
 
     await this.tryResetBranch();
 
-    // There will be conflicts, we do not want to treat this as a failure.
-    await forceRunAsync('git', ['cherry-pick', ...this.gpgSign, releaseCommitSha],
-      { ignoreFailure: true });
+    // There might be conflicts, we do not want to treat this as a hard failure,
+    // but we want to retain that information.
+    try {
+      await forceRunAsync('git', ['cherry-pick', ...this.gpgSign, releaseCommitSha],
+        { ignoreFailure: false });
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -150,9 +150,12 @@ export default class ReleasePromotion extends Session {
     const appliedCleanly = await this.cherryPickToDefaultBranch();
 
     // Ensure `node_version.h`'s `NODE_VERSION_IS_RELEASE` bit is not updated
-    await forceRunAsync('git',
-      ['checkout', appliedCleanly ? 'HEAD^' : 'HEAD', '--', 'src/node_version.h'],
-      { ignoreFailure: false });
+    await forceRunAsync('git', ['checkout',
+      appliedCleanly
+        ? 'HEAD^' // In the absence of conflict, the top of the remote branch is the commit before.
+        : 'HEAD', // In case of conflict, HEAD is still the top of the remove branch.
+      '--', 'src/node_version.h'],
+    { ignoreFailure: false });
 
     if (appliedCleanly) {
       // There were no conflicts, we have to amend the commit to revert the


### PR DESCRIPTION
As I was testing `git node release --promote` with https://github.com/nodejs/node/pull/55879, I realized the assumption that a release commit would necessarily conflict when cherry-picked to the default branch is wrong for the case of semver-patch releases.