### PR TITLE
chore: update codecov action to v5

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,4 +29,4 @@ jobs:
       test-command: npm run coverage:ci
       post-test-steps: |
         - name: Upload coverage report to Codecov
-          uses: codecov/codecov-action@v3
+          uses: codecov/codecov-action@v5


### PR DESCRIPTION
Tokenless uploads are supported again.

Refs: https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token
