### PR TITLE
feat: use nodejs.org folder a base for --pre-release

### DIFF
--- a/components/git/security.js
+++ b/components/git/security.js
@@ -29,8 +29,8 @@ const securityOptions = {
     type: 'string'
   },
   'pre-release': {
-    describe: 'Create the pre-release announcement',
-    type: 'boolean'
+    describe: 'Create the pre-release announcement to the given nodejs.org folder',
+    type: 'string'
   },
   'notify-pre-release': {
     describe: 'Notify the community about the security release',
@@ -73,7 +73,7 @@ export function builder(yargs) {
       'git node security --remove-report=H1-ID',
       'Removes the Hackerone report based on ID provided from vulnerabilities.json'
     ).example(
-      'git node security --pre-release',
+      'git node security --pre-release="../nodejs.org/"',
       'Create the pre-release announcement on the Nodejs.org repo'
     ).example(
       'git node security --notify-pre-release',
@@ -149,11 +149,12 @@ async function updateReleaseDate(argv) {
   return update.updateReleaseDate(releaseDate);
 }
 
-async function createPreRelease() {
+async function createPreRelease(argv) {
+  const nodejsOrgFolder = argv['pre-release'];
   const logStream = process.stdout.isTTY ? process.stdout : process.stderr;
   const cli = new CLI(logStream);
   const preRelease = new SecurityBlog(cli);
-  return preRelease.createPreRelease();
+  return preRelease.createPreRelease(nodejsOrgFolder);
 }
 
 async function requestCVEs() {

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -339,7 +339,7 @@ ncu-config set waitTimeMultiApproval 48
 
 ## `git node v8`
 
-Update or patch the V8 engine.  
+Update or patch the V8 engine.
 This tool will maintain a clone of the V8 repository in `~/.update-v8/v8`
 if it's used without `--v8-dir`.
 
@@ -376,7 +376,7 @@ Options:
 ### `git node v8 minor`
 
 Compare current V8 version with latest upstream of the same major. Applies a
-patch if necessary.  
+patch if necessary.
 If the `git apply` command fails, a patch file will be written in the Node.js
 clone directory.
 
@@ -476,7 +476,7 @@ This command creates a pre-release announcement for the security release.
 Example:
 
 ```sh
-  git node security --pre-release
+  git node security --pre-release="/path/to/nodejs.org"
 ```
 
 ### `git node security --add-report=report-id`

--- a/lib/security_blog.js
+++ b/lib/security_blog.js
@@ -16,7 +16,7 @@ const kChanged = Symbol('changed');
 export default class SecurityBlog extends SecurityRelease {
   req;
 
-  async createPreRelease() {
+  async createPreRelease(nodejsOrgFolder) {
     const { cli } = this;
 
     // checkout on security release branch
@@ -45,11 +45,30 @@ export default class SecurityBlog extends SecurityRelease {
     };
     const month = releaseDate.toLocaleString('en-US', { month: 'long' }).toLowerCase();
     const year = releaseDate.getFullYear();
-    const fileName = `${month}-${year}-security-releases.md`;
+    const fileName = `${month}-${year}-security-releases`;
+    const fileNameExt = fileName + '.md';
     const preRelease = this.buildPreRelease(template, data);
-    const file = path.join(process.cwd(), fileName);
+
+    const pathToBlogPosts = 'apps/site/pages/en/blog/release';
+    const pathToBannerJson = 'apps/site/site.json';
+
+    const file = path.resolve(process.cwd(), nodejsOrgFolder, pathToBlogPosts, fileNameExt);
+    const site = path.resolve(process.cwd(), nodejsOrgFolder, pathToBannerJson);
+    const siteJson = JSON.parse(fs.readFileSync(site));
+
+    const endDate = new Date(data.annoucementDate);
+    endDate.setDate(endDate.getDate() + 7);
+    const capitalizedMonth = month[0].toUpperCase() + month.slice(1);
+    siteJson.websiteBanners.index = {
+      startDate: data.annoucementDate,
+      endDate: endDate.toISOString(),
+      text: `${capitalizedMonth} Security Release is available`,
+      link: `https://nodejs.org/en/blog/vulnerability/${fileName}`,
+      type: 'warning'
+    };
     fs.writeFileSync(file, preRelease);
-    cli.ok(`Pre-release announcement file created at ${file}`);
+    fs.writeFileSync(site, JSON.stringify(siteJson, null, 2));
+    cli.ok(`Announcement file created and banner has been updated. Folder: ${nodejsOrgFolder}`);
   }
 
   async createPostRelease() {


### PR DESCRIPTION
Fixes: https://github.com/nodejs-private/security-release/issues/15 & https://github.com/nodejs-private/security-release/issues/18

```
➜  security-release (next-security-release) ../node-core-utils/bin/git-node.js security --pre-release='../nodejs.org'                                                                                            ✱
   ℹ  Current branch: next-security-release
--------------------------------------------------------------------------------
✔ When is the security release going to be announced? Enter in YYYY/MM/DD format: 2024/11/28
   ✔  Announcement file created and banner has been updated. Folder: ../nodejs.org
➜  security-release (next-security-release) cd ../nodejs.org                                                                                                                                                     
➜  nodejs.org (main) git status                                                                                                                                                                                
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   apps/site/site.json

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        apps/site/pages/en/blog/release/november-2024-security-releases.md

no changes added to commit (use "git add" and/or "git commit -a")
```

Diff:

```diff
diff --git a/apps/site/site.json b/apps/site/site.json
index 3ed40c4e..50aa0798 100644
--- a/apps/site/site.json
+++ b/apps/site/site.json
@@ -28,10 +28,10 @@
   ],
   "websiteBanners": {
     "index": {
-      "startDate": "2024-07-08T00:00:00.000Z",
-      "endDate": "2024-07-16T23:59:00.000Z",
-      "text": "July Security Release is available",
-      "link": "https://nodejs.org/en/blog/vulnerability/july-2024-security-releases",
+      "startDate": "2024-11-28T03:00:00.000Z",
+      "endDate": "2024-12-05T03:00:00.000Z",
+      "text": "November Security Release is available",
+      "link": "https://nodejs.org/en/blog/vulnerability/november-2024-security-releases",
       "type": "warning"
     }
   },
@@ -45,4 +45,4 @@
       "link": "https://linuxfoundation.surveymonkey.com/r/nodenext10survey24"
     }
   }
-}
+}
\ No newline at end of file
```
