### PR TITLE
fix(git-node): support preparing releases on shallow clones

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -367,6 +367,16 @@ export default class ReleasePreparation extends Session {
       runSync('git', ['fetch', this.upstream, 'tag', '-n', tagName]);
       this.cli.stopSpinner(`Tag fetched: ${tagName}`);
     }
+    try {
+      if (runSync('git', ['describe', '--abbrev=0', '--tags']).trim() !== tagName) {
+        this.cli.warn(`${tagName} is not the closest tag`);
+      }
+    } catch {
+      this.cli.startSpinner(`${tagName} is unreachable from the current HEAD`);
+      runSync('git', ['fetch', '--shallow-exclude', tagName, this.upstream, this.branch]);
+      runSync('git', ['fetch', '--deepen=1', this.upstream, this.branch]);
+      this.cli.stopSpinner('Local clone unshallowed');
+    }
     return tagName;
   }
 


### PR DESCRIPTION
Relevant for the GHA usecase, so we don't have to fetch the whole repo.