### PR TITLE
feat(git-node): verify tag signature during release promotion

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -131,6 +131,7 @@ export default class ReleasePromotion extends Session {
       throw new Error('Aborted');
     }
     await this.secureTagRelease();
+    await this.verifyTagSignature();
 
     // Set up for next release.
     cli.startSpinner('Setting up for next release');
@@ -221,6 +222,28 @@ export default class ReleasePromotion extends Session {
     `}' doc/changelogs/CHANGELOG_V${
       this.versionComponents.major}.md | gh release create v${this.version} --verify-tag --latest${
         this.isLTS ? '=false' : ''} --title=${JSON.stringify(this.releaseTitle)} --notes-file -`);
+  }
+
+  async verifyTagSignature() {
+    const { cli, version } = this;
+    const [needle, haystack] = await Promise.all([forceRunAsync(
+      'git', ['--no-pager',
+        'log', '-1',
+        `refs/tags/v${version}`,
+        '--format=* **%an** <<%ae>>\n  `%GF`'
+      ], { captureStdout: true }), fs.readFile('README.md')]);
+    if (haystack.includes(needle)) {
+      return;
+    }
+    cli.warn('Tag was signed with an undocumented identity/key pair!');
+    cli.info('Expected to find the following entry in the README:');
+    cli.info(needle);
+    cli.info('If you are using a subkey, it might be OK.');
+    cli.info(`Otherwise consider removing the tag (git tag -d v${version
+             }), check your local config, and start the process over.`);
+    if (!await cli.prompt('Do you want to proceed anyway?', { defaultAnswer: false })) {
+      throw new Error('Aborted');
+    }
   }
 
   async verifyPRAttributes() {


### PR DESCRIPTION
Before pushing the tag upstream, we can verify if it's signed with a known identity (name+email address+key combo), as the releaser might be relying on a mailmap entry, which are typically not used when verifying a tag signature (at least not by GitHub web UI).

/cc @nodejs/releasers 