### PR TITLE
Fix `git node release --prepare` update proposal workflow

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -93,9 +93,9 @@ export default class ReleasePreparation extends Session {
     } = this;
 
     // Create new proposal branch.
-    cli.startSpinner(`Creating new proposal branch for ${newVersion}`);
+    cli.startSpinner(`Switching to proposal branch for ${newVersion}`);
     const proposalBranch = await this.createProposalBranch(releaseBranch);
-    cli.stopSpinner(`Created new proposal branch for ${newVersion}`);
+    cli.stopSpinner(`Switched to proposal branch for ${newVersion}`);
 
     const success = await this.cherryPickSecurityPRs(filterLabels);
     if (!success) {
@@ -201,9 +201,9 @@ export default class ReleasePreparation extends Session {
     }
 
     // Create new proposal branch.
-    cli.startSpinner(`Creating new proposal branch for ${newVersion}`);
+    cli.startSpinner(`Switching to proposal branch for ${newVersion}`);
     await this.createProposalBranch();
-    cli.stopSpinner(`Created new proposal branch for ${newVersion}`);
+    cli.stopSpinner(`Switched to proposal branch for ${newVersion}`);
 
     if (this.isLTSTransition) {
       // For releases transitioning into LTS, fetch the new code name.
@@ -535,7 +535,7 @@ export default class ReleasePreparation extends Session {
 
     await runAsync('git', [
       'checkout',
-      '-b',
+      '-B',
       proposalBranch,
       base
     ]);


### PR DESCRIPTION
This allows for updating a proposal once the proposal branch has already been created, PR opened, e.g:

```sh
git checkout v1.x-staging # go back to the staging branch
# make changes, rebase, add more commits, (likely force) push v1.x-staging to upstream
git node release -S --prepare 1.y.z # run release prepare script again
# proposal branch is now ready to be force-pushed to upstream, release commit and changelog are updated
```