### PR TITLE
chore(git-node): Add make lint-md reminder

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -195,6 +195,12 @@ export default class ReleasePromotion extends Session {
       }
     }
 
+    cli.separator();
+    cli.warn('Reminder: Lint markdown files');
+    cli.info('You might need to amend the commit if there are issues:');
+    cli.info('make lint-md');
+    cli.separator();
+
     // Push to the remote the release tag, and default, release, and staging branch.
     await this.pushToRemote(workingOnNewReleaseCommit);
 


### PR DESCRIPTION
After two consecutive releases in which I mistakenly pushed a broken release commit to main, I'm convinced that the process needs improvement.

This PR proposes to add a reminder to `git node release promote` to lint markdown files prior to pushing branches to upstream remote.

Refs: https://github.com/nodejs/node/commit/a344300bfa146fce9d1f20a71b073263a4720eab
Refs: https://github.com/nodejs/node/pull/56508