### PR TITLE
feat: update changelog-maker to a CVE-ID support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@pkgjs/nv": "^0.2.2",
     "branch-diff": "^3.1.1",
     "chalk": "^5.3.0",
-    "changelog-maker": "^4.1.1",
+    "changelog-maker": "^4.3.1",
     "cheerio": "^1.0.0",
     "clipboardy": "^4.0.0",
     "core-validate-commit": "^4.1.0",


### PR DESCRIPTION
Just to guarantee people will be use a version from changelog-maker that supports CVE-ID