### PR TITLE
fix: use vulnerability as folder for post-release announcement

### DIFF
--- a/lib/security_blog.js
+++ b/lib/security_blog.js
@@ -101,7 +101,7 @@ export default class SecurityBlog extends SecurityRelease {
       dependencyUpdates: content.dependencies
     };
 
-    const pathToBlogPosts = path.resolve(nodejsOrgFolder, 'apps/site/pages/en/blog/release');
+    const pathToBlogPosts = path.resolve(nodejsOrgFolder, 'apps/site/pages/en/blog/vulnerability');
     const pathToBannerJson = path.resolve(nodejsOrgFolder, 'apps/site/site.json');
 
     const preReleasePath = path.resolve(pathToBlogPosts, data.slug + '.md');


### PR DESCRIPTION
Follow up https://github.com/nodejs/node-core-utils/pull/887