### PR TITLE
fix(git-node): allow security release promotion

### DIFF
--- a/components/git/release.js
+++ b/components/git/release.js
@@ -112,9 +112,10 @@ function release(state, argv) {
 }
 
 async function main(state, argv, cli, dir) {
-  const prID = /^(?:https:\/\/github\.com\/nodejs\/node\/pull\/)?(\d+)$/.exec(argv.prid);
+  const prID = /^(?:https:\/\/github\.com\/nodejs(-private)?\/node\1\/pull\/)?(\d+)$/.exec(argv.prid);
   if (prID) {
-    argv.prid = Number(prID[1]);
+    if (prID[1]) argv.security = true;
+    argv.prid = Number(prID[2]);
   }
   if (state === PREPARE) {
     const release = new ReleasePreparation(argv, cli, dir);

--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -395,7 +395,7 @@ export default class ReleasePromotion extends Session {
   // Set up the branch so that nightly builds are produced with the next
   // version number and a pre-release tag.
   async setupForNextRelease() {
-    const { versionComponents, prid } = this;
+    const { versionComponents, prid, owner, repo } = this;
 
     // Update node_version.h for next patch release.
     const filePath = path.resolve('src', 'node_version.h');
@@ -426,7 +426,7 @@ export default class ReleasePromotion extends Session {
       '-m',
       `Working on ${workingOnVersion}`,
       '-m',
-      `PR-URL: https://github.com/${this.config.owner}/${this.config.owner}/pull/${prid}`
+      `PR-URL: https://github.com/${owner}/${repo}/pull/${prid}`
     ], { ignoreFailure: false });
     const workingOnNewReleaseCommit = await forceRunAsync('git', ['rev-parse', 'HEAD'],
       { ignoreFailure: false, captureStdout: true });

--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -19,6 +19,10 @@ export default class ReleasePromotion extends Session {
   constructor(argv, req, cli, dir) {
     super(cli, dir, argv.prid);
     this.req = req;
+    if (argv.security) {
+      this.config.owner = 'nodejs-private';
+      this.config.repo = 'node-private';
+    }
     this.dryRun = !argv.run;
     this.isLTS = false;
     this.ltsCodename = '';
@@ -422,7 +426,7 @@ export default class ReleasePromotion extends Session {
       '-m',
       `Working on ${workingOnVersion}`,
       '-m',
-      `PR-URL: https://github.com/nodejs/node/pull/${prid}`
+      `PR-URL: https://github.com/${this.config.owner}/${this.config.owner}/pull/${prid}`
     ], { ignoreFailure: false });
     const workingOnNewReleaseCommit = await forceRunAsync('git', ['rev-parse', 'HEAD'],
       { ignoreFailure: false, captureStdout: true });


### PR DESCRIPTION
In order to promote a security release using this script:

- your local HEAD should be the release proposal commit
- ncu config **upstream** should point to the **public repo** (NOT the private one)

N.B.: At the end of the process, it won't tell you to push to the private repo, until you do that manually the release proposal won't auto-close.