### PR TITLE
lib: use messageonly type when notable-changes sec release

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -481,7 +481,10 @@ export default class ReleasePreparation extends Session {
     const data = await fs.readFile(majorChangelogPath, 'utf8');
     const arr = data.split('\n');
     const allCommits = this.getChangelog();
-    const notableChanges = await this.getBranchDiff({ onlyNotableChanges: true });
+    const notableChanges = await this.getBranchDiff({
+      onlyNotableChanges: true,
+      format: isSecurityRelease ? 'messageonly' : 'markdown',
+    });
     let releaseHeader = `## ${date}, Version ${newVersion}` +
                           ` ${releaseInfo}, @${username}\n`;
     if (isSecurityRelease) {

--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -622,7 +622,7 @@ export default class ReleasePreparation extends Session {
 
     const notableChanges = await this.getBranchDiff({
       onlyNotableChanges: true,
-      format: 'plaintext'
+      format: isSecurityRelease ? 'messageonly' : 'plaintext'
     });
     messageBody.push('Notable changes:\n\n');
     if (isLTSTransition) {


### PR DESCRIPTION
Partially fixes: https://github.com/nodejs-private/security-release/issues/48