### PR TITLE
chore: remove redundant pnpm config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 package-lock=false
-auto-install-peers=true


### PR DESCRIPTION
Remove the redundant pnpm-only `auto-install-peers` config from the `.npmrc` file as it is set to `true` by default now. Removing this also resolves a warning from npm that it is an unknown config option and will stop working in the future.