### PR TITLE
fix(ncu-ci): fetch commits instead of PR metadata

### DIFF
--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -26,7 +26,7 @@ export class RunPRJob {
     this.prData = new PRData({ prid, owner, repo }, cli, request);
     this.certifySafe =
       certifySafe ||
-      Promise.all([this.prData.getReviews(), this.prData.getPR()]).then(() =>
+      Promise.all([this.prData.getReviews(), this.prData.getCommits()]).then(() =>
         (this.certifySafe = new PRChecker(cli, this.prData, request, {}).getApprovedTipOfHead())
       );
   }

--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -531,7 +531,7 @@ export default class PRChecker {
     const { maxCommits } = argv;
 
     if (commits.length === 0) {
-      cli.warn('No commits found');
+      cli.warn('No commits detected');
       return false;
     }
 


### PR DESCRIPTION
I was testing #911, I noticed I would get `No commits found` errors, and indeed it looks like I forgot to change the API call now that we're no longer relying on the PR metadata.