### PR TITLE
feat(git-node): auto-unshallow shallow clones

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -347,7 +347,8 @@ export default class Session {
     const { cli, upstream, branch } = this;
     const branchName = `${upstream}/${branch}`;
     cli.startSpinner(`Bringing ${branchName} up to date...`);
-    await runAsync('git', ['fetch', upstream, branch]);
+    const maybeUnshallow = fs.existsSync('.git/shallow') ? ['--unshallow'] : [];
+    await runAsync('git', ['fetch', ...maybeUnshallow, upstream, branch]);
     cli.stopSpinner(`${branchName} is now up-to-date`);
     const stray = this.getStrayCommits(true);
     if (!stray.length) {


### PR DESCRIPTION
NCU expects the local clone to not be shallow, and throws arguably confusing errors when running `git node land` on a shallow clone. We might pass the correct flag if we detect unshallowness.

For a concrete example, that would allow us to use shallow clone in the CQ, and lazy-unshallow only if there are PRs ready to land (currently, if there's a PRs that was open for more than 2 days, and CI is still running, it will cause CQ to fully clone the repo every 10 minutes for nothing).