### PR TITLE
chore: remove dead code from `PRChecker`

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -30,15 +30,6 @@ const FAST_TRACK_RE = /^Fast-track has been requested by @(.+?)\. Please 👍 to
 const FAST_TRACK_MIN_APPROVALS = 2;
 const GIT_CONFIG_GUIDE_URL = 'https://github.com/nodejs/node/blob/99b1ada/doc/guides/contributing/pull-requests.md#step-1-fork';
 
-// eslint-disable-next-line no-extend-native
-Array.prototype.findLastIndex ??= function findLastIndex(fn) {
-  const reversedIndex = Reflect.apply(
-    Array.prototype.findIndex,
-    this.slice().reverse(),
-    arguments);
-  return reversedIndex === -1 ? -1 : this.length - reversedIndex - 1;
-};
-
 export default class PRChecker {
   /**
    * @param {{}} cli
@@ -49,7 +40,7 @@ export default class PRChecker {
     this.request = request;
     this.data = data;
     const {
-      pr, reviewers, comments, reviews, commits, collaborators
+      pr, reviewers, comments, reviews, commits
     } = data;
     this.reviewers = reviewers;
     this.pr = pr;
@@ -61,9 +52,6 @@ export default class PRChecker {
     this.reviews = reviews;
     this.commits = commits;
     this.argv = argv;
-    this.collaboratorEmails = new Set(
-      Array.from(collaborators).map((c) => c[1].email)
-    );
   }
 
   get waitTimeSingleApproval() {


### PR DESCRIPTION
`findLastIndex` is provided by V8 on all supported Node.js release lines.

`collaboratorEmails` is not read anywhere.