### PR TITLE
feat(ncu-ci): parse comments to find a safe commit

### DIFF
--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -16,6 +16,26 @@ export const CI_PR_URL = `https://${CI_DOMAIN}/job/${CI_PR_NAME}/build`;
 const CI_V8_NAME = CI_TYPES.get(CI_TYPES_KEYS.V8).jobName;
 export const CI_V8_URL = `https://${CI_DOMAIN}/job/${CI_V8_NAME}/build`;
 
+const REQUEST_CI_COMMENT = /^@nodejs-github-bot .+([0-9a-f]{40})$/;
+
+async function findSafeFullCommitSHA(cli, prData, request) {
+  // First, let's check if the head was approved.
+  await Promise.all([prData.getReviews(), prData.getCommits()]);
+
+  const approvedHead = new PRChecker(cli, prData, request, {}).getApprovedTipOfHead();
+  if (approvedHead) return approvedHead;
+
+  // Else, let's find out if a collaborator added a comment with a full commit SHA.
+  await Promise.all([prData.getCollaborators(), prData.getComments()]);
+  const collaborators = Array.from(prData.collaborators.values(),
+    (c) => c.login.toLowerCase());
+  return prData.comments
+    .findLast(c =>
+      collaborators.includes(c.author.login.toLowerCase()) &&
+      REQUEST_CI_COMMENT.test(c.body))
+    ?.body.match(REQUEST_CI_COMMENT)[1];
+}
+
 export class RunPRJob {
   constructor(cli, request, owner, repo, prid, certifySafe) {
     this.cli = cli;
@@ -26,9 +46,7 @@ export class RunPRJob {
     this.prData = new PRData({ prid, owner, repo }, cli, request);
     this.certifySafe =
       certifySafe ||
-      Promise.all([this.prData.getReviews(), this.prData.getCommits()]).then(() =>
-        (this.certifySafe = new PRChecker(cli, this.prData, request, {}).getApprovedTipOfHead())
-      );
+      findSafeFullCommitSHA(cli, this.prData, request).then((h) => (this.certifySafe = h));
   }
 
   async getCrumb() {
@@ -72,6 +90,8 @@ export class RunPRJob {
     const { cli, certifySafe } = this;
 
     if (!(await certifySafe)) {
+      cli.info('If the tip of this PR looks safe, add a comment in the form of:');
+      cli.info('@nodejs-github-bot test <commit-full-sha-or-URL>');
       cli.error('Refusing to run CI on potentially unsafe PR');
       return false;
     }

--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -16,7 +16,7 @@ export const CI_PR_URL = `https://${CI_DOMAIN}/job/${CI_PR_NAME}/build`;
 const CI_V8_NAME = CI_TYPES.get(CI_TYPES_KEYS.V8).jobName;
 export const CI_V8_URL = `https://${CI_DOMAIN}/job/${CI_V8_NAME}/build`;
 
-const REQUEST_CI_COMMENT = /^@nodejs-github-bot .+([0-9a-f]{40})$/;
+const REQUEST_CI_COMMENT = /^@nodejs-github-bot .+([0-9a-f]{40})\.*\n*$/;
 
 async function findSafeFullCommitSHA(cli, prData, request) {
   // First, let's check if the head was approved.

--- a/lib/queries/PRComments.gql
+++ b/lib/queries/PRComments.gql
@@ -9,6 +9,7 @@ query Comments($prid: Int!, $owner: String!, $repo: String!, $after: String) {
         }
         nodes {
           publishedAt
+          body
           bodyText
           author {
             login

--- a/test/unit/ci_start.test.js
+++ b/test/unit/ci_start.test.js
@@ -23,7 +23,7 @@ describe('Jenkins', () => {
   const dummySHA = '51ce389dc1d539216d30bba0986a8c270801d65f';
 
   before(() => {
-    sinon.stub(FormData.prototype, 'append').callsFake(function(key, value) {
+    const stubbed = sinon.stub(FormData.prototype, 'append').callsFake(function(key, value) {
       assert.strictEqual(key, 'json');
       const { parameter } = JSON.parse(value);
       const expectedParameters = {
@@ -45,6 +45,8 @@ describe('Jenkins', () => {
 
       return Reflect.apply(FormData.prototype.append.wrappedMethod, this, arguments);
     });
+
+    return () => stubbed.restore();
   });
 
   it('should fail if starting node-pull-request throws', async() => {
@@ -121,12 +123,17 @@ describe('Jenkins', () => {
     before(() => {
       sinon.replace(PRData.prototype, 'getReviews', function() {});
       sinon.replace(PRData.prototype, 'getCommits', function() {});
+      return () => {
+        PRData.prototype.getReviews.restore();
+        PRData.prototype.getCommits.restore();
+      };
     });
     afterEach(() => {
       PRData.prototype.getCollaborators.restore();
       PRData.prototype.getComments.restore();
       PRChecker.prototype.getApprovedTipOfHead.restore();
     });
+
     for (const { headIsApproved = false, collaborators = [], comments = [], expected } of [{
       headIsApproved: true,
       expected: true,

--- a/test/unit/ci_start.test.js
+++ b/test/unit/ci_start.test.js
@@ -11,6 +11,7 @@ import {
   CI_PR_URL
 } from '../../lib/ci/run_ci.js';
 import PRChecker from '../../lib/pr_checker.js';
+import PRData from '../../lib/pr_data.js';
 
 import TestCLI from '../fixtures/test_cli.js';
 
@@ -125,6 +126,10 @@ describe('Jenkins', () => {
       }safe`, async() => {
         const cli = new TestCLI();
 
+        sinon.replace(PRData.prototype, 'getCollaborators',
+          function() { this.collaborators = []; });
+        sinon.replace(PRData.prototype, 'getComments',
+          function() { this.comments = []; });
         sinon.replace(PRChecker.prototype, 'getApprovedTipOfHead',
           sinon.fake.returns(certifySafe && 'deadbeef'));
 


### PR DESCRIPTION
Currently, the `request-ci` only works for approved PRs. This is annoying because:

- collaborators cannot approve their own PRs, and have to wait for someone else to approve their PR for them, or start the CI manually.
- it gives an incentive to approve a PR just to run the CI rather than because the collaborator actually supports it.

There have been suggestions to use PR author, or PR head repo owner, or commit signature, or a combination of the three – but I don't really like that idea, because:

- it doesn't help for PRs from non-collaborators.
- we should care about who is requesting the CI, not who's proposing the change.

IIUC comments are not editable by triagers, so should be a safe way to determine a safe SHA for unapproved PRs. 

EDIT 2026: it is annoying, but also seems to be mostly working, folks have gotten used to wait for approval or start CI manually. Not sure this is actually needed.