### PR TITLE
normalize idl name when matching asset

### DIFF
--- a/lib/wpt/index.js
+++ b/lib/wpt/index.js
@@ -222,7 +222,7 @@ export class InterfacesUpdater extends WPTUpdater {
     const found = [];
     for (const mod of supported) {
       const idl = `${mod}.idl`;
-      const asset = assets.find(asset => asset.name === idl);
+      const asset = assets.find(asset => asset.name.toLowerCase() === idl.toLowerCase());
       if (asset) {
         found.push(asset);
       } else {


### PR DESCRIPTION
the convention where a name matches exactly no longer holds since https://github.com/web-platform-tests/wpt/pull/52264