### PR TITLE
fix: prepare interfaces updater for updated webcrypto

### DIFF
--- a/components/git/wpt.js
+++ b/components/git/wpt.js
@@ -47,7 +47,8 @@ async function main(argv) {
   const statusFolder = path.join(nodedir, 'test', 'wpt', 'status');
   let supported = [
     'dom',
-    'html'
+    'html',
+    'webcrypto'
   ];
   if (fs.existsSync(statusFolder)) {
     const jsons = fs.readdirSync(statusFolder);


### PR DESCRIPTION
adds webcrypto to the list of known interfaces to pull since https://github.com/web-platform-tests/wpt/pull/52264 makes it so the file no longer matches the directory name in webcrypto's case.