### PR TITLE
fix(ncu-ci): pass `COMMIT_SHA_CHECK` to V8 CI

### DIFF
--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -62,7 +62,8 @@ export class RunPRJob {
       parameter: [
         { name: 'GITHUB_ORG', value: this.owner },
         { name: 'REPO_NAME', value: this.repo },
-        { name: 'GIT_REMOTE_REF', value: `refs/pull/${this.prid}/head` }
+        { name: 'GIT_REMOTE_REF', value: `refs/pull/${this.prid}/head` },
+        { name: 'COMMIT_SHA_CHECK', value: this.certifySafe }
       ]
     }));
     return payload;


### PR DESCRIPTION
Similar to `node-test-pull-request`, `node-test-commit-v8-linux` also now requires `COMMIT_SHA_CHECK` to be passed to it.

Refs: https://github.com/nodejs/node-core-utils/pull/911

