### PR TITLE
fix: auto-push git node --security

### DIFF
--- a/lib/update_security_release.js
+++ b/lib/update_security_release.js
@@ -46,6 +46,10 @@ export default class UpdateSecurityRelease extends SecurityRelease {
     }
     const vulnerabilitiesJSONPath = this.getVulnerabilitiesJSONPath();
     fs.writeFileSync(vulnerabilitiesJSONPath, JSON.stringify(content, null, 2));
+
+    const commitMessage = 'chore: git node security --sync';
+    commitAndPushVulnerabilitiesJSON([vulnerabilitiesJSONPath],
+      commitMessage, { cli: this.cli, repository: this.repository });
     this.cli.ok('Synced vulnerabilities.json with HackerOne');
   }
 


### PR DESCRIPTION
**fix: auto-push git node --security**
```
This change makes git node --security to
auto push the changes to remote. This makes
this feature aligned with other git node security
features that also push to the remote automatically
```