### PR TITLE
fix: mention CI green on security --cleanup

### DIFF
--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -70,7 +70,7 @@ export default class PrepareSecurityRelease extends SecurityRelease {
         { cli: this.cli, repository: this.repository }
       );
     }
-    this.cli.info(`If the PR is ready (CI is green): merge pull request with:
+    this.cli.info(`If the PR is ready (CI is passing): merge pull request with:
         - git checkout main
         - git merge ${NEXT_SECURITY_RELEASE_BRANCH} --no-ff -m "chore: add latest security release"
         - git push origin main`);

--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -70,7 +70,7 @@ export default class PrepareSecurityRelease extends SecurityRelease {
         { cli: this.cli, repository: this.repository }
       );
     }
-    this.cli.info(`Merge pull request with:
+    this.cli.info(`If the PR is ready (CI is green): merge pull request with:
         - git checkout main
         - git merge ${NEXT_SECURITY_RELEASE_BRANCH} --no-ff -m "chore: add latest security release"
         - git push origin main`);


### PR DESCRIPTION
Very often we add new properties to vulnerabilities.json and having a green ci before merging the PR is a must.