### PR TITLE
fix(git-node): output vote keyPart to stdout, not stderr

### DIFF
--- a/lib/voting_session.js
+++ b/lib/voting_session.js
@@ -111,7 +111,7 @@ export default class VotingSession extends Session {
                     out.toString('base64') +
                     '\n-----END SHAMIR KEY PART-----';
     this.cli.log('Your key part is:');
-    this.cli.log(keyPart);
+    console.log(keyPart); // Using `console.log` so this gets output to stdout, not stderr.
     const body = 'I would like to close this vote, and for this effect, I\'m revealing my ' +
                  `key part:\n\n${'```'}\n${keyPart}\n${'```'}\n`;
     if (this.postComment) {


### PR DESCRIPTION
Useful when piping to another command. E.g., `git node vote <url> --decrypt-key-part 2>/dev/null` reveals the key without any other output.