### PR TITLE
fix(git-node): pass `-S` flag directly to Caritat

### DIFF
--- a/lib/voting_session.js
+++ b/lib/voting_session.js
@@ -29,6 +29,7 @@ export default class VotingSession extends Session {
     this.abstain = abstain;
     this.closeVote = argv['decrypt-key-part'];
     this.postComment = argv['post-comment'];
+    this.gpgSign = argv['gpg-sign'];
   }
 
   get argv() {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/TSC/pull/1770#issuecomment-3103074002

In 1263d0f07457d6c8f9f9720caa24227a2ba66621, we moved the logic to the parent `Session` class so we can use it for other kind of sessions, however Caritat already has internal logic to handle that flag, so we should just pass the value directly