### PR TITLE
improve: enhance remote configuration error message

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -382,12 +382,15 @@ export default class Session {
       cli.setExitCode(1);
     }
     if (!upstream) {
-      cli.warn('You have not told git-node the remote you want to sync with.');
+      cli.warn('You need to configure the remote repository for Node.js core.');
       cli.separator();
       cli.info(
-        'For example, if your remote pointing to nodejs/node is' +
-        ' `remote-upstream`, you can run:\n\n' +
-        '  $ ncu-config set upstream remote-upstream');
+        '1. First, add the Node.js core repository as a remote (if not already added):\n' +
+        '   $ git remote add upstream https://github.com/nodejs/node.git\n\n' +
+        '2. Then, tell git-node to use this remote for syncing:\n' +
+        '   $ ncu-config set upstream upstream\n\n' +
+        'Note: Using "upstream" is recommended, but you can use any remote name.\n' +
+        'For security reasons, you need to add the remote manually.');
       cli.separator();
       cli.setExitCode(1);
     }


### PR DESCRIPTION
- Suggest 'upstream' as the default remote name
- Clarify the need to add the remote manually for security
- Provide a clear example of the git remote add command