### PR TITLE
fix(git-node): improve release tag signature verification

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -196,7 +196,7 @@ export default class ReleasePromotion extends Session {
 
   async verifyTagSignature(version) {
     const { cli } = this;
-    const verifyTagPattern = /gpg:[^\n]+\ngpg:\s+using RSA key ([^\n]+)\ngpg:\s+issuer "([^"]+)"\ngpg:\s+Good signature from "([^<]+) <\2>"/;
+    const verifyTagPattern = /gpg:[^\n]+\ngpg:\s+using \w+ key ([^\n]+)\ngpg:\s+issuer "([^"]+)"\ngpg:\s+Good signature from (?:"[^"]+"(?: \[ultimate\])?\ngpg:\s+aka )*"([^<]+) <\2>"/;
     const [verifyTagOutput, haystack] = await Promise.all([forceRunAsync(
       'git', ['--no-pager',
         'verify-tag',


### PR DESCRIPTION
Add support for non-RSA keys, and for keys with several identities.