### PR TITLE
fix: add warning before spawning `gpg`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -29,6 +29,7 @@ export function getConfig(configType, dir) {
   const configPath = getConfigPath(configType, dir);
   const encryptedConfigPath = configPath + '.gpg';
   if (existsSync(encryptedConfigPath)) {
+    console.warn('Encrypted config detected, spawning gpg to decrypt it...');
     const { status, stdout } =
       spawnSync('gpg', ['--decrypt', encryptedConfigPath]);
     if (status === 0) {


### PR DESCRIPTION
I kinda forgot I moved to encrypted config file, and got surprised to be asked for my passphrase. Adding a warning so next time I forget, I won't be surprised.