### PR TITLE
chore!: drop Node.js 18.x from supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities for Node.js core collaborators",
   "type": "module",
   "engines": {
-    "node": "^20.20.0 || ^22.20.0 || >=24.10.0"
+    "node": "^20.19.0 || ^22.20.0 || >=24.10.0"
   },
   "bin": {
     "get-metadata": "bin/get-metadata.js",


### PR DESCRIPTION
Seems to be required to use the latest versions of Undici (#946)