### PR TITLE
feat(git-node): verify tag with official keyring

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -225,7 +225,11 @@ export default class ReleasePromotion extends Session {
       cli.warn('or that nodejs/release-keys contains outdated information.');
       cli.warn('The release should not proceed.');
       if (!await cli.prompt('Do you want to proceed anyway?', { defaultAnswer: false })) {
-        cli.info(`Run 'git tag -d v${version}' to remove the local tag.`);
+        if (await cli.prompt('Do you want to delete the local tag?')) {
+          await forceRunAsync('git', ['tag', '-d', `v${version}`]);
+        } else {
+          cli.info(`Run 'git tag -d v${version}' to remove the local tag.`);
+        }
         throw new Error('Aborted', { cause });
       }
     } finally {


### PR DESCRIPTION
Instead of trying to parse `git tag` output (which is not stable), we could simply download the keyring from nodejs/release-keys and rely on the exit code. It should no longer provide false negatives.