### PR TITLE
fix: remove stack traces from non-debug output

### DIFF
--- a/lib/verbosity.js
+++ b/lib/verbosity.js
@@ -18,6 +18,9 @@ export function setVerbosityFromEnv() {
   if (Object.keys(VERBOSITY).includes(env)) {
     verbosity = VERBOSITY[env];
   }
+  if (!isDebugVerbosity()) {
+    Error.stackTraceLimit = 0;
+  }
 };
 
 export function debuglog(...args) {


### PR DESCRIPTION
The stack traces should be irrelevant for most users of NCU, and could hide some important output.