### PR TITLE
fix: spawning of `gpg` to read config

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,7 +3,7 @@ import { ClientRequest } from 'node:http';
 
 import ghauth from 'ghauth';
 
-import { getMergedConfig, getNcurcPath } from './config.js';
+import { clearCachedConfig, getMergedConfig, getNcurcPath } from './config.js';
 
 export default lazy(auth);
 
@@ -89,6 +89,7 @@ async function auth(
         mode: 0o600 /* owner read/write */
       });
       // Try again reading the file
+      clearCachedConfig();
       ({ username, token } = getMergedConfig());
     }
     check(username, token);

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,6 +28,9 @@ export function getMergedConfig(dir, home) {
   }
   return mergedConfig;
 };
+export function clearCachedConfig() {
+  mergedConfig = null;
+}
 
 export function getConfig(configType, dir) {
   const configPath = getConfigPath(configType, dir);


### PR DESCRIPTION
Regarding `GPG_BIN`:
https://github.com/nodejs/node-core-utils/blob/9b642b02a1918610b087de81256bcedd6195a2d8/docs/git-node.md#L418-L419

Caching `getMergedConfig` as it typically gets called 4 times when starting `git-node`:

```
Error: Encrypted config detected, spawning gpg to decrypt it...
    at getConfig (…/lib/config.js:32:18)
    at getMergedConfig (…/lib/config.js:22:24)
    at …/components/git/metadata.js:11:16
    at ModuleJob.run (node:internal/modules/esm/module_job:345:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:651:26)
    at async Promise.all (index 2)
Error: Encrypted config detected, spawning gpg to decrypt it...
    at getConfig (…/lib/config.js:32:18)
    at getMergedConfig (…/lib/config.js:22:24)
    at auth (…/lib/auth.js:73:30)
    at …/lib/auth.js:39:19
    at main (…/components/git/land.js:167:29)
    at land (…/components/git/land.js:158:21)
    at Object.handler (…/components/git/land.js:143:12)
    at …/node_modules/yargs/build/lib/command.js:206:54
    at maybeAsyncResult (…/node_modules/yargs/build/lib/utils/maybe-async-result.js:9:15)
    at CommandInstance.handleValidationAndGetResult (…/node_modules/yargs/build/lib/command.js:205:25)
Error: Encrypted config detected, spawning gpg to decrypt it...
    at getConfig (…/lib/config.js:32:18)
    at getMergedConfig (…/lib/config.js:22:24)
    at proxy (…/lib/proxy.js:9:18)
    at new Request (…/lib/request.js:22:23)
    at main (…/components/git/land.js:170:15)
Error: Encrypted config detected, spawning gpg to decrypt it...
    at getConfig (…/lib/config.js:32:18)
    at getMergedConfig (…/lib/config.js:22:24)
    at new Session (…/lib/session.js:22:24)
    at new LandingSession (…/lib/landing_session.js:25:5)
    at main (…/components/git/land.js:171:17)
```