### PR TITLE
chore: only enable nodeBuiltin globals for ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,11 +18,12 @@ export default [
       'coverage/',
       'node_modules/',
       'lib/wpt/templates/',
+      'test/fixtures/release/*.js', // Copied from the nodejs/node repo
     ],
   },
   {
     languageOptions: {
-      globals: globals.node,
+      globals: globals.nodeBuiltin,
       sourceType: 'module',
       ecmaVersion: 'latest',
     },

--- a/test/fixtures/release/expected-test-process-release.js
+++ b/test/fixtures/release/expected-test-process-release.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// eslint-disable-next-line n/no-missing-require
 require('../common');
 
 const assert = require('assert');

--- a/test/fixtures/release/original-test-process-release.js
+++ b/test/fixtures/release/original-test-process-release.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// eslint-disable-next-line n/no-missing-require
 require('../common');
 
 const assert = require('assert');


### PR DESCRIPTION
Code is ESM, so we shouldn't enable CommonJS "globals".
