### PR TITLE
fir(git-node): include full URL in suggested `gh` command

### DIFF
--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -464,8 +464,8 @@ export default class LandingSession extends Session {
     const url = `https://github.com/${owner}/${repo}/pull/${prid}`;
     cli.log(`2. Post "Landed in ${willBeLanded}" in ${url}`);
     if (isGhAvailable()) {
-      cli.log(`   gh pr comment ${prid} --body "Landed in ${willBeLanded}"`);
-      cli.log(`   gh pr close ${prid}`);
+      cli.log(`   gh pr comment ${url} --body "Landed in ${willBeLanded}"`);
+      cli.log(`   gh pr close ${url}`);
     }
   }
 


### PR DESCRIPTION
`gh` does not always pick up correctly which repo we're targeting if I give just the PR ID.