### PR TITLE
fix(ncu-config): do not override encrypted values silently

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -70,14 +70,18 @@ function addEncryptedPropertyGetter(target, key, input) {
         return value;
       },
       set(newValue) {
-        addEncryptedPropertyGetter(target, key, newValue) ||
-            setOwnProperty(target, key, newValue);
+        if (!addEncryptedPropertyGetter(target, key, newValue)) {
+          throw new Error(
+            'Refusing to override an encrypted value with a non-encrypted one. ' +
+            'Please use an encrypted one, or delete the config key first.'
+          );
+        }
       }
     });
   }
 }
 
-export function getConfig(configType, dir) {
+export function getConfig(configType, dir, raw = false) {
   const configPath = getConfigPath(configType, dir);
   const encryptedConfigPath = configPath + '.gpg';
   if (existsSync(encryptedConfigPath)) {
@@ -90,8 +94,12 @@ export function getConfig(configType, dir) {
   }
   try {
     const json = readJson(configPath);
-    for (const [key, val] of Object.entries(json)) {
-      addEncryptedPropertyGetter(json, key, val);
+    if (!raw) {
+      // Raw config means encrypted values are returned as is.
+      // Otherwise we install getters to decrypt them when accessed.
+      for (const [key, val] of Object.entries(json)) {
+        addEncryptedPropertyGetter(json, key, val);
+      }
     }
     return json;
   } catch (cause) {
@@ -99,7 +107,7 @@ export function getConfig(configType, dir) {
   }
 };
 
-export function getConfigPath(configType, dir) {
+function getConfigPath(configType, dir) {
   switch (configType) {
     case GLOBAL_CONFIG:
       return getNcurcPath();
@@ -117,7 +125,7 @@ export function getConfigPath(configType, dir) {
   }
 };
 
-export function writeConfig(configType, obj, dir) {
+function writeConfig(configType, obj, dir) {
   const configPath = getConfigPath(configType, dir);
   const encryptedConfigPath = configPath + '.gpg';
   if (existsSync(encryptedConfigPath)) {
@@ -141,7 +149,7 @@ export function writeConfig(configType, obj, dir) {
 };
 
 export function updateConfig(configType, obj, dir) {
-  const config = getConfig(configType, dir);
+  const config = getConfig(configType, dir, true);
   writeConfig(configType, Object.assign(config, obj), dir);
 };
 


### PR DESCRIPTION
It's deceivingly easy to end up with a clear-text value when trying to modify an existing encrypted config entry. I think throwing in this case is a safer behavior.