### PR TITLE
feat(v8): add command to sync V8 deps

### DIFF
--- a/components/git/v8.js
+++ b/components/git/v8.js
@@ -2,12 +2,12 @@ import path from 'node:path';
 
 import logSymbols from 'log-symbols';
 
-import { minor, major, backport } from '../../lib/update-v8/index.js';
+import { minor, major, backport, deps } from '../../lib/update-v8/index.js';
 import { defaultBaseDir } from '../../lib/update-v8/constants.js';
 import { checkCwd } from '../../lib/update-v8/common.js';
 import { forceRunAsync } from '../../lib/run.js';
 
-export const command = 'v8 [major|minor|backport]';
+export const command = 'v8 [major|minor|backport|deps]';
 export const describe = 'Update or patch the V8 engine';
 
 export function builder(yargs) {
@@ -25,6 +25,11 @@ export function builder(yargs) {
           type: 'boolean',
           describe: 'Bump the NODE_MODULE_VERSION constant',
           default: true
+        });
+        yargs.option('concurrent', {
+          type: 'boolean',
+          describe: 'Update dependencies concurrently',
+          default: true,
         });
       }
     })
@@ -61,6 +66,19 @@ export function builder(yargs) {
                 'If multiple commits are backported, squash them into one. When ' +
                 '`--squash` is passed, `--preserve-original-author` will be ignored',
             default: false
+          });
+      }
+    })
+    .command({
+      command: 'deps',
+      desc: 'Update V8 dependencies from the DEPS file',
+      handler,
+      builder: (yargs) => {
+        yargs
+          .option('concurrent', {
+            type: 'boolean',
+            describe: 'Update dependencies concurrently',
+            default: true,
           });
       }
     })
@@ -126,6 +144,8 @@ export function handler(argv) {
           return major(options);
         case 'backport':
           return backport(options);
+        case 'deps':
+          return deps(options);
       }
     })
     .catch((err) => {

--- a/lib/update-v8/deps.js
+++ b/lib/update-v8/deps.js
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+import { chromiumGit, v8Deps } from './constants.js';
+import { forceRunAsync } from '../run.js';
+import {
+  addToGitignore,
+  filterForVersion,
+  getNodeV8Version,
+  removeDirectory,
+  replaceGitignore,
+} from './util.js';
+
+async function fetchFromGit(cwd, repo, commit) {
+  await removeDirectory(cwd);
+  await fs.mkdir(cwd, { recursive: true });
+  await exec('init');
+  await exec('remote', 'add', 'origin', repo);
+  await exec('fetch', 'origin', commit);
+  await exec('reset', '--hard', 'FETCH_HEAD');
+  await removeDirectory(path.join(cwd, '.git'));
+
+  function exec(...options) {
+    return forceRunAsync('git', options, {
+      ignoreFailure: false,
+      spawnArgs: { cwd, stdio: 'ignore' }
+    });
+  }
+}
+
+async function readDeps(nodeDir) {
+  const depsStr = await fs.readFile(path.join(nodeDir, 'deps/v8/DEPS'), 'utf8');
+  const start = depsStr.indexOf('deps = {');
+  const end = depsStr.indexOf('\n}', start) + 2;
+  const depsDeclaration = depsStr.substring(start, end).replace(/^ *#.*/gm, '');
+  const Var = () => chromiumGit; // eslint-disable-line no-unused-vars
+  let deps;
+  eval(depsDeclaration); // eslint-disable-line no-eval
+  return deps;
+}
+
+async function lookupDep(depsTable, depName) {
+  const dep = depsTable[depName];
+  if (!dep) {
+    throw new Error(`V8 dep "${depName}" not found in DEPS file`);
+  }
+  if (typeof dep === 'object') {
+    return dep.url.split('@');
+  }
+  return dep.split('@');
+}
+
+export default function updateV8Deps() {
+  return {
+    title: 'Update V8 DEPS',
+    task: async(ctx, task) => {
+      const newV8Version = await getNodeV8Version(ctx.nodeDir);
+      const repoPrefix = newV8Version.majorMinor >= 86 ? '' : 'v8/';
+      const deps = filterForVersion(v8Deps.map((v8Dep) => ({
+        ...v8Dep,
+        repo: `${repoPrefix}${v8Dep.repo}`,
+        path: v8Dep.repo
+      })), newV8Version);
+      if (deps.length === 0) return;
+      const depsTable = await readDeps(ctx.nodeDir);
+      const subtasks = [];
+      for (const dep of deps) {
+        // Update .gitignore sequentially to avoid races
+        if (dep.gitignore) {
+          if (typeof dep.gitignore === 'string') {
+            await addToGitignore(ctx.nodeDir, dep.gitignore);
+          } else {
+            await replaceGitignore(ctx.nodeDir, dep.gitignore);
+          }
+        }
+        subtasks.push({
+          title: `Update ${dep.path}`,
+          task: async(ctx) => {
+            const [repo, commit] = await lookupDep(depsTable, dep.repo);
+            const thePath = path.join(ctx.nodeDir, 'deps/v8', dep.path);
+            await fetchFromGit(thePath, repo, commit);
+          }
+        });
+      }
+      return task.newListr(subtasks, { concurrent: ctx.concurrent });
+    }
+  };
+};

--- a/lib/update-v8/index.js
+++ b/lib/update-v8/index.js
@@ -5,6 +5,7 @@ import updateVersionNumbers from './updateVersionNumbers.js';
 import commitUpdate from './commitUpdate.js';
 import majorUpdate from './majorUpdate.js';
 import minorUpdate from './minorUpdate.js';
+import updateDeps from './deps.js';
 import updateV8Clone from './updateV8Clone.js';
 
 export function major(options) {
@@ -29,6 +30,14 @@ export async function backport(options) {
   options.gpgSign = options.gpgSign ? ['-S'] : [];
   const tasks = new Listr(
     [updateV8Clone(), doBackport(options)],
+    getOptions(options)
+  );
+  return tasks.run(options);
+};
+
+export async function deps(options) {
+  const tasks = new Listr(
+    [updateDeps()],
     getOptions(options)
   );
   return tasks.run(options);

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -1,17 +1,12 @@
 import path from 'node:path';
-import { promises as fs } from 'node:fs';
 
 import { getCurrentV8Version } from './common.js';
+import updateV8Deps from './deps.js';
 import {
-  getNodeV8Version,
-  filterForVersion,
-  addToGitignore,
-  replaceGitignore,
   removeDirectory,
   isVersionString
 } from './util.js';
 import applyNodeChanges from './applyNodeChanges.js';
-import { chromiumGit, v8Deps } from './constants.js';
 import { forceRunAsync } from '../run.js';
 
 export default function majorUpdate() {
@@ -105,66 +100,4 @@ function addDepsV8() {
       spawnArgs: { cwd: ctx.nodeDir, stdio: 'ignore' }
     })
   };
-}
-
-function updateV8Deps() {
-  return {
-    title: 'Update V8 DEPS',
-    task: async(ctx) => {
-      const newV8Version = await getNodeV8Version(ctx.nodeDir);
-      const repoPrefix = newV8Version.majorMinor >= 86 ? '' : 'v8/';
-      const deps = filterForVersion(v8Deps.map((v8Dep) => ({
-        ...v8Dep,
-        repo: `${repoPrefix}${v8Dep.repo}`,
-        path: v8Dep.repo
-      })), newV8Version);
-      if (deps.length === 0) return;
-      for (const dep of deps) {
-        if (dep.gitignore) {
-          if (typeof dep.gitignore === 'string') {
-            await addToGitignore(ctx.nodeDir, dep.gitignore);
-          } else {
-            await replaceGitignore(ctx.nodeDir, dep.gitignore);
-          }
-        }
-        const [repo, commit] = await readDeps(ctx.nodeDir, dep.repo);
-        const thePath = path.join(ctx.nodeDir, 'deps/v8', dep.path);
-        await fetchFromGit(thePath, repo, commit);
-      }
-    }
-  };
-}
-
-async function readDeps(nodeDir, depName) {
-  const depsStr = await fs.readFile(path.join(nodeDir, 'deps/v8/DEPS'), 'utf8');
-  const start = depsStr.indexOf('deps = {');
-  const end = depsStr.indexOf('\n}', start) + 2;
-  const depsDeclaration = depsStr.substring(start, end).replace(/^ *#.*/gm, '');
-  const Var = () => chromiumGit; // eslint-disable-line no-unused-vars
-  let deps;
-  eval(depsDeclaration); // eslint-disable-line no-eval
-  const dep = deps[depName];
-  if (!dep) {
-    throw new Error(`V8 dep "${depName}" not found in DEPS file`);
-  }
-  if (typeof dep === 'object') {
-    return dep.url.split('@');
-  }
-  return dep.split('@');
-}
-
-async function fetchFromGit(cwd, repo, commit) {
-  await fs.mkdir(cwd, { recursive: true });
-  await exec('init');
-  await exec('remote', 'add', 'origin', repo);
-  await exec('fetch', 'origin', commit);
-  await exec('reset', '--hard', 'FETCH_HEAD');
-  await removeDirectory(path.join(cwd, '.git'));
-
-  function exec(...options) {
-    return forceRunAsync('git', options, {
-      ignoreFailure: false,
-      spawnArgs: { cwd, stdio: 'ignore' }
-    });
-  }
 }

--- a/lib/update-v8/util.js
+++ b/lib/update-v8/util.js
@@ -37,13 +37,18 @@ export function filterForVersion(list, version) {
 
 export async function addToGitignore(nodeDir, value) {
   const gitignorePath = path.join(nodeDir, 'deps/v8/.gitignore');
-  await fs.appendFile(gitignorePath, `${value}\n`);
+  const gitignore = await fs.readFile(gitignorePath, 'utf8');
+  if (!gitignore.includes(value)) {
+    await fs.appendFile(gitignorePath, `${value}\n`);
+  }
 }
 
 export async function replaceGitignore(nodeDir, options) {
   const gitignorePath = path.join(nodeDir, 'deps/v8/.gitignore');
   let gitignore = await fs.readFile(gitignorePath, 'utf8');
-  gitignore = gitignore.replace(options.match, options.replace);
+  if (!gitignore.includes(options.replace)) {
+    gitignore = gitignore.replace(options.match, options.replace);
+  }
   await fs.writeFile(gitignorePath, gitignore);
 }
 


### PR DESCRIPTION
Add `git node v8 deps` to (re)sync V8 dependencies from V8's `DEPS` file.

---

I started on this while exploring [potentially adding Chromium's Rust crates ](https://redirect.github.com/nodejs/node/pull/60897#issuecomment-3612317694)(`third_party/rust`) to the Node.js source tree (although it looks like we might do [our own vendoring ](https://redirect.github.com/nodejs/node/pull/61072)to potentially allow other uses of Rust). It will also be useful for exploring adding `third_party/libc++/src` for V8's custom_libcxx to avoid [requiring libatomic](https://redirect.github.com/nodejs/node/issues/37219#issuecomment-3415266847).

On its own it shouldn't do anything (other than revert any patches we have floated on top of the third_party deps). Its main use would be to test updates to [`lib/update-v8/constants.js`](https://github.com/nodejs/node-core-utils/blob/main/lib/update-v8/constants.js) or even V8's DEPS (if we ever want to roll forward a dependency (I expect that to be rare/unlikely)).