### PR TITLE
 chore: test upgrade-policy: lts/strict in matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Lint
         run: npm run lint
 
@@ -25,6 +25,7 @@ jobs:
     name: Test on Node.js
     uses: pkgjs/action/.github/workflows/node-test.yaml@v0
     with:
+      upgrade-policy: lts/strict
       runs-on: ubuntu-latest, macos-latest
       test-command: npm run coverage:ci
       post-test-steps: |


### PR DESCRIPTION
The current release (26) doesn't work currently with the yargs version locked in by c8 until https://github.com/yargs/yargs/issues/2509 or https://github.com/bcoe/c8/pull/578 is fixed.