### PR TITLE
ci: declare contents:read on the lint job

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,12 +6,13 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint using ESLint
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Use latest Node.js LTS

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     name: Lint using ESLint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Use latest Node.js LTS


### PR DESCRIPTION
Pins the `lint` job to `contents: read`. The job only runs `actions/checkout`, `actions/setup-node`, `npm install`, and `npm run lint`. No GitHub API write.

Block sits on the job rather than at workflow scope on purpose: the second job (`test`) uses `pkgjs/action`'s reusable `node-test.yaml@v0`, and a caller-level permissions block intersects with the callee's grant (which might need `codecov-action`'s id-token write or similar). Scoping the new declaration to `lint` leaves the test job untouched.

Defense-in-depth motivation is the [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) precedent: a compromised third-party action runs inside the existing job context with whatever scope the token was issued at; the explicit cap bounds the blast radius. Matches the workflow-level `contents: read` in `commitlint.yml` and the `id-token: write` + `contents: read` in `release-please.yml`. YAML validated locally with `yaml.safe_load`.

BEGIN_COMMIT_OVERRIDE
chore: declare contents:read on the GHA test workflow (#1077)
END_COMMIT_OVERRIDE