### PR TITLE
fix(git-node): prefill both version options when requesting CVEs

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -94,6 +94,16 @@ export default class CLI {
     return answer;
   }
 
+  async promptRadio(message, choices, opts = undefined) {
+    if (Object.hasOwn(opts, 'defaultAnswer')) {
+      opts.default = opts.defaultAnswer;
+    }
+    return inquirer.select({
+      ...opts,
+      message, choices,
+    });
+  }
+
   async promptCheckbox(message, choices) {
     if (this.assumeYes) {
       return choices.filter((c) => c.checked).map((c) => c.value);

--- a/lib/update_security_release.js
+++ b/lib/update_security_release.js
@@ -290,10 +290,10 @@ Summary: ${summary}\n`,
 
       const nextPatchVersion = semver.inc(version, 'patch');
       const nextMinorVersion = semver.inc(version, 'minor');
-      const patchedVersion = await this.cli.prompt(
+      const patchedVersion = await this.cli.promptRadio(
         `What is the patched version (>=) for release line ${affectedVersion}?`,
+        [nextPatchVersion, nextMinorVersion],
         {
-          questionType: 'input',
           defaultAnswer: isPatchRelease ? nextPatchVersion : nextMinorVersion
         });
 


### PR DESCRIPTION
Instead having to type the full version number if not using the default, we can prefill them both