### PR TITLE
fix(git-node): security release preparation should not use staging

### DIFF
--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -37,7 +37,7 @@ export default class ReleasePreparation extends Session {
   }
 
   get branch() {
-    return this.stagingBranch;
+    return this.isSecurityRelease ? this.releaseBranch : this.stagingBranch;
   }
 
   warnForNonMergeablePR(pr) {
@@ -520,7 +520,7 @@ export default class ReleasePreparation extends Session {
     await fs.writeFile(majorChangelogPath, arr.join('\n'));
   }
 
-  async createProposalBranch(base = this.stagingBranch) {
+  async createProposalBranch(base = this.branch) {
     const { newVersion } = this;
     const proposalBranch = `v${newVersion}-proposal`;
 


### PR DESCRIPTION
I had a hard time understanding why my local changes weren't taken into consideration, turns out it was using `v26.x-staging` commits despite enforcing that I was on `v26.x`