### PR TITLE
chore(git-node): remove abort error in case of fixable error

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -523,11 +523,7 @@ export default class ReleasePromotion extends Session {
       cli.separator();
       cli.info('Resolve the conflicts and commit the result');
       cli.separator();
-      const didResolveConflicts = await cli.prompt(
-        'Finished resolving cherry-pick conflicts?', { defaultAnswer: true });
-      if (!didResolveConflicts) {
-        throw new Error('Aborted');
-      }
+      await cli.prompt('Ready to continue?', { defaultAnswer: true });
     }
 
     if (existsSync('.git/CHERRY_PICK_HEAD')) {
@@ -537,16 +533,20 @@ export default class ReleasePromotion extends Session {
     }
 
     // Validate release commit on the default branch
-    const releaseCommitOnDefaultBranch =
-      await forceRunAsync('git', ['show', 'HEAD', '--name-only', '--pretty=format:%s'],
-        { captureStdout: true, ignoreFailure: false });
-    const [commitTitle, ...modifiedFiles] = releaseCommitOnDefaultBranch.trim().split('\n');
-    await this.validateReleaseCommit(commitTitle);
-    if (modifiedFiles.some(file => !file.endsWith('.md'))) {
-      cli.warn('Some modified files are not markdown, that\'s unusual.');
-      cli.info(`The list of modified files: ${modifiedFiles.map(f => `- ${f}`).join('\n')}`);
-      if (!await cli.prompt('Do you want to proceed anyway?', { defaultAnswer: false })) {
-        throw new Error('Aborted');
+    while (true) {
+      const releaseCommitOnDefaultBranch =
+        await forceRunAsync('git', ['show', 'HEAD', '--name-only', '--pretty=format:%s'],
+          { captureStdout: true, ignoreFailure: false });
+      const [commitTitle, ...modifiedFiles] = releaseCommitOnDefaultBranch.trim().split('\n');
+      await this.validateReleaseCommit(commitTitle);
+      if (modifiedFiles.some(file => !file.endsWith('.md'))) {
+        cli.warn('Some modified files are not markdown, that\'s unusual.');
+        cli.info(`The list of modified files: ${modifiedFiles.map(f => `- ${f}`).join('\n')}`);
+        if (await cli.prompt('Consider amending the commit before continuing. Ready to continue?', {
+          defaultAnswer: false
+        })) {
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
In the promotion script, the cherry-pick can have error that the releaser wants to fix before continuing. However, if they answer no, the whole process is aborted, which is rarely something the releaser would actually want – and if they do, I guess they'd have to do Ctrl+C from now on.