### PR TITLE
chore(git-node): clarify prompt message in promotion script

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -540,9 +540,9 @@ export default class ReleasePromotion extends Session {
       const [commitTitle, ...modifiedFiles] = releaseCommitOnDefaultBranch.trim().split('\n');
       await this.validateReleaseCommit(commitTitle);
       if (modifiedFiles.some(file => !file.endsWith('.md'))) {
-        cli.warn('Some modified files are not markdown, that\'s unusual.');
+        cli.warn('Some modified files are not markdown, that\'s unusual. Consider amending the commit.');
         cli.info(`The list of modified files: ${modifiedFiles.map(f => `- ${f}`).join('\n')}`);
-        if (await cli.prompt('Consider amending the commit. Ignore and continue anyway?', {
+        if (await cli.prompt('Ignore and continue anyway?', {
           defaultAnswer: false
         })) {
           break;

--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -540,7 +540,9 @@ export default class ReleasePromotion extends Session {
       const [commitTitle, ...modifiedFiles] = releaseCommitOnDefaultBranch.trim().split('\n');
       await this.validateReleaseCommit(commitTitle);
       if (modifiedFiles.some(file => !file.endsWith('.md'))) {
-        cli.warn('Some modified files are not markdown, that\'s unusual. Consider amending the commit.');
+        cli.warn(
+          'Some modified files are not markdown, that\'s unusual. Consider amending the commit.'
+        );
         cli.info(`The list of modified files: ${modifiedFiles.map(f => `- ${f}`).join('\n')}`);
         if (await cli.prompt('Ignore and continue anyway?', {
           defaultAnswer: false

--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -542,7 +542,7 @@ export default class ReleasePromotion extends Session {
       if (modifiedFiles.some(file => !file.endsWith('.md'))) {
         cli.warn('Some modified files are not markdown, that\'s unusual.');
         cli.info(`The list of modified files: ${modifiedFiles.map(f => `- ${f}`).join('\n')}`);
-        if (await cli.prompt('Consider amending the commit before continuing. Ready to continue?', {
+        if (await cli.prompt('Consider amending the commit. Ignore and continue anyway?', {
           defaultAnswer: false
         })) {
           break;


### PR DESCRIPTION
Introduced in #1099, it wasn't very clear that answering Yes would ignore the error, so rephrasing the prompt message to clarify that