### PR TITLE
fix(git-node): add missing loop exit condition

### DIFF
--- a/lib/promote_release.js
+++ b/lib/promote_release.js
@@ -539,16 +539,16 @@ export default class ReleasePromotion extends Session {
           { captureStdout: true, ignoreFailure: false });
       const [commitTitle, ...modifiedFiles] = releaseCommitOnDefaultBranch.trim().split('\n');
       await this.validateReleaseCommit(commitTitle);
-      if (modifiedFiles.some(file => !file.endsWith('.md'))) {
-        cli.warn(
-          'Some modified files are not markdown, that\'s unusual. Consider amending the commit.'
-        );
-        cli.info(`The list of modified files: ${modifiedFiles.map(f => `- ${f}`).join('\n')}`);
-        if (await cli.prompt('Ignore and continue anyway?', {
-          defaultAnswer: false
-        })) {
-          break;
-        }
+      if (!modifiedFiles.some(file => !file.endsWith('.md'))) break;
+
+      cli.warn(
+        'Some modified files are not markdown, that\'s unusual. Consider amending the commit.'
+      );
+      cli.info(`The list of modified files: ${modifiedFiles.map(f => `- ${f}`).join('\n')}`);
+      if (await cli.prompt('Ignore and continue anyway?', {
+        defaultAnswer: false
+      })) {
+        break;
       }
     }
   }


### PR DESCRIPTION
As it's currently written, if the commit is "clean" (i.e. contains only MD changes), the code stays in the `while(true);` loop until the user gives up.