### PR TITLE
docs: refer to "squash" in help screen for git node land

### DIFF
--- a/components/git/land.js
+++ b/components/git/land.js
@@ -48,8 +48,8 @@ const landActions = {
     type: 'boolean'
   },
   fixupAll: {
-    describe: 'Automatically fixup all commits to the first one dismissing ' +
-      'other commit messages',
+    describe: 'Automatically fixup ("squash") all commits to the first one ' +
+      'dismissing other commit messages',
     default: false,
     type: 'boolean'
   },


### PR DESCRIPTION
Since this is my first contribution to NCU I'll note that `npm run test-all` [as documented in the contributing guide](https://github.com/nodejs/node-core-utils/blob/2d1085f5824c76f9fe7261cefc6ccd74c9ce4035/CONTRIBUTING.md#step-5-test) doesn't seem to be valid. I have run `npm test` on this though. Based on the fact it looks like the target was removed in https://github.com/nodejs/node-core-utils/pull/670 I'll submit a follow on PR to remove that step from the guide.

This change is because I was looking for the option on `git node land` to squash commits when landing https://github.com/nodejs/node/pull/64193 (which I was pretty sure I'd used on the past) but it doesn't have `squash` in the help screen as it's named `fixupAll` and this will allow `git node land --help | grep squash` to find it. I may also add a reference to this as a recommendation in the main node collaborator guide if people thing that's appropriate.