### PR TITLE
docs: remove "npm test-all" from CONTRIBUTING.md"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,6 @@ in `test/integration`. Test fixtures should be placed in `test/fixtures`.
 $ npm install
 # To run the unit tests
 $ npm test
-# To run all the tests
-$ npm run test-all
 ```
 
 Make sure the linter is happy and that all tests pass before submitting a


### PR DESCRIPTION
Spotted during https://github.com/nodejs/node-core-utils/pull/1108
`npm test-all` seems to have been removed from `package.json` in https://github.com/nodejs/node-core-utils/pull/670/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519 but was left in the documentation. If something else should replace it then let me know, otherwise removing it and leaving `npm test` in there seems reasonable.
