### PR TITLE
refactor(v8): cache new V8 version during major update

### DIFF
--- a/lib/update-v8/applyNodeChanges.js
+++ b/lib/update-v8/applyNodeChanges.js
@@ -1,7 +1,6 @@
 import path from 'node:path';
 
 import {
-  getNodeV8Version,
   filterForVersion,
   replaceGitignore,
   removeDirectory
@@ -18,8 +17,7 @@ export default function applyNodeChanges() {
   return {
     title: 'Apply Node-specific changes',
     task: async(ctx, task) => {
-      const v8Version = await getNodeV8Version(ctx.nodeDir);
-      const list = filterForVersion(nodeChanges, v8Version);
+      const list = filterForVersion(nodeChanges, ctx.newVersion);
       return task.newListr(list.map((change) => change.task()));
     }
   };

--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -8,7 +8,7 @@ import { ListrEnquirerPromptAdapter } from '@listr2/prompt-adapter-enquirer';
 
 import { shortSha } from '../utils.js';
 
-import { getCurrentV8Version } from './common.js';
+import { getV8Version } from './common.js';
 import { forceRunAsync } from '../run.js';
 
 export async function checkOptions(options) {
@@ -28,7 +28,7 @@ export async function checkOptions(options) {
 
 export function doBackport(options) {
   const todo = [
-    getCurrentV8Version(),
+    getV8Version('current'),
     generatePatches()
   ];
 

--- a/lib/update-v8/commitUpdate.js
+++ b/lib/update-v8/commitUpdate.js
@@ -1,10 +1,7 @@
-import { getNodeV8Version } from './util.js';
-
 export default function commitUpdate() {
   return {
     title: 'Commit V8 update',
     task: async(ctx) => {
-      const newV8Version = await getNodeV8Version(ctx.nodeDir);
       await ctx.execGitNode('add', ['deps/v8']);
       const moreArgs = [];
       let message;
@@ -15,9 +12,9 @@ export default function commitUpdate() {
           '-m',
           `Refs: https://github.com/v8/v8/compare/${prev}...${next}`
         );
-        message = `deps: patch V8 to ${newV8Version}`;
+        message = `deps: patch V8 to ${ctx.newVersion}`;
       } else {
-        message = `deps: update V8 to ${newV8Version}`;
+        message = `deps: update V8 to ${ctx.newVersion}`;
       }
       await ctx.execGitNode('commit', ['-m', message, ...moreArgs]);
     },

--- a/lib/update-v8/common.js
+++ b/lib/update-v8/common.js
@@ -3,11 +3,11 @@ import { promises as fs } from 'node:fs';
 
 import { getNodeV8Version } from './util.js';
 
-export function getCurrentV8Version() {
+export function getV8Version(label) {
   return {
-    title: 'Get current V8 version',
+    title: `Get ${label} V8 version`,
     task: async(ctx) => {
-      ctx.currentVersion = await getNodeV8Version(ctx.nodeDir);
+      ctx[`${label}Version`] = await getNodeV8Version(ctx.nodeDir);
     }
   };
 };

--- a/lib/update-v8/deps.js
+++ b/lib/update-v8/deps.js
@@ -6,7 +6,6 @@ import { forceRunAsync } from '../run.js';
 import {
   addToGitignore,
   filterForVersion,
-  getNodeV8Version,
   removeDirectory,
   replaceGitignore,
 } from './util.js';
@@ -54,13 +53,12 @@ export default function updateV8Deps() {
   return {
     title: 'Update V8 DEPS',
     task: async(ctx, task) => {
-      const newV8Version = await getNodeV8Version(ctx.nodeDir);
-      const repoPrefix = newV8Version.majorMinor >= 86 ? '' : 'v8/';
+      const repoPrefix = ctx.newVersion.majorMinor >= 86 ? '' : 'v8/';
       const deps = filterForVersion(v8Deps.map((v8Dep) => ({
         ...v8Dep,
         repo: `${repoPrefix}${v8Dep.repo}`,
         path: v8Dep.repo
-      })), newV8Version);
+      })), ctx.newVersion);
       if (deps.length === 0) return;
       const depsTable = await readDeps(ctx.nodeDir);
       const subtasks = [];

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { getCurrentV8Version } from './common.js';
+import { getV8Version } from './common.js';
 import updateV8Deps from './deps.js';
 import {
   removeDirectory,
@@ -14,10 +14,11 @@ export default function majorUpdate() {
     title: 'Major V8 update',
     task: (ctx, task) => {
       return task.newListr([
-        getCurrentV8Version(),
+        getV8Version('current'),
         checkoutBranch(),
         removeDepsV8(),
         cloneLocalV8(),
+        getV8Version('new'),
         removeDepsV8Git(),
         addDepsV8(),
         updateV8Deps(),

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
-import { getCurrentV8Version } from './common.js';
+import { getV8Version } from './common.js';
 import { isVersionString } from './util.js';
 import { forceRunAsync } from '../run.js';
 
@@ -10,7 +10,7 @@ export default function minorUpdate() {
     title: 'Minor V8 update',
     task: (ctx, task) => {
       return task.newListr([
-        getCurrentV8Version(),
+        getV8Version('current'),
         getLatestV8Version(),
         doMinorUpdate()
       ]);

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -1,8 +1,6 @@
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 
-import { getNodeV8Version } from './util.js';
-
 export default function updateVersionNumbers() {
   return {
     title: 'Update version numbers',
@@ -16,10 +14,9 @@ function bumpNodeModule() {
   return {
     title: 'Bump NODE_MODULE_VERSION',
     task: async(ctx) => {
-      const v8Version = await getNodeV8Version(ctx.nodeDir);
       const newModuleVersion = await updateModuleVersionRegistry(
         ctx.nodeDir,
-        v8Version,
+        ctx.newVersion,
         ctx.nodeMajorVersion
       );
       await updateModuleVersion(ctx.nodeDir, newModuleVersion);
@@ -33,7 +30,7 @@ function bumpNodeModule() {
           '-m',
           getCommitTitle(newModuleVersion),
           '-m',
-          getCommitBody(v8Version)
+          getCommitBody(ctx.newVersion)
         ]
       );
     },


### PR DESCRIPTION
After updating the V8 tree, we currently re-fetch the new V8 version from the filesystem several times during various tasks. Instead, we can cache it in the same way that we do the existing version.

Updates `getCurrentV8Version()` to a generic task that accepts a label for the version, either 'current' or 'new', from which the context property name is derived.