### PR TITLE
fix(v8): set RUSTC_BOOTSTRAP=1 when using Cargo nightly features

### DIFF
--- a/lib/update-v8/updateCrates.js
+++ b/lib/update-v8/updateCrates.js
@@ -37,7 +37,10 @@ function enumerateTemporalDependencies() {
         {
           ignoreFailure: false,
           captureStdout: true,
-          spawnArgs: { cwd: path.join(ctx.nodeDir, chromiumCratesDir) }
+          spawnArgs: {
+            cwd: path.join(ctx.nodeDir, chromiumCratesDir),
+            env: { ...process.env, RUSTC_BOOTSTRAP: '1' }
+          }
         }
       );
       const crates = new Set();


### PR DESCRIPTION
We need to enable `-Z bindeps` to read the Chromium crates tree, but this is not available on Cargo release builds by default. Setting RUSTC_BOOTSTRAP overrides this behaviour.

This is technically an unstable feature, but Chromium's tooling also uses it for the same purpose, and it's extremely unlikely to be withdrawn.

Refs: https://github.com/nodejs/node-core-utils/pull/1117#pullrequestreview-4787507714