### PR TITLE
chore(linter): fix import resolver to support condition-only export map

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,9 +47,13 @@ export default [
       'import/resolver': {
         node: {
           pathFilter(pkg, path, relativePath) {
-            const pkgExport = relativePath
-              ? pkg.exports?.[`./${relativePath}`]
-              : pkg.exports?.['.'];
+            let pkgExport;
+            if (relativePath) {
+              pkgExport = pkg.exports?.[`./${relativePath}`];
+            }
+            if (!relativePath || (!pkgExport && relativePath === 'index')) {
+              pkgExport = pkg.exports?.['.'] ?? pkg.exports;
+            }
             return pkgExport?.import?.default ??
                    pkgExport?.import ??
                    pkgExport?.[0]?.import ??

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import { ClientRequest } from 'node:http';
 
-// eslint-disable-next-line import/no-unresolved
 import ghauth from 'ghauth';
 
 import { clearCachedConfig, encryptValue, getMergedConfig, getNcurcPath } from './config.js';


### PR DESCRIPTION
The override from #1000 only supported pathy export maps, e.g.

```json
{
  ".": "./index.js",
  "./conditional": {
    "import": "./conditional.mjs",
    "default": "./conditional.cjs"
  }
}
```

rather than

```json
{
  "import": "./index.mjs",
  "default": "./index.cjs"
}
```

Unblocks #1132.