### PR TITLE
chore: remove unused catch bindings

### DIFF
--- a/components/git/land.js
+++ b/components/git/land.js
@@ -181,7 +181,7 @@ async function main(state, argv, cli, dir) {
   }
   try {
     session.restore();
-  } catch (err) { // JSON error?
+  } catch { // JSON error?
     if (state === ABORT) {
       await session.abort();
       return;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,12 @@ export default [
         { ignoreRegExpLiterals: true, ignoreUrls: true },
       ],
       '@stylistic/object-property-newline': 'off',
+      'no-unused-vars': ['error', {
+        args: 'none',
+        caughtErrors: 'all',
+        ignoreRestSiblings: true,
+        vars: 'all',
+      }],
       'promise/always-return': ['error', { ignoreLastCallback: true }],
       'n/no-process-exit': 'off',
       'n/no-unsupported-features/node-builtins': 'off',

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -76,7 +76,7 @@ async function auth(
       let token;
       try {
         ({ username, token } = getMergedConfig());
-      } catch (e) {
+      } catch {
         // Ignore error and prompt
       }
 
@@ -127,7 +127,7 @@ async function auth(
       let token;
       try {
         token = await encryptValue(credentials.token);
-      } catch (err) {
+      } catch {
         console.warn('Failed encrypt token, storing unencrypted instead');
         token = credentials.token;
       }

--- a/lib/backport_session.js
+++ b/lib/backport_session.js
@@ -27,7 +27,7 @@ export default class BackportSession extends Session {
       logs = runSync('git',
         ['log', `-${num}`, '--format=%h', rev, '--', file]
       ).trim();
-    } catch (e) {
+    } catch {
       return null;
     }
     if (!logs) {
@@ -282,7 +282,7 @@ export default class BackportSession extends Session {
         ['rev-parse', '--verify', '--quiet', branch]
       );
       return true;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -38,7 +38,7 @@ export class RunPRJob {
     try {
       const { crumb } = await this.request.json(CI_CRUMB_URL);
       return crumb;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -286,7 +286,7 @@ export default class LandingSession extends Session {
             }
           });
         return this.final();
-      } catch (e) {
+      } catch {
         await runAsync('git', ['rebase', '--abort']);
         const count = subjects.length;
         cli.log(`Couldn't rebase ${count} commits in the PR automatically`);

--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -309,7 +309,7 @@ export default class PrepareSecurityRelease extends SecurityRelease {
         return body.substring(index);
       }
       return body;
-    } catch (error) {
+    } catch {
       this.cli.error(`Could not retrieve the security issue template from ${url}`);
     }
   }

--- a/lib/security-release/security-release.js
+++ b/lib/security-release/security-release.js
@@ -121,7 +121,7 @@ export async function commitAndPushVulnerabilitiesJSON(
       ['push', '-u', 'origin', NEXT_SECURITY_RELEASE_BRANCH],
       `This pushes the security release branch to origin/${NEXT_SECURITY_RELEASE_BRANCH}.`
     );
-  } catch (error) {
+  } catch {
     cli.warn('Rebasing...');
     // try to pull rebase and push again
     await runSecurityGitCommand(

--- a/lib/security_blog.js
+++ b/lib/security_blog.js
@@ -362,7 +362,7 @@ export default class SecurityBlog extends SecurityRelease {
       const date = await this.promptAnnouncementDate(cli);
       validateDate(date);
       return new Date(date).toISOString();
-    } catch (error) {
+    } catch {
       return PLACEHOLDERS.annoucementDate;
     }
   }

--- a/lib/session.js
+++ b/lib/session.js
@@ -160,7 +160,7 @@ export default class Session {
     let sess;
     try {
       sess = this.session;
-    } catch (err) {
+    } catch {
       return fs.rmSync(this.sessionPath, { recursive: true, force: true });
     }
 

--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -261,7 +261,7 @@ async function applyPatch(ctx, task, patch, method = 'apply') {
       ['-p1', '--3way', '--directory=deps/v8'],
       patch.data /* input */
     );
-  } catch (e) {
+  } catch {
     patch.hadConflicts = true;
     return task.prompt(ListrEnquirerPromptAdapter).run({
       type: 'input',

--- a/lib/update-v8/common.js
+++ b/lib/update-v8/common.js
@@ -46,7 +46,7 @@ export async function checkCwd(ctx) {
       isNode = true;
       ctx.nodeMajorVersion = parseInt(match[1], 10);
     }
-  } catch (e) {
+  } catch {
     // ignore
   }
   if (!isNode) {

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -58,7 +58,7 @@ function checkoutBranch() {
       ctx.newVersion = version.split('.').map((s) => parseInt(s, 10));
       try {
         await ctx.execGitV8('branch', '-D', ctx.branch);
-      } catch (e) {
+      } catch {
         // ignore
       }
       await ctx.execGitV8('branch', ctx.branch, `origin/${ctx.branch}`);

--- a/lib/update_security_release.js
+++ b/lib/update_security_release.js
@@ -66,7 +66,7 @@ export default class UpdateSecurityRelease extends SecurityRelease {
 
     try {
       validateDate(releaseDate);
-    } catch (error) {
+    } catch {
       cli.error('Invalid date format. Please use the format yyyy/mm/dd.');
       process.exit(1);
     }
@@ -350,7 +350,7 @@ export default class UpdateSecurityRelease extends SecurityRelease {
             h1Report.data.relationships.severity?.data.attributes.cvss_vector_string,
           rating: h1Report.data.relationships.severity?.data.attributes.rating
         };
-      } catch (error) {
+      } catch {
         this.cli.error(`Couldnt not retrieve severity from report ${id}, skipping...`);
         return false;
       }


### PR DESCRIPTION
eslint/js/recommended detects these by default, but neostandard disables the rule. This syntax has been supported since Node.js 10.x, may as well make use of it.