### PR TITLE
chore(linter): enable neostandard semicolon mode

### DIFF
--- a/components/metadata.js
+++ b/components/metadata.js
@@ -114,4 +114,4 @@ export async function getMetadata(argv, skipRefs, cli) {
     ...result,
     json: formatMetadataResult(result)
   };
-};
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import importPlugin from 'eslint-plugin-import';
 
 export default [
   pluginJs.configs.recommended,
-  ...neostandard(),
+  ...neostandard({ semi: true }),
   nodePlugin.configs['flat/recommended'],
   pluginPromise.configs['flat/recommended'],
   importPlugin.flatConfigs.recommended,
@@ -28,7 +28,6 @@ export default [
       ecmaVersion: 'latest',
     },
     rules: {
-      '@stylistic/semi': ['error', 'always'],
       '@stylistic/space-before-function-paren': ['error', 'never'],
       '@stylistic/no-multi-spaces': ['error', { ignoreEOLComments: true }],
       camelcase: 'off',

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -94,7 +94,7 @@ async function auth(
           'and run the following command to add it to your ncu config: ' +
           'ncu-config --global set -x jenkins_token'
         );
-      };
+      }
       check(username, jenkins_token);
       const jenkins = encode(username, jenkins_token);
       setOwnProperty(result, 'jenkins', jenkins);

--- a/lib/backport_session.js
+++ b/lib/backport_session.js
@@ -273,7 +273,7 @@ export default class BackportSession extends Session {
     const upstreamCommit = this.getBranchCommit(`${this.upstream}/${branch}`);
 
     return localCommit === upstreamCommit;
-  };
+  }
 
   isLocalBranchExists(branch) {
     try {

--- a/lib/ci/failure_aggregator.js
+++ b/lib/ci/failure_aggregator.js
@@ -49,7 +49,7 @@ export class FailureAggregator {
       data.push({
         reason, type: failures[0].type, failures, prs, machines
       });
-    };
+    }
 
     const groupedByType = _.groupBy(data, 'type');
     for (const type of Object.keys(groupedByType)) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -217,7 +217,7 @@ export default class CLI {
   setExitCode(statusCode) {
     process.exitCode = statusCode;
   }
-};
+}
 
 CLI.SPINNER_STATUS = SPINNER_STATUS;
 CLI.QUESTION_TYPE = QUESTION_TYPE;

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,7 @@ export function getMergedConfig(dir, home, additional) {
       ...Object.getOwnPropertyDescriptors(additional),
     })
     : mergedConfig;
-};
+}
 export function clearCachedConfig() {
   mergedConfig = null;
 }
@@ -117,7 +117,7 @@ export function getConfig(configType, dir, raw = false) {
   } catch (cause) {
     throw new Error('Unable to parse config file ' + configPath, { cause });
   }
-};
+}
 
 function getConfigPath(configType, dir) {
   switch (configType) {
@@ -135,7 +135,7 @@ function getConfigPath(configType, dir) {
     default:
       throw Error('Invalid configType');
   }
-};
+}
 
 function writeConfig(configType, obj, dir) {
   const configPath = getConfigPath(configType, dir);
@@ -158,20 +158,20 @@ function writeConfig(configType, obj, dir) {
   }
   writeJson(configPath, obj);
   return configPath;
-};
+}
 
 export function updateConfig(configType, obj, dir) {
   const config = getConfig(configType, dir, true);
   writeConfig(configType, Object.assign(config, obj), dir);
-};
+}
 
 export function getHomeDir(home) {
   if (process.env.XDG_CONFIG_HOME) {
     return process.env.XDG_CONFIG_HOME;
   }
   return home || os.homedir();
-};
+}
 
 export function getNcuDir(dir) {
   return path.join(dir || process.cwd(), '.ncu');
-};
+}

--- a/lib/file.js
+++ b/lib/file.js
@@ -8,7 +8,7 @@ export function appendFile(file, content) {
   }
   // TODO(joyeecheung): what if the file is a dir?
   fs.appendFileSync(file, content, 'utf8');
-};
+}
 
 export function writeFile(file, content) {
   const parts = path.parse(file);
@@ -17,18 +17,18 @@ export function writeFile(file, content) {
   }
   // TODO(joyeecheung): what if the file is a dir?
   fs.writeFileSync(file, content, 'utf8');
-};
+}
 
 export function writeJson(file, obj) {
   writeFile(file, `${JSON.stringify(obj, null, 2)}\n`);
-};
+}
 
 export function readFile(file) {
   if (fs.existsSync(file)) {
     return fs.readFileSync(file, 'utf8');
   }
   return '';
-};
+}
 
 export function readJson(file) {
   const content = readFile(file);
@@ -36,7 +36,7 @@ export function readJson(file) {
     return JSON.parse(content);
   }
   return {};
-};
+}
 
 export function removeDirectory(directory) {
   return fs.promises.rm(directory, { recursive: true, force: true });

--- a/lib/landing_session.js
+++ b/lib/landing_session.js
@@ -510,7 +510,7 @@ export default class LandingSession extends Session {
       cli.log('A git rebase/am is in progress.' +
         ' Please complete it before running git node land --final');
       return;
-    };
+    }
 
     const stray = this.getStrayCommits();
     if (stray.length > 1) {

--- a/lib/links.js
+++ b/lib/links.js
@@ -100,15 +100,15 @@ export function parsePRFromURL(url) {
     };
   }
   return undefined;
-};
+}
 
 export function getPrURL({ owner, repo, prid }) {
   return `https://github.com/${owner}/${repo}/pull/${prid}`;
-};
+}
 
 export function getMachineUrl(machine) {
   return `[${machine.hostname}](${machine.url})`;
-};
+}
 
 const PR_URL_RE = /PR-URL: https:\/\/github.com\/.+/;
 export function parsePrURL(text) {
@@ -120,4 +120,4 @@ export function parsePrURL(text) {
     return undefined;
   }
   return parsePRFromURL(match[0]);
-};
+}

--- a/lib/pr_data.js
+++ b/lib/pr_data.js
@@ -112,4 +112,4 @@ export default class PRData {
     const assoc = this.pr.authorAssociation;
     return assoc === FIRST_TIME_CONTRIBUTOR || assoc === FIRST_TIMER;
   }
-};
+}

--- a/lib/pr_summary.js
+++ b/lib/pr_summary.js
@@ -58,5 +58,5 @@ export default class PRSummary {
     for (const { name, email } of committers.values()) {
       cli.log(` - ${name} <${email}>`);
     }
-  };
+  }
 }

--- a/lib/prepare_release.js
+++ b/lib/prepare_release.js
@@ -559,7 +559,7 @@ export default class ReleasePreparation extends Session {
         arr.splice(idx, 1, `<b>${newRefLink}</b><br/>`, `${lastRefLink}<br/>`);
         break;
       }
-    };
+    }
 
     await fs.writeFile(mainChangelogPath, arr.join('\n'));
   }
@@ -640,7 +640,7 @@ export default class ReleasePreparation extends Session {
         arr.splice(idx, 0, ...toAppend);
         break;
       }
-    };
+    }
 
     await fs.writeFile(majorChangelogPath, arr.join('\n'));
   }

--- a/lib/prepare_security.js
+++ b/lib/prepare_security.js
@@ -275,7 +275,7 @@ export default class PrepareSecurityRelease extends SecurityRelease {
         - git push -u origin ${NEXT_SECURITY_RELEASE_BRANCH}
         - open a PR on ${this.repository.owner}/${this.repository.repo}`);
       return;
-    };
+    }
 
     // commit and push the vulnerabilities.json file
     const commitMessage = 'chore: create vulnerabilities.json for next security release';

--- a/lib/run.js
+++ b/lib/run.js
@@ -77,7 +77,7 @@ export function forceRunAsync(cmd, args, options) {
       throw error;
     }
   });
-};
+}
 
 export function runPromise(promise) {
   return promise.catch((error) => {
@@ -86,11 +86,11 @@ export function runPromise(promise) {
     }
     exit();
   });
-};
+}
 
 export function runAsync(cmd, args, options) {
   return runPromise(runAsyncBase(cmd, args, options));
-};
+}
 
 export function runSync(cmd, args, options) {
   if (cmd instanceof URL) {
@@ -111,8 +111,8 @@ export function runSync(cmd, args, options) {
   } else {
     return child.stdout.toString();
   }
-};
+}
 
 export function exit() {
   process.exit(1);
-};
+}

--- a/lib/security-release/security-release.js
+++ b/lib/security-release/security-release.js
@@ -85,7 +85,7 @@ export async function checkoutOnSecurityReleaseBranch(cli, repository) {
       `This checks out or recreates the ${NEXT_SECURITY_RELEASE_BRANCH} branch locally.`
     );
     cli.ok(`Checkout on branch: ${NEXT_SECURITY_RELEASE_BRANCH} `);
-  };
+  }
 }
 
 export async function commitAndPushVulnerabilitiesJSON(

--- a/lib/team_info.js
+++ b/lib/team_info.js
@@ -76,7 +76,7 @@ TeamInfo.update = async function(cli, request, content) {
       const opening = `<!-- ncu-team-sync.team(${org}/${team}) -->`;
       const ending = '<!-- ncu-team-sync end -->';
       blocks.set(mapKey, `${opening}\n\n${teamData}\n\n${ending}`);
-    };
+    }
   }
 
   if (blocks.size === 0) {

--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -24,7 +24,7 @@ export async function checkOptions(options) {
       return true;
     }
   }
-};
+}
 
 export function doBackport(options) {
   const todo = [
@@ -54,7 +54,7 @@ export function doBackport(options) {
       return task.newListr(todo);
     }
   };
-};
+}
 
 function commitSquashedBackport() {
   return {
@@ -77,7 +77,7 @@ function commitSquashedBackport() {
       await ctx.execGitNode('commit', ['-m', messageTitle, '-m', messageBody]);
     }
   };
-};
+}
 
 const commitTask = (patch, extraArgs, trailers) => async(ctx) => {
   const messageTitle = formatMessageTitle([patch]);

--- a/lib/update-v8/commitUpdate.js
+++ b/lib/update-v8/commitUpdate.js
@@ -20,4 +20,4 @@ export default function commitUpdate() {
     },
     skip: (ctx) => ctx.skipped
   };
-};
+}

--- a/lib/update-v8/common.js
+++ b/lib/update-v8/common.js
@@ -12,7 +12,7 @@ export function getV8Version(label) {
       ctx[`${label}Version`] = await getNodeV8Version(ctx.nodeDir);
     }
   };
-};
+}
 
 export function checkCargoAvailable() {
   return {
@@ -56,4 +56,4 @@ export async function checkCwd(ctx) {
     );
   }
   return ctx;
-};
+}

--- a/lib/update-v8/deps.js
+++ b/lib/update-v8/deps.js
@@ -83,4 +83,4 @@ export default function updateV8Deps() {
       return task.newListr(subtasks, { concurrent: ctx.concurrent });
     }
   };
-};
+}

--- a/lib/update-v8/index.js
+++ b/lib/update-v8/index.js
@@ -23,7 +23,7 @@ export function major(options) {
     getOptions(options)
   );
   return tasks.run(options);
-};
+}
 
 export function minor(options) {
   const tasks = new Listr(
@@ -31,7 +31,7 @@ export function minor(options) {
     getOptions(options)
   );
   return tasks.run(options);
-};
+}
 
 export async function backport(options) {
   const shouldStop = await checkOptions(options);
@@ -42,7 +42,7 @@ export async function backport(options) {
     getOptions(options)
   );
   return tasks.run(options);
-};
+}
 
 export async function deps(options) {
   const tasks = new Listr(
@@ -50,7 +50,7 @@ export async function deps(options) {
     getOptions(options)
   );
   return tasks.run(options);
-};
+}
 
 /**
  * Get the listr2 options.

--- a/lib/update-v8/majorUpdate.js
+++ b/lib/update-v8/majorUpdate.js
@@ -26,7 +26,7 @@ export default function majorUpdate() {
       ]);
     }
   };
-};
+}
 
 function checkoutBranch() {
   return {

--- a/lib/update-v8/minorUpdate.js
+++ b/lib/update-v8/minorUpdate.js
@@ -16,7 +16,7 @@ export default function minorUpdate() {
       ]);
     }
   };
-};
+}
 
 function getLatestV8Version() {
   return {

--- a/lib/update-v8/updateV8Clone.js
+++ b/lib/update-v8/updateV8Clone.js
@@ -10,7 +10,7 @@ export default function updateV8Clone() {
       return task.newListr([fetchOrigin(), createClone()]);
     }
   };
-};
+}
 
 function fetchOrigin() {
   return {

--- a/lib/update-v8/updateVersionNumbers.js
+++ b/lib/update-v8/updateVersionNumbers.js
@@ -8,7 +8,7 @@ export default function updateVersionNumbers() {
       return task.newListr([resetEmbedderString(), bumpNodeModule()]);
     }
   };
-};
+}
 
 function bumpNodeModule() {
   return {

--- a/lib/update-v8/util.js
+++ b/lib/update-v8/util.js
@@ -26,7 +26,7 @@ export async function getNodeV8Version(cwd) {
   } catch (cause) {
     throw new Error('Could not find V8 version', { cause });
   }
-};
+}
 
 export function filterForVersion(list, version) {
   return list.filter((dep) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,12 +6,12 @@ import { forceRunAsync } from './run.js';
 export function ascending(a, b) {
   if (a === b) return 0;
   return a < b ? -1 : 1;
-};
+}
 
 export function descending(a, b) {
   if (a === b) return 0;
   return a > b ? -1 : 1;
-};
+}
 
 export function flatten(arr) {
   let result = [];
@@ -27,7 +27,7 @@ export function flatten(arr) {
 
 export function shortSha(sha) {
   return sha.slice(0, 12);
-};
+}
 
 let isGhAvailableCache;
 export function isGhAvailable() {
@@ -35,7 +35,7 @@ export function isGhAvailable() {
     isGhAvailableCache = which.sync('gh', { nothrow: true }) !== null;
   }
   return isGhAvailableCache;
-};
+}
 
 /**
  * Returns the user's preferred text editor command.
@@ -65,4 +65,4 @@ export async function getEditor(options = {}) {
 
   return process.env.VISUAL || process.env.EDITOR ||
           (platform() === 'win32' ? 'notepad.exe' : 'vi');
-};
+}

--- a/lib/verbosity.js
+++ b/lib/verbosity.js
@@ -11,7 +11,7 @@ export let verbosity = VERBOSITY.NONE;
 
 export function isDebugVerbosity() {
   return verbosity === VERBOSITY.DEBUG;
-};
+}
 
 export function setVerbosityFromEnv() {
   const env = (process.env.NCU_VERBOSITY || '').toUpperCase();
@@ -21,9 +21,9 @@ export function setVerbosityFromEnv() {
   if (!isDebugVerbosity()) {
     Error.stackTraceLimit = 0;
   }
-};
+}
 
 export function debuglog(...args) {
   // Prepend a line break in case it's logged while the spinner is running
   console.error(chalk.green(util.format('\n[DEBUG]', ...args)));
-};
+}

--- a/test/fixtures/assert_throws_async.js
+++ b/test/fixtures/assert_throws_async.js
@@ -13,4 +13,4 @@ export default async function assertThrowsAsync(fn, regExp) {
   } finally {
     assert.throws(throwFn, regExp);
   }
-};
+}

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -112,7 +112,7 @@ for (const item of readdirSync(path('./github-ci'))) {
     continue;
   }
   githubCI[basename(item, '.json')] = readJSON(`./github-ci/${item}`);
-};
+}
 
 export const pullRequests = {};
 
@@ -121,7 +121,7 @@ for (const item of readdirSync(path('./pull_requests'))) {
     continue;
   }
   pullRequests[basename(item, '.json')] = readJSON(`./pull_requests/${item}`);
-};
+}
 
 export const jenkinsCI = {};
 
@@ -133,4 +133,4 @@ for (const subdir of readdirSync(path('./jenkins'))) {
     jenkinsCI[`${subdir}/${basename(item, '.json')}`] =
       readJSON(`./jenkins/${subdir}/${item}`);
   }
-};
+}

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -7,19 +7,19 @@ const __dirname = nodePath.dirname(fileURLToPath(import.meta.url));
 export function readFile(...args) {
   const file = nodePath.join(__dirname, ...args);
   return fs.readFileSync(file, 'utf8');
-};
+}
 
 export function readJSON(...args) {
   const file = readFile(...args);
   return JSON.parse(file);
-};
+}
 
 export function patchPrototype(arr, key, proto) {
   for (const item of arr) {
     Object.setPrototypeOf(item[key], proto);
   }
-};
+}
 
 export function path(...args) {
   return nodePath.join(__dirname, ...args);
-};
+}


### PR DESCRIPTION
neostandard defaults to disallowing terminating semicolons, but this can be switched by passing `semi: true` to the neostandard initializer.

We were previously omitting this option and manually overriding the semicolon rule, but this left other semicolon linting disabled, specifically `@stylistic/no-extra-semi`.