### PR TITLE
chore: fix typo in reviews.js comment

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -83,7 +83,7 @@ export class ReviewAnalyzer {
       switch (r.state) {
         case APPROVED:
         case CHANGES_REQUESTED:
-          // Overwrite previous reviews, whether initalized or not
+          // Overwrite previous reviews, whether initialized or not
           map.set(
             login,
             new Review(r.state, r.publishedAt, r.url, FROM_REVIEW)


### PR DESCRIPTION
Typo in a code comment: `initalized` -> `initialized`.

`lib/reviews.js:86`. Comment only, no functional change.
