### PR TITLE
fix: skip orphaned check suites when checking GitHub CI

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -25,6 +25,10 @@ const WAIT_TIME_SINGLE_APPROVAL = 24 * 7;
 
 const GITHUB_SUCCESS_CONCLUSIONS = ['SUCCESS', 'NEUTRAL', 'SKIPPED'];
 const GITHUB_ACTIONS_APP = 'github-actions';
+// A GitHub Actions check suite with no runs that has not started after this
+// long is considered orphaned (created but never dispatched by GitHub) and is
+// ignored so it does not block landing. See nodejs/node-core-utils#1160.
+const ORPHANED_CHECK_SUITE_TIMEOUT = MINUTE * 60 * 3;
 
 const FAST_TRACK_RE = /^Fast-track has been requested by @(.+?)\. Please 👍 to approve\.$/;
 const FAST_TRACK_MIN_APPROVALS = 2;
@@ -460,8 +464,17 @@ export default class PRChecker {
     const pendingJobs = [];
 
     // GitHub new Check API
-    for (const { status, conclusion, checkRuns } of checkSuites.nodes) {
+    for (const { status, conclusion, checkRuns, createdAt } of checkSuites.nodes) {
       if (status !== 'COMPLETED') {
+        // Skip orphaned check suites: no runs and never dispatched by GitHub.
+        // They will never complete, so they should not block landing.
+        const runCount = checkRuns?.nodes?.length ?? 0;
+        const age = Date.now() - new Date(createdAt).getTime();
+        if (runCount === 0 && age > ORPHANED_CHECK_SUITE_TIMEOUT) {
+          cli.warn('Ignoring orphaned check suite with no runs ' +
+            `(status: ${status}, age: ${Math.round(age / MINUTE / 60)}h)`);
+          continue;
+        }
         pendingJobs.push({ status, conclusion });
         continue;
       }

--- a/lib/queries/PR.gql
+++ b/lib/queries/PR.gql
@@ -35,6 +35,7 @@ query PR($prid: Int!, $owner: String!, $repo: String!) {
             # https://api.github.com/apps/github-actions
             checkSuites(first: 100, filterBy: { appId: 15368 }) {
               nodes {
+                createdAt,
                 conclusion,
                 status,
                 checkRuns(first: 40) {

--- a/test/fixtures/github-ci/check-suite-orphaned.json
+++ b/test/fixtures/github-ci/check-suite-orphaned.json
@@ -1,0 +1,39 @@
+[
+  {
+    "commit": {
+      "committedDate": "2017-10-26T12:10:20Z",
+      "oid": "9d098ssiskj8dhd39js0sjd0cn2ng4is9n40sj12d",
+      "messageHeadline": "doc: add api description README",
+      "author": {
+        "login": "foo"
+      },
+      "checkSuites": {
+        "nodes": [
+          {
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "checkRuns": {
+              "nodes": [
+                {
+                  "name": "test-linux",
+                  "status": "COMPLETED",
+                  "conclusion": "SUCCESS",
+                  "detailsUrl": "https://example.com"
+                }
+              ]
+            }
+          },
+          {
+            "status": "QUEUED",
+            "conclusion": null,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "checkRuns": {
+              "nodes": []
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -1803,6 +1803,28 @@ describe('PRChecker', () => {
       cli.assertCalledWith(expectedLogs);
     });
 
+    it('should skip orphaned check suite with no runs older than the timeout',
+      async() => {
+        const cli = new TestCLI();
+
+        const expectedLogs = {
+          ok: [
+            ['Last GitHub CI successful']
+          ]
+        };
+
+        const commits = githubCI['check-suite-orphaned'];
+        const data = Object.assign({}, baseData, { commits });
+
+        const checker = new PRChecker(cli, data, {}, testArgv);
+
+        const status = await checker.checkCI();
+        assert(status);
+        // Ignore the warn channel: it reports the orphaned suite's age, which
+        // is computed from the current time and is therefore non-deterministic.
+        cli.assertCalledWith(expectedLogs, { ignore: ['warn'] });
+      });
+
     it('should error if commit status failed', async() => {
       const cli = new TestCLI();
 


### PR DESCRIPTION
### Problem

`checkGitHubCI()` blocks landing with `✘ GitHub CI is still running` whenever any GitHub Actions check suite has a status other than `COMPLETED`. GitHub occasionally creates check suites that remain stuck in `QUEUED` with zero check runs — they are never dispatched and will never complete. These orphaned suites block the commit queue indefinitely, forcing collaborators to land PRs manually with `git node land`.

This was discussed in #1160 and observed on at least two recent nodejs/node PRs ([#64991](https://github.com/nodejs/node/pull/64991), [#64830](https://github.com/nodejs/node/pull/64830)), both stuck on an orphaned `Test macOS` suite and landed manually.

### Fix

Skip a non-completed suite only when **both**:
- it has zero check runs (`checkRuns.nodes.length === 0`), and
- it was created more than 3 hours ago.

A legitimately queued suite gets its check runs attached within seconds, so it will not match. Suites with active runs still block as before, and a freshly created empty suite (within the window) is not skipped. This is strictly narrower than the current manual workaround (`git node land --yes`), which bypasses *all* checks including real failures.

Adds `createdAt` to the `checkSuites` GraphQL query to compute suite age.

### Trade-off

If someone adds `commit-queue` before `request-ci` has finished triggering all workflows, a suite that should have run but hasn't started yet could — after aging past the 3h threshold — be skipped, landing the PR without that workflow's results. The 3h window makes this unlikely in practice, and the timeout can be made configurable in a follow-up if desired.

### Test

Added a unit test with an orphaned suite (0 runs, old `createdAt`) alongside a completed suite; the checker now passes instead of blocking. `test/unit/pr_checker.test.js`: 74/74 pass.

Refs: #1160

### Validated against the affected PRs

Ran the skip condition against the live check-suite data of both PRs that were stuck on this:

| PR | Orphaned suite | runs | age | result with this fix |
|----|----------------|------|-----|----------------------|
| [#64991](https://github.com/nodejs/node/pull/64991) | `queued` | 0 | ~199h | skipped → unblocked |
| [#64830](https://github.com/nodejs/node/pull/64830) | `queued` | 0 | ~358h | skipped → unblocked |

In both cases the single orphaned suite is exactly what blocked the commit queue, and this change lets the check pass instead of hanging indefinitely.
