### PR TITLE
chore: replace which with spawnSync

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 import { platform } from 'node:os';
-import which from 'which';
+import { spawnSync } from 'node:child_process';
 
 import { forceRunAsync } from './run.js';
 
@@ -32,7 +32,9 @@ export function shortSha(sha) {
 let isGhAvailableCache;
 export function isGhAvailable() {
   if (isGhAvailableCache === undefined) {
-    isGhAvailableCache = which.sync('gh', { nothrow: true }) !== null;
+    isGhAvailableCache = spawnSync(
+      'gh', ['--version'], { stdio: 'ignore' }
+    ).status === 0;
   }
   return isGhAvailableCache;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "semver",
         "smol-toml",
         "undici",
-        "which",
         "yargs"
       ],
       "license": "MIT",
@@ -49,7 +48,6 @@
         "semver": "^7.7.1",
         "smol-toml": "^1.7.0",
         "undici": "^8.3.0",
-        "which": "^7.0.0",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -5161,16 +5159,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/isexe": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -9909,22 +9897,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/which": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-7.0.0.tgz",
-      "integrity": "sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^4.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/which-boxed-primitive": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "semver": "^7.7.1",
     "smol-toml": "^1.7.0",
     "undici": "^8.3.0",
-    "which": "^7.0.0",
     "yargs": "^18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Use Node.js' built-in child_process API to detect whether the GitHub CLI is available.
This removes the runtime dependency for "which".

### Testing

#### when `gh` is installed

```console
$> node
Welcome to Node.js v22.23.2.
Type ".help" for more information.
> require("which").sync('gh', { nothrow: true }) !== null
true
> require('node:child_process').spawnSync(
...   'gh', ['--version'], { stdio: 'ignore' }
... ).status === 0
true
```

#### when `gh` is not installed

```console
$> node
Welcome to Node.js v22.23.2.
Type ".help" for more information.
> require("which").sync('gh', { nothrow: true }) !== null
false
> require('node:child_process').spawnSync(
...   'gh', ['--version'], { stdio: 'ignore' }
... ).status === 0
false
```