### PR TITLE
chore: remove redundant globals dependency

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-import globals from 'globals';
 import pluginJs from '@eslint/js';
 import neostandard from 'neostandard';
 import nodePlugin from 'eslint-plugin-n';
@@ -23,7 +22,6 @@ export default [
   },
   {
     languageOptions: {
-      globals: globals.nodeBuiltin,
       sourceType: 'module',
       ecmaVersion: 'latest',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-n": "^17.24.0",
         "eslint-plugin-promise": "^7.3.0",
-        "globals": "^17.4.0",
         "neostandard": "^0.13.0",
         "sinon": "^22.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-promise": "^7.3.0",
-    "globals": "^17.4.0",
     "neostandard": "^0.13.0",
     "sinon": "^22.0.0"
   }


### PR DESCRIPTION
Removes the redundant `globals` dev dependency because `neostandard` already provides the required Node.js globals.

No lint behavior changes.