### PR TITLE
chore: remove redundant ESLint plugin dependencies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,12 @@
 import pluginJs from '@eslint/js';
-import neostandard from 'neostandard';
-import nodePlugin from 'eslint-plugin-n';
-import pluginPromise from 'eslint-plugin-promise';
+import neostandard, { plugins } from 'neostandard';
 import importPlugin from 'eslint-plugin-import';
 
 export default [
   pluginJs.configs.recommended,
   ...neostandard({ semi: true }),
-  nodePlugin.configs['flat/recommended'],
-  pluginPromise.configs['flat/recommended'],
+  plugins.n.configs['flat/recommended'],
+  plugins.promise.configs['flat/recommended'],
   importPlugin.flatConfigs.recommended,
   {
     ignores: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,8 +62,6 @@
         "c8": "^12.0.0",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-n": "^17.24.0",
-        "eslint-plugin-promise": "^7.3.0",
         "neostandard": "^0.13.0",
         "sinon": "^22.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
     "c8": "^12.0.0",
     "eslint": "^9.39.4",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-n": "^17.24.0",
-    "eslint-plugin-promise": "^7.3.0",
     "neostandard": "^0.13.0",
     "sinon": "^22.0.0"
   }


### PR DESCRIPTION
Removes redundant `eslint-plugin-n` and `eslint-plugin-promise` dev dependencies and updates the ESLint configuration to use the plugin instances exported by `neostandard`, preserving the existing linting behavior.