### PR TITLE
feat: expose pull request labels in metadata JSON

### DIFF
--- a/components/metadata.js
+++ b/components/metadata.js
@@ -61,7 +61,8 @@ export function formatMetadataResult({ status, data, metadata, checker }) {
       owner: data.owner,
       repo: data.repo,
       number: data.prid,
-      url: data.pr.url
+      url: data.pr.url,
+      labels: data.pr.labels.nodes.map(({ name }) => name)
     },
     metadata,
     reasonCodes,

--- a/docs/git-node.md
+++ b/docs/git-node.md
@@ -328,8 +328,9 @@ git node metadata 167 --repo llnode --readme ../node/README.md
 When `--json` is used, stdout contains a JSON object and progress/check output
 is written to stderr. The command still exits non-zero when the pull request is
 not ready to land. The JSON includes `ready`, `readiness`, `exitCode`,
-`metadata`, `reasonCodes`, and `reasons`. `reasonCodes` is a de-duplicated list
-of stable machine-readable codes such as `missing-approval`,
+`pullRequest`, `metadata`, `reasonCodes`, and `reasons`. `pullRequest.labels` is
+an array of the pull request's label names. `reasonCodes` is a de-duplicated
+list of stable machine-readable codes such as `missing-approval`,
 `missing-tsc-approval`, `wait-time`, `missing-github-ci`, `pending-github-ci`,
 `conflict`, `requested-changes`, and `stale-review`.
 

--- a/test/unit/metadata.test.js
+++ b/test/unit/metadata.test.js
@@ -26,7 +26,13 @@ describe('metadata command helpers', () => {
         repo: 'node',
         prid: 12345,
         pr: {
-          url: 'https://github.com/nodejs/node/pull/12345'
+          url: 'https://github.com/nodejs/node/pull/12345',
+          labels: {
+            nodes: [
+              { name: 'commit-queue' },
+              { name: 'fast-track' }
+            ]
+          }
         }
       },
       metadata: 'PR-URL: https://github.com/nodejs/node/pull/12345\n',
@@ -43,7 +49,8 @@ describe('metadata command helpers', () => {
         owner: 'nodejs',
         repo: 'node',
         number: 12345,
-        url: 'https://github.com/nodejs/node/pull/12345'
+        url: 'https://github.com/nodejs/node/pull/12345',
+        labels: ['commit-queue', 'fast-track']
       },
       metadata: 'PR-URL: https://github.com/nodejs/node/pull/12345\n',
       reasonCodes: [PR_CHECK_REASON_CODES.WAIT_TIME],
@@ -59,7 +66,8 @@ describe('metadata command helpers', () => {
         repo: 'node',
         prid: 12345,
         pr: {
-          url: 'https://github.com/nodejs/node/pull/12345'
+          url: 'https://github.com/nodejs/node/pull/12345',
+          labels: { nodes: [] }
         }
       },
       metadata: 'PR-URL: https://github.com/nodejs/node/pull/12345\n',
@@ -75,6 +83,7 @@ describe('metadata command helpers', () => {
 
     assert.strictEqual(result.readiness, METADATA_READINESS.DEFERRABLE);
     assert.strictEqual(result.exitCode, METADATA_EXIT_CODES.DEFERRABLE);
+    assert.deepStrictEqual(result.pullRequest.labels, []);
   });
 
   it('classifies missing approvals as failed', () => {
@@ -85,7 +94,8 @@ describe('metadata command helpers', () => {
         repo: 'node',
         prid: 12345,
         pr: {
-          url: 'https://github.com/nodejs/node/pull/12345'
+          url: 'https://github.com/nodejs/node/pull/12345',
+          labels: { nodes: [] }
         }
       },
       metadata: 'PR-URL: https://github.com/nodejs/node/pull/12345\n',
@@ -111,7 +121,8 @@ describe('metadata command helpers', () => {
         repo: 'node',
         prid: 12345,
         pr: {
-          url: 'https://github.com/nodejs/node/pull/12345'
+          url: 'https://github.com/nodejs/node/pull/12345',
+          labels: { nodes: [] }
         }
       },
       metadata: 'PR-URL: https://github.com/nodejs/node/pull/12345\n',


### PR DESCRIPTION
Expose pull request label names in `git node metadata --json` as `pullRequest.labels`.

The metadata command already fetches these labels, exposing them will allow commit queue to avoid separately fetching labels before deciding whether a label mutation is needed.