### PR TITLE
fix: ignore fully skipped startup failures

### DIFF
--- a/lib/pr_checker.js
+++ b/lib/pr_checker.js
@@ -467,43 +467,54 @@ export default class PRChecker {
       }
 
       if (!GITHUB_SUCCESS_CONCLUSIONS.includes(conclusion)) {
-        hasFailures = true;
+        const runs = checkRuns?.nodes ?? [];
+        const allRunsSkipped = runs.length > 0 &&
+          runs.length === checkRuns.totalCount &&
+          runs.every((checkRun) => checkRun.status === 'COMPLETED' &&
+            checkRun.conclusion === 'SKIPPED');
 
-        // If we have detailed checkRuns, show specific failing jobs
-        if (checkRuns && checkRuns.nodes && checkRuns.nodes.length > 0) {
-          for (const checkRun of checkRuns.nodes) {
-            if (checkRun.status === 'COMPLETED' &&
-                !GITHUB_SUCCESS_CONCLUSIONS.includes(checkRun.conclusion)) {
-              if (checkRun.conclusion === 'CANCELLED') {
-                cancelledJobs.push({
-                  name: checkRun.name,
-                  conclusion: checkRun.conclusion,
-                  url: checkRun.detailsUrl
-                });
-              } else {
-                failedJobs.push({
-                  name: checkRun.name,
-                  conclusion: checkRun.conclusion,
-                  url: checkRun.detailsUrl
-                });
-              }
+        // GitHub can report a STARTUP_FAILURE for a workflow even though all
+        // of its conditional jobs were skipped. There is no failed check in
+        // that case, so the suite should not make the commit unlandable.
+        if (conclusion === 'STARTUP_FAILURE' && allRunsSkipped) {
+          continue;
+        }
+
+        hasFailures = true;
+        let reportedFailure = false;
+
+        // If we have detailed checkRuns, show specific failing jobs.
+        for (const checkRun of runs) {
+          if (checkRun.status === 'COMPLETED' &&
+              !GITHUB_SUCCESS_CONCLUSIONS.includes(checkRun.conclusion)) {
+            reportedFailure = true;
+            if (checkRun.conclusion === 'CANCELLED') {
+              cancelledJobs.push({
+                name: checkRun.name,
+                conclusion: checkRun.conclusion,
+                url: checkRun.detailsUrl
+              });
+            } else {
+              failedJobs.push({
+                name: checkRun.name,
+                conclusion: checkRun.conclusion,
+                url: checkRun.detailsUrl
+              });
             }
           }
-        } else {
-          // Fallback to check suite level information if no checkRuns
-          if (conclusion === 'CANCELLED') {
-            cancelledJobs.push({
-              name: GITHUB_ACTIONS_APP,
-              conclusion,
-              url: null
-            });
-          } else {
-            failedJobs.push({
-              name: GITHUB_ACTIONS_APP,
-              conclusion,
-              url: null
-            });
-          }
+        }
+
+        // Fall back to the suite when its failed conclusion is not reflected
+        // by an individual check run.
+        if (!reportedFailure) {
+          const failures = conclusion === 'CANCELLED'
+            ? cancelledJobs
+            : failedJobs;
+          failures.push({
+            name: GITHUB_ACTIONS_APP,
+            conclusion,
+            url: null
+          });
         }
       }
     }

--- a/lib/queries/PR.gql
+++ b/lib/queries/PR.gql
@@ -38,6 +38,7 @@ query PR($prid: Int!, $owner: String!, $repo: String!) {
                 conclusion,
                 status,
                 checkRuns(first: 40) {
+                  totalCount
                   nodes {
                     name
                     status

--- a/test/unit/graphql_queries.test.js
+++ b/test/unit/graphql_queries.test.js
@@ -20,6 +20,7 @@ describe('GraphQL queries', () => {
       headCommitQuery,
       /checkSuites\(first: 100, filterBy: \{ appId: 15368 \}\)/);
     assert.match(headCommitQuery, /checkRuns\(first: 40\)/);
+    assert.match(headCommitQuery, /checkRuns\(first: 40\) \{\s+totalCount/);
     assert.match(headCommitQuery, /status \{\s+state\s+\}/);
     assert.doesNotMatch(headCommitQuery, /\bapp\s*\{/);
     assert.doesNotMatch(commitsQuery, /checkSuites/);

--- a/test/unit/pr_checker.test.js
+++ b/test/unit/pr_checker.test.js
@@ -1860,6 +1860,88 @@ describe('PRChecker', () => {
       cli.assertCalledWith(expectedLogs);
     });
 
+    it('should ignore startup failures with only skipped check runs',
+      async() => {
+        const cli = new TestCLI();
+
+        const expectedLogs = {
+          ok: [
+            ['Last GitHub CI successful']
+          ]
+        };
+
+        const commits = [{
+          commit: {
+            checkSuites: {
+              nodes: [{
+                status: 'COMPLETED',
+                conclusion: 'STARTUP_FAILURE',
+                checkRuns: {
+                  totalCount: 2,
+                  nodes: [
+                    {
+                      name: 'stale-comment',
+                      status: 'COMPLETED',
+                      conclusion: 'SKIPPED'
+                    },
+                    {
+                      name: 'notable-change',
+                      status: 'COMPLETED',
+                      conclusion: 'SKIPPED'
+                    }
+                  ]
+                }
+              }]
+            }
+          }
+        }];
+        const data = Object.assign({}, baseData, { commits });
+
+        const checker = new PRChecker(cli, data, {}, testArgv);
+
+        const status = await checker.checkCI();
+        assert(status);
+        cli.assertCalledWith(expectedLogs);
+      });
+
+    it('should report a suite failure when check runs are incomplete',
+      async() => {
+        const cli = new TestCLI();
+
+        const expectedLogs = {
+          error: [
+            ['1 GitHub CI job(s) failed:'],
+            ['  - github-actions: STARTUP_FAILURE']
+          ]
+        };
+
+        const commits = [{
+          commit: {
+            checkSuites: {
+              nodes: [{
+                status: 'COMPLETED',
+                conclusion: 'STARTUP_FAILURE',
+                checkRuns: {
+                  totalCount: 2,
+                  nodes: [{
+                    name: 'stale-comment',
+                    status: 'COMPLETED',
+                    conclusion: 'SKIPPED'
+                  }]
+                }
+              }]
+            }
+          }
+        }];
+        const data = Object.assign({}, baseData, { commits });
+
+        const checker = new PRChecker(cli, data, {}, testArgv);
+
+        const status = await checker.checkCI();
+        assert(!status);
+        cli.assertCalledWith(expectedLogs);
+      });
+
     it('should succeed if commit status succeeded', async() => {
       const cli = new TestCLI();
 


### PR DESCRIPTION
GitHub Actions can report a check suite as `STARTUP_FAILURE` even when every check run in that suite was skipped. This caused `checkGitHubCI()` to mark the PR as unlandable without reporting a specific failed job or reason code.

Ignore this suite-level result when every check run was fetched and every run completed with `SKIPPED`. Other startup failures continue to block landing and now fall back to a suite-level diagnostic when no failed check run is available.

Query the check-run `totalCount` to ensure truncated results are not mistaken for a fully skipped suite.

Observed in https://github.com/nodejs/node/pull/65538#issuecomment-5445313746

https://github.com/nodejs/node/actions/runs/32985142178/attempts/1
https://github.com/nodejs/node/actions/runs/32984879569/attempts/1

<img width="809" height="154" alt="Screenshot 2026-08-27 at 23 36 02" src="https://github.com/user-attachments/assets/97785f3f-fbb5-4779-87fd-6914e95262f8" />
