### PR TITLE
chore(v8): replace Enquirer prompt adapter with Inquirer

### DIFF
--- a/lib/update-v8/backport.js
+++ b/lib/update-v8/backport.js
@@ -3,8 +3,8 @@ import {
   promises as fs
 } from 'node:fs';
 
-import { confirm } from '@inquirer/prompts';
-import { ListrEnquirerPromptAdapter } from '@listr2/prompt-adapter-enquirer';
+import { confirm, input } from '@inquirer/prompts';
+import { ListrInquirerPromptAdapter } from '@listr2/prompt-adapter-inquirer';
 
 import { shortSha } from '../utils.js';
 
@@ -263,8 +263,7 @@ async function applyPatch(ctx, task, patch, method = 'apply') {
     );
   } catch {
     patch.hadConflicts = true;
-    return task.prompt(ListrEnquirerPromptAdapter).run({
-      type: 'input',
+    return task.prompt(ListrInquirerPromptAdapter).run(input, {
       message: "Resolve merge conflicts and enter 'RESOLVED'",
       validate: value => value.toUpperCase() === 'RESOLVED'
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.0",
       "bundleDependencies": [
         "@inquirer/prompts",
-        "@listr2/prompt-adapter-enquirer",
+        "@listr2/prompt-adapter-inquirer",
         "@node-core/caritat",
         "@pkgjs/nv",
         "branch-diff",
@@ -31,7 +31,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.4.1",
-        "@listr2/prompt-adapter-enquirer": "^2.0.12",
+        "@listr2/prompt-adapter-inquirer": "^3.0.5",
         "@node-core/caritat": "^1.6.0",
         "@pkgjs/nv": "^0.3.0",
         "branch-diff": "^3.1.1",
@@ -790,17 +790,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@listr2/prompt-adapter-enquirer": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-enquirer/-/prompt-adapter-enquirer-2.0.16.tgz",
-      "integrity": "sha512-CNhdBXWi+HWJCyjYwOSgEmK0rrUnwZrG9h0bKUrwxSqpz5A6unMTxvN254k+3TbDZRtzu+21mcb4KNT/6vxIzg==",
+    "node_modules/@listr2/prompt-adapter-inquirer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-3.0.5.tgz",
+      "integrity": "sha512-WELs+hj6xcilkloBXYf9XXK8tYEnKsgLj01Xl5ONUJpKjmT5hGVUzNUS5tooUxs7pGMrw+jFD/41WpqW4V3LDA==",
       "inBundle": true,
       "license": "MIT",
+      "dependencies": {
+        "@inquirer/type": "^3.0.8"
+      },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
+        "@inquirer/prompts": ">= 3 < 8",
+        "listr2": "9.0.5"
       }
     },
     "node_modules/@node-core/caritat": {
@@ -1623,17 +1627,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -2920,46 +2913,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/enquirer/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/enquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/entities": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "bundleDependencies": true,
   "dependencies": {
     "@inquirer/prompts": "^7.4.1",
-    "@listr2/prompt-adapter-enquirer": "^2.0.12",
+    "@listr2/prompt-adapter-inquirer": "^3.0.5",
     "@node-core/caritat": "^1.6.0",
     "@pkgjs/nv": "^0.3.0",
     "branch-diff": "^3.1.1",


### PR DESCRIPTION
Replace `@listr2/prompt-adapter-enquirer` with the [recommended](https://listr2.kilic.dev/task/prompts.html#adapters) Inquirer adapter.

The project already depends on `@inquirer/prompts`, so this avoids installing and maintaining a second prompt stack. The merge-conflict prompt in `update-v8` now uses the Inquirer `input` prompt while preserving its existing validation.

The [enquirer](https://listr2.kilic.dev/task/prompts.html#enquirer) is effectively unmaintained, and is kept on lifeline support only.