### PR TITLE
chore: use listr2 figure utilities

### DIFF
--- a/lib/figures.js
+++ b/lib/figures.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
-import figures from 'figures';
+import { figures } from 'listr2';
 
 export const warning = chalk.yellow(figures.warning);
 export const error = chalk.red(figures.cross);
-export const info = chalk.blue(figures.info);
+export const info = chalk.blue(figures.pointer);
 export const success = chalk.green(figures.tick);

--- a/lib/figures.js
+++ b/lib/figures.js
@@ -3,5 +3,5 @@ import { figures } from 'listr2';
 
 export const warning = chalk.yellow(figures.warning);
 export const error = chalk.red(figures.cross);
-export const info = chalk.blue(figures.pointer);
+export const info = chalk.blue(figures.info);
 export const success = chalk.green(figures.tick);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "changelog-maker",
         "cheerio",
         "core-validate-commit",
-        "figures",
         "ghauth",
         "git-secure-tag",
         "js-yaml",
@@ -39,7 +38,6 @@
         "changelog-maker": "^4.4.1",
         "cheerio": "^1.0.0",
         "core-validate-commit": "^6.0.0",
-        "figures": "^6.1.0",
         "ghauth": "^7.0.1",
         "git-secure-tag": "^2.3.1",
         "js-yaml": "^5.2.1",
@@ -3671,22 +3669,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "changelog-maker": "^4.4.1",
     "cheerio": "^1.0.0",
     "core-validate-commit": "^6.0.0",
-    "figures": "^6.1.0",
     "ghauth": "^7.0.1",
     "git-secure-tag": "^2.3.1",
     "js-yaml": "^5.2.1",


### PR DESCRIPTION
Replace the standalone [figures](https://www.npmjs.com/package/figures) dependency with the [figures utilities](https://github.com/listr2/listr2/blob/master/packages/listr2/src/utils/format/figures.ts) already exported by Listr2.

~Since Listr2 does not provide an `info` figure, its `pointer` figure is used for informational messages.~

|              | figures | listr2 |
|--------------|---------|--------|
| warning      | ⚠       | ⚠      |
| cross        | ✘       | ✖      |
| info/pointer | ℹ       | ℹ       |
| tick         | ✔       | ✔      |