### PR TITLE
chore(deps): bump listr2 to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.4.1",
-        "@listr2/prompt-adapter-inquirer": "^3.0.5",
+        "@listr2/prompt-adapter-inquirer": "^4.2.6",
         "@node-core/caritat": "^1.6.0",
         "@pkgjs/nv": "^0.3.0",
         "branch-diff": "^3.1.1",
@@ -43,7 +43,7 @@
         "ghauth": "^7.0.1",
         "git-secure-tag": "^2.3.1",
         "js-yaml": "^5.2.1",
-        "listr2": "^9.0.5",
+        "listr2": "^11.0.1",
         "ora": "^9.0.0",
         "semver": "^7.7.1",
         "smol-toml": "^1.7.0",
@@ -791,20 +791,38 @@
       }
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-3.0.5.tgz",
-      "integrity": "sha512-WELs+hj6xcilkloBXYf9XXK8tYEnKsgLj01Xl5ONUJpKjmT5hGVUzNUS5tooUxs7pGMrw+jFD/41WpqW4V3LDA==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-4.2.6.tgz",
+      "integrity": "sha512-eQSUUwTpKIXOgbJ4Fx2vEzV0h6ofWknhgtaTSab0C5xG/kWZRg9n3hx5+lE9Z5Z+cXZ2efpVpWT0tNueWRP71w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/type": "^3.0.8"
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "@inquirer/prompts": ">= 3 < 8",
-        "listr2": "9.0.5"
+        "@inquirer/prompts": ">= 3 < 9",
+        "listr2": "11.0.1"
+      }
+    },
+    "node_modules/@listr2/prompt-adapter-inquirer/node_modules/@inquirer/type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@node-core/caritat": {
@@ -1629,10 +1647,26 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1643,9 +1677,9 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2303,31 +2337,31 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.1.1.tgz",
+      "integrity": "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
+        "slice-ansi": "^9.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -2430,13 +2464,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "inBundle": true,
       "license": "MIT"
     },
@@ -3599,13 +3626,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5291,36 +5311,49 @@
       }
     },
     "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-11.0.1.tgz",
+      "integrity": "sha512-TzOB/8yb2KIW/hb7DCLfloZi0j01xhIqqvvHuXhPVEprbebjPtxWzBmUC4jZoQv6imUfxYk6tbAudCb/m//DPQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
+        "cli-truncate": "^6.1.1",
+        "log-update": "^8.0.0",
+        "wrap-ansi": "^10.0.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.1.tgz",
+      "integrity": "sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -5398,54 +5431,55 @@
       }
     },
     "node_modules/log-update": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-8.0.0.tgz",
+      "integrity": "sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^7.0.0",
+        "ansi-escapes": "^7.3.0",
         "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
+        "slice-ansi": "^9.0.0",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.2.0",
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/log-update/node_modules/ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "environment": "^1.0.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.1.tgz",
+      "integrity": "sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -8606,13 +8640,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -8895,17 +8922,17 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -9173,13 +9200,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.4.1",
-        "@listr2/prompt-adapter-inquirer": "^4.2.6",
+        "@listr2/prompt-adapter-inquirer": "^4.2.7",
         "@node-core/caritat": "^1.6.0",
         "@pkgjs/nv": "^0.3.0",
         "branch-diff": "^3.1.1",
@@ -43,7 +43,7 @@
         "ghauth": "^7.0.1",
         "git-secure-tag": "^2.3.1",
         "js-yaml": "^5.2.1",
-        "listr2": "^11.0.1",
+        "listr2": "^11.1.0",
         "ora": "^9.0.0",
         "semver": "^7.7.1",
         "smol-toml": "^1.7.0",
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-4.2.6.tgz",
-      "integrity": "sha512-eQSUUwTpKIXOgbJ4Fx2vEzV0h6ofWknhgtaTSab0C5xG/kWZRg9n3hx5+lE9Z5Z+cXZ2efpVpWT0tNueWRP71w==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-4.2.7.tgz",
+      "integrity": "sha512-k180vxSv2KqmnDxoato6pCqEJsov4U5C0EVmldZkAdNeVBxY48A/LM6TCNPGIzDK/iZSfsZP0Mw+gbWc5hXLyA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -804,7 +804,7 @@
       },
       "peerDependencies": {
         "@inquirer/prompts": ">= 3 < 9",
-        "listr2": "11.0.1"
+        "listr2": "11.1.0"
       }
     },
     "node_modules/@listr2/prompt-adapter-inquirer/node_modules/@inquirer/type": {
@@ -5311,9 +5311,9 @@
       }
     },
     "node_modules/listr2": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-11.0.1.tgz",
-      "integrity": "sha512-TzOB/8yb2KIW/hb7DCLfloZi0j01xhIqqvvHuXhPVEprbebjPtxWzBmUC4jZoQv6imUfxYk6tbAudCb/m//DPQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-11.1.0.tgz",
+      "integrity": "sha512-xsuczF6mWkEo/E80QHaEokQzKmTy7m80KcLRnkUt9wrcePres2w7dbQi5zOsWtDUg8Dac4gPFyu4EJ/IvKwTOg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "bundleDependencies": true,
   "dependencies": {
     "@inquirer/prompts": "^7.4.1",
-    "@listr2/prompt-adapter-inquirer": "^4.2.6",
+    "@listr2/prompt-adapter-inquirer": "^4.2.7",
     "@node-core/caritat": "^1.6.0",
     "@pkgjs/nv": "^0.3.0",
     "branch-diff": "^3.1.1",
@@ -47,7 +47,7 @@
     "ghauth": "^7.0.1",
     "git-secure-tag": "^2.3.1",
     "js-yaml": "^5.2.1",
-    "listr2": "^11.0.1",
+    "listr2": "^11.1.0",
     "ora": "^9.0.0",
     "semver": "^7.7.1",
     "smol-toml": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "bundleDependencies": true,
   "dependencies": {
     "@inquirer/prompts": "^7.4.1",
-    "@listr2/prompt-adapter-inquirer": "^3.0.5",
+    "@listr2/prompt-adapter-inquirer": "^4.2.6",
     "@node-core/caritat": "^1.6.0",
     "@pkgjs/nv": "^0.3.0",
     "branch-diff": "^3.1.1",
@@ -47,7 +47,7 @@
     "ghauth": "^7.0.1",
     "git-secure-tag": "^2.3.1",
     "js-yaml": "^5.2.1",
-    "listr2": "^9.0.5",
+    "listr2": "^11.0.1",
     "ora": "^9.0.0",
     "semver": "^7.7.1",
     "smol-toml": "^1.7.0",


### PR DESCRIPTION
Bump needed to use `figures.info` which will be available in future versions of `listr2@v11`

Refs: https://github.com/nodejs/node-core-utils/pull/1174#issuecomment-5481270982

---

Upgrade [`listr2`](https://github.com/listr2/listr2/releases) from v9.0.5 to v11.0.1.

Also upgrade `@listr2/prompt-adapter-inquirer` from v3.0.5 to v4.2.6 because the adapter requires the corresponding `listr2` v11 release.

### Notable upstream changes in `listr2`

#### v10

- Drops support for Node.js 20. The `node-core-utils` already requires Node.js 22.22.2 or newer.
- Updates major internal dependencies and the package bundling mechanism.
- Replaces `colorette` with Node.js `util.styleText`.
- Includes compatibility handling for readline cleanup on modern Node.js releases.

See the [`listr2` v10.0.0](https://github.com/listr2/listr2/releases/tag/listr2%4010.0.0), [v10.1.0](https://github.com/listr2/listr2/releases/tag/listr2%4010.1.0), and [v10.2.0](https://github.com/listr2/listr2/releases/tag/listr2%4010.2.0) release notes.

#### v11

- Adds a distinct cancelled task state and runs task rollbacks when execution is interrupted.
- Improves renderer performance through partial output updates.
- Preserves terminal hyperlinks and derives wrapping width from the configured output stream.
- Prevents output-listener leaks after tasks finish.
- Uses Node.js `EventEmitter` instead of `eventemitter3`.
- Simplifies error collection and removes context cloning from collected errors.

The v11 error-collection API has breaking changes, but `node-core-utils` does not use the affected `Listr.errors` or `collectErrors` APIs. Existing task lists and the Inquirer prompt integration require no source changes.

See the [`listr2` v11.0.0 release notes](https://github.com/listr2/listr2/releases/tag/listr2%4011.0.0).
