### PR TITLE
refactor: replace chalk with util.styleText

### DIFF
--- a/lib/ci/build-types/test_build.js
+++ b/lib/ci/build-types/test_build.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { shortSha } from '../../utils.js';
 import {
@@ -119,11 +119,11 @@ export class TestBuild extends Job {
       cli.table('Built On', failure.builtOn);
     }
     if (!reason.includes('\n') && reason.length < 40) {
-      cli.table('Reason', chalk.red(reason));
+      cli.table('Reason', styleText('red', reason));
     } else {
       cli.table('Reason', '');
       const lines = reason.split('\n');
-      cli.log(`  ${chalk.red(lines[0])}`);
+      cli.log(`  ${styleText('red', lines[0])}`);
       for (let i = 1; i < lines.length; ++i) {
         cli.log(`  ${lines[i]}`);
       }

--- a/lib/ci/failure_aggregator.js
+++ b/lib/ci/failure_aggregator.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { getMachineUrl, parsePRFromURL } from '../links.js';
 import CIFailureParser from './ci_failure_parser.js';
@@ -140,7 +140,7 @@ export class FailureAggregator {
           cli.table('First CI', `${prs[0].upstream}`);
         }
         cli.table('Last CI', `${prs[prs.length - 1].upstream}`);
-        cli.log('\n' + chalk.bold('Example: ') + `${failures[0].url}\n`);
+        cli.log('\n' + styleText('bold', 'Example: ') + `${failures[0].url}\n`);
         const example = failures[0].reason;
         cli.log(example.length > 512 ? example.slice(0, 512) + '...' : example);
         cli.separator();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,5 @@
 import ora from 'ora';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import * as inquirer from '@inquirer/prompts';
 
 import { warning, error, info, success } from './figures.js';
@@ -22,7 +22,7 @@ const QUESTION_TYPE = {
 const formatter = new Intl.ListFormat('en', { type: 'disjunction' });
 
 function head(text, length = 11) {
-  return chalk.bold(text.padEnd(length));
+  return styleText('bold', text.padEnd(length));
 }
 
 export default class CLI {
@@ -180,9 +180,9 @@ export default class CLI {
     const rest = (length - text.length - 2);
     const half = sep.repeat(Math.abs(Math.floor(rest / 2)));
     if (rest % 2 === 0) {
-      this.log(`${half} ${chalk.bold(text)} ${half}`);
+      this.log(`${half} ${styleText('bold', text)} ${half}`);
     } else {
-      this.log(`${half} ${chalk.bold(text)} ${sep}${half}`);
+      this.log(`${half} ${styleText('bold', text)} ${sep}${half}`);
     }
   }
 
@@ -193,7 +193,7 @@ export default class CLI {
 
   warn(text, options = {}) {
     const prefix = options.newline ? this.eolIndent : this.figureIndent;
-    this.log(prefix + chalk.bold(`${warning}  ${text}`));
+    this.log(prefix + styleText('bold', `${warning}  ${text}`));
   }
 
   info(text, options = {}) {
@@ -210,7 +210,7 @@ export default class CLI {
         this.log(JSON.stringify(obj.data, null, 2));
       }
     } else {
-      this.log(prefix + chalk.bold(`${error}  ${obj}`));
+      this.log(prefix + styleText('bold', `${error}  ${obj}`));
     }
   }
 

--- a/lib/figures.js
+++ b/lib/figures.js
@@ -1,7 +1,7 @@
-import chalk from 'chalk';
 import { figures } from 'listr2';
+import { styleText } from 'node:util';
 
-export const warning = chalk.yellow(figures.warning);
-export const error = chalk.red(figures.cross);
-export const info = chalk.blue(figures.info);
-export const success = chalk.green(figures.tick);
+export const warning = styleText('yellow', figures.warning);
+export const error = styleText('red', figures.cross);
+export const info = styleText('blue', figures.info);
+export const success = styleText('green', figures.tick);

--- a/lib/verbosity.js
+++ b/lib/verbosity.js
@@ -1,6 +1,4 @@
-import util from 'node:util';
-
-import chalk from 'chalk';
+import { format, styleText } from 'node:util';
 
 const VERBOSITY = {
   NONE: 0,
@@ -25,5 +23,5 @@ export function setVerbosityFromEnv() {
 
 export function debuglog(...args) {
   // Prepend a line break in case it's logged while the spinner is running
-  console.error(chalk.green(util.format('\n[DEBUG]', ...args)));
+  console.error(styleText('green', format('\n[DEBUG]', ...args)));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@node-core/caritat",
         "@pkgjs/nv",
         "branch-diff",
-        "chalk",
         "changelog-maker",
         "cheerio",
         "core-validate-commit",
@@ -34,7 +33,6 @@
         "@node-core/caritat": "^1.6.0",
         "@pkgjs/nv": "^0.3.0",
         "branch-diff": "^3.1.1",
-        "chalk": "^6.0.0",
         "changelog-maker": "^4.4.1",
         "cheerio": "^1.0.0",
         "core-validate-commit": "^6.0.0",
@@ -2157,19 +2155,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
-      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/changelog-maker": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@node-core/caritat": "^1.6.0",
     "@pkgjs/nv": "^0.3.0",
     "branch-diff": "^3.1.1",
-    "chalk": "^6.0.0",
     "changelog-maker": "^4.4.1",
     "cheerio": "^1.0.0",
     "core-validate-commit": "^6.0.0",


### PR DESCRIPTION
Replace [chalk](https://www.npmjs.com/package/chalk) with Node.js’s built-in [util.styleText()](https://nodejs.org/api/util.html#utilstyletextformat-text-options).