### PR TITLE
fix: exclude debug line break from styling

### DIFF
--- a/lib/verbosity.js
+++ b/lib/verbosity.js
@@ -23,5 +23,5 @@ export function setVerbosityFromEnv() {
 
 export function debuglog(...args) {
   // Prepend a line break in case it's logged while the spinner is running
-  console.error(styleText('green', format('\n[DEBUG]', ...args)));
+  console.error('\n' + styleText('green', format('[DEBUG]', ...args)));
 }


### PR DESCRIPTION
Refs: https://github.com/nodejs/node-core-utils/pull/1183#discussion_r3934023796