### PR TITLE
chore: replace ora with yocto-spinner

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,5 @@
-import ora from 'ora';
 import { styleText } from 'node:util';
+import yoctoSpinner from 'yocto-spinner';
 import * as inquirer from '@inquirer/prompts';
 
 import { warning, error, info, success } from './figures.js';
@@ -29,7 +29,7 @@ export default class CLI {
   constructor(stream, options = {}) {
     const spinnerOptions = options.spinner ?? {};
     this.stream = stream || process.stderr;
-    this.spinner = ora({ stream: this.stream, ...spinnerOptions });
+    this.spinner = yoctoSpinner({ stream: this.stream, ...spinnerOptions });
     this.SPINNER_STATUS = SPINNER_STATUS;
     this.QUESTION_TYPE = QUESTION_TYPE;
     this.figureIndent = '   ';
@@ -154,10 +154,7 @@ export default class CLI {
       case INFO:
         symbol = info;
     }
-    const text = ' ' + rawText;
-    this.spinner.stopAndPersist({
-      symbol, text
-    });
+    this.spinner.stop(`${symbol}  ${rawText}`);
   }
 
   write(text) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,11 @@
         "git-secure-tag",
         "js-yaml",
         "listr2",
-        "ora",
         "semver",
         "smol-toml",
         "undici",
-        "yargs"
+        "yargs",
+        "yocto-spinner"
       ],
       "license": "MIT",
       "dependencies": {
@@ -40,11 +40,11 @@
         "git-secure-tag": "^2.3.1",
         "js-yaml": "^5.2.1",
         "listr2": "^11.1.0",
-        "ora": "^9.0.0",
         "semver": "^7.7.1",
         "smol-toml": "^1.7.0",
         "undici": "^8.3.0",
-        "yargs": "^18.0.0"
+        "yargs": "^18.0.0",
+        "yocto-spinner": "^1.2.2"
       },
       "bin": {
         "git-node": "bin/git-node.js",
@@ -6877,73 +6877,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ora": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^8.1.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/cli-spinners": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
-      "integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -9011,19 +8944,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -10141,6 +10061,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yocto-spinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.2.tgz",
+      "integrity": "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     "git-secure-tag": "^2.3.1",
     "js-yaml": "^5.2.1",
     "listr2": "^11.1.0",
-    "ora": "^9.0.0",
     "semver": "^7.7.1",
     "smol-toml": "^1.7.0",
     "undici": "^8.3.0",
-    "yargs": "^18.0.0"
+    "yargs": "^18.0.0",
+    "yocto-spinner": "^1.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
Replaces `ora` with the smaller `yocto-spinner` package.

The CLI spinner wrapper now uses `yocto-spinner` while preserving the existing custom status symbols and output formatting.

Comparison between the two packages: https://npmx.dev/compare?packages=ora,yocto-spinner
The yocto-spinner is created by the author of ora: https://github.com/sindresorhus/ora#install