### PR TITLE
Fix duplicate ci run check

### DIFF
--- a/lib/ci/run_ci.js
+++ b/lib/ci/run_ci.js
@@ -73,9 +73,10 @@ export class RunPRJob {
   }
 
   async start() {
-    const { cli, request, certifySafe, checkForDuplicates } = this;
+    const { cli, request, checkForDuplicates } = this;
+    const certifySafe = await this.certifySafe;
 
-    if (!(await certifySafe)) {
+    if (!certifySafe) {
       cli.error('Refusing to run CI on potentially unsafe PR');
       return false;
     }

--- a/test/unit/ci_start.test.js
+++ b/test/unit/ci_start.test.js
@@ -291,13 +291,22 @@ describe('Jenkins', () => {
       ]
     });
 
-    it('should return false if already started', async() => {
+    it('should return false if inferred commit already has CI', async() => {
       const cli = new TestCLI();
+      sinon.replace(PRData.prototype, 'getReviews', sinon.fake.resolves());
+      sinon.replace(PRData.prototype, 'getCommits', sinon.fake.resolves());
+      sinon.replace(PRChecker.prototype, 'getApprovedTipOfHead',
+        sinon.fake.returns('deadbeef'));
       sinon.replace(PRBuild.prototype, 'getBuildData',
         sinon.fake.resolves(mockJenkinsResponse(getParameters('deadbeef'))));
 
-      const jobRunner = new RunPRJob(cli, {}, owner, repo, prid, 'deadbeef', true);
+      const request = {
+        fetch: sinon.stub().resolves({ status: 201 }),
+        json: sinon.stub().withArgs(CI_CRUMB_URL).resolves({ crumb })
+      };
+      const jobRunner = new RunPRJob(cli, request, owner, repo, prid, undefined, true);
       assert.strictEqual(await jobRunner.start(), false);
+      assert.strictEqual(request.fetch.callCount, 0);
     });
     it('should return true when last CI is on a different commit', async() => {
       const cli = new TestCLI();


### PR DESCRIPTION
It appears there was a bug in the duplicate run checking. As evidenced here https://github.com/nodejs/node/pull/65920#event-30806865483 ... where there was a prior CI run that was detected but ignored, causing a new run to be started.